### PR TITLE
feat(ml): switch xgboost early-stopping to realized_edge_metric

### DIFF
--- a/src/pscanner/ml/training.py
+++ b/src/pscanner/ml/training.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import json
 import os
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from pathlib import Path
 
 import numpy as np
@@ -44,6 +44,37 @@ def _rss_mb() -> int:
     return (rss_pages * os.sysconf("SC_PAGE_SIZE")) // (1024 * 1024)
 
 
+def _make_edge_eval_metric(
+    y_val: np.ndarray,
+    implied_prob_val: np.ndarray,
+    n_min: int,
+) -> Callable[[np.ndarray, xgb.DMatrix], tuple[str, float]]:
+    """Build an xgboost ``custom_metric`` closure that tracks realized edge.
+
+    Returned tuple is ``("realized_edge", -edge)`` so xgboost's default
+    minimization treats higher edge as better — early stopping then picks
+    the round whose val edge is highest, not the round whose val log-loss
+    is lowest. Logloss minima and edge maxima can diverge sharply (logloss
+    penalizes overconfidence on losers; edge cares whether ``pred >
+    implied`` predicts winners), so aligning the inner loop with what the
+    outer Optuna loop actually grades on closes a real selection bias.
+
+    The flat ``-1.0`` region returned by ``realized_edge_metric`` when
+    ``n_taken < n_min`` becomes ``+1.0`` after negation. xgboost sees a
+    plateau at the worst possible value early in training and continues
+    boosting until enough bets pass the gate — no false-positive stop.
+    """
+    captured_y = y_val
+    captured_implied = implied_prob_val
+    captured_n_min = n_min
+
+    def _metric(predt: np.ndarray, _dmatrix: xgb.DMatrix) -> tuple[str, float]:
+        edge = realized_edge_metric(captured_y, predt, captured_implied, n_min=captured_n_min)
+        return ("realized_edge", -edge)
+
+    return _metric
+
+
 def run_single_trial(
     trial: optuna.Trial,
     dtrain: xgb.DMatrix,
@@ -59,10 +90,13 @@ def run_single_trial(
     Sampled hyperparameters: ``learning_rate``, ``max_depth``,
     ``min_child_weight``, ``subsample``, ``colsample_bytree``,
     ``reg_alpha``, ``reg_lambda``, ``gamma``. Boosting rounds are
-    capped at 2000 with 50-round early stopping on val log-loss; the
-    actual rounds used for prediction is ``best_iteration + 1``. The
-    chosen ``best_iteration`` is recorded on the trial's user attrs so
-    the winning model can be refit later without re-running the study.
+    capped at 2000 with 50-round early stopping on the custom
+    ``realized_edge`` metric (negated so xgboost's default minimization
+    selects the edge-maximizing round). ``logloss`` is still reported
+    via ``eval_metric`` as a calibration sanity baseline in train logs.
+    The actual rounds used for prediction is ``best_iteration + 1``.
+    The chosen ``best_iteration`` is recorded on the trial's user attrs
+    so the winning model can be refit later without re-running the study.
 
     ``dtrain`` and ``dval`` are expected to be shared across trials --
     XGBoost's ``train()`` treats them as read-only, so a single pair
@@ -98,11 +132,15 @@ def run_single_trial(
         "seed": seed,
         "verbosity": 0,
     }
+    edge_metric = _make_edge_eval_metric(
+        y_val=y_val, implied_prob_val=implied_prob_val, n_min=n_min
+    )
     booster = xgb.train(
         params,
         dtrain,
         num_boost_round=_NUM_BOOST_ROUND,
         evals=[(dval, "val")],
+        custom_metric=edge_metric,
         early_stopping_rounds=_EARLY_STOPPING_ROUNDS,
         verbose_eval=False,
     )

--- a/tests/ml/test_training.py
+++ b/tests/ml/test_training.py
@@ -9,9 +9,11 @@ from pathlib import Path
 import numpy as np
 import optuna
 import polars as pl
+import pytest
 import xgboost as xgb
 
 from pscanner.ml.training import (
+    _make_edge_eval_metric,
     evaluate_on_test,
     fit_winning_model,
     run_single_trial,
@@ -32,6 +34,60 @@ def _toy_problem(
     y_train, y_val = y[:150], y[150:]
     implied_val = implied[150:]
     return X_train, y_train, X_val, y_val, implied_val
+
+
+def test_make_edge_eval_metric_returns_negated_edge() -> None:
+    """When predictions beat implied for many rows, the metric returns -edge."""
+    n = 100
+    y_val = np.array([1] * 60 + [0] * 40)  # 60% win rate among taken bets
+    implied_val = np.full(n, 0.4)  # All bets at 40% implied prob
+    predt = np.full(n, 0.7)  # Model predicts 70% > 40%, so all rows pass the gate
+
+    metric = _make_edge_eval_metric(y_val=y_val, implied_prob_val=implied_val, n_min=20)
+    name, value = metric(predt, xgb.DMatrix(np.zeros((n, 1)), label=y_val))
+
+    assert name == "realized_edge"
+    # Realized edge = mean(y - implied) over taken bets = 0.6 - 0.4 = 0.2
+    # Negated for xgboost minimization → -0.2
+    assert value == pytest.approx(-0.2)
+
+
+def test_make_edge_eval_metric_returns_plus_one_in_n_min_flat_region() -> None:
+    """When too few predictions beat implied (n_taken < n_min), metric returns +1.0.
+
+    The flat ``-1.0`` from the underlying ``realized_edge_metric`` becomes
+    ``+1.0`` after negation — early-stopping sees the worst-possible value
+    and continues training rather than stopping in the flat region.
+    """
+    n = 100
+    y_val = np.zeros(n, dtype=int)
+    implied_val = np.full(n, 0.9)
+    # Only 5 predictions beat implied (below the n_min=20 floor).
+    predt = np.full(n, 0.1)
+    predt[:5] = 0.95
+
+    metric = _make_edge_eval_metric(y_val=y_val, implied_prob_val=implied_val, n_min=20)
+    name, value = metric(predt, xgb.DMatrix(np.zeros((n, 1)), label=y_val))
+
+    assert name == "realized_edge"
+    assert value == 1.0
+
+
+def test_make_edge_eval_metric_closure_captures_inputs() -> None:
+    """The closure binds y_val/implied/n_min at construction time, not call time."""
+    y_val = np.array([1, 0, 1, 0])
+    implied_val = np.array([0.3, 0.3, 0.3, 0.3])
+    metric = _make_edge_eval_metric(y_val=y_val, implied_prob_val=implied_val, n_min=2)
+
+    # Mutate the source arrays after factory return — closure must use captured refs.
+    # NumPy arrays are passed by reference, so the closure sees the mutation; this
+    # test pins that behavior so any future shift to a defensive copy is intentional.
+    y_val[:] = [0, 0, 0, 0]
+
+    predt = np.array([0.5, 0.5, 0.5, 0.5])
+    _, value = metric(predt, xgb.DMatrix(np.zeros((4, 1)), label=y_val))
+    # All rows pass gate (4 >= n_min=2). Edge = (0+0+0+0)/4 - 0.3 = -0.3. Negated: +0.3.
+    assert value == pytest.approx(0.3)
 
 
 def test_run_single_trial_returns_finite_edge() -> None:


### PR DESCRIPTION
Closes #43.

## Summary
- The Optuna outer loop has always graded trials on `realized_edge_metric`, but the xgboost inner loop chose `best_iteration` via logloss early-stopping. Logloss minimum and edge maximum aren't the same iteration in general — logloss penalizes overconfidence on losers, edge cares whether `pred > implied` predicts winners. Trials were being scored on rounds picked for the wrong metric.
- New closure factory `_make_edge_eval_metric` in `pscanner.ml.training` builds an xgboost `custom_metric` callback returning `('realized_edge', -edge)`. The negation lets xgboost's default minimization act as maximization of edge — early stopping now picks the round that actually maximizes val edge.
- The existing `realized_edge_metric` anti-overfit guard (returns `-1.0` when `n_taken < n_min`) becomes `+1.0` after negation, which xgboost reads as the worst possible value. Early-stopping continues training through that flat region rather than false-positive-stopping in it.
- `eval_metric=logloss` stays in `params` as a calibration sanity baseline in training logs (the value is reported alongside the custom metric; xgboost's early-stop watches the last metric, which is the custom one).

## Test plan
- [x] 3 new unit tests on `_make_edge_eval_metric`: negated-edge semantics, `n_min` flat-region (returns `+1.0`), closure capture.
- [x] All 7 existing `test_training.py` tests still pass — including determinism + n_jobs=2 study tests.
- [x] Full repo suite: 902 passed, 0 warnings, ruff/format/ty clean.
- [ ] Re-run `uv run pscanner ml train --device cuda` on the post-#46 corpus and compare `metrics.json`'s `best_iteration` and `best_val_edge` against the current `0.0956` baseline (deferred until #46's subgraph backfill completes, since the corpus will shift anyway).

🤖 Generated with [Claude Code](https://claude.com/claude-code)