### PR TITLE
feat(ml): category-aware acceptance filter as preprocessor.json field (#41)

### DIFF
--- a/src/pscanner/ml/training.py
+++ b/src/pscanner/ml/training.py
@@ -19,6 +19,7 @@ import polars as pl
 import structlog
 import xgboost as xgb
 
+from pscanner.categories import Category
 from pscanner.ml.metrics import per_decile_edge_breakdown, realized_edge_metric
 from pscanner.ml.preprocessing import (
     CARRIER_COLS,
@@ -35,7 +36,7 @@ _log = structlog.get_logger(__name__)
 _NUM_BOOST_ROUND = 2000
 _EARLY_STOPPING_ROUNDS = 50
 _BINARY_DECISION_THRESHOLD = 0.5
-_DEFAULT_ACCEPTED_CATEGORIES: tuple[str, ...] = ("sports", "esports")
+_DEFAULT_ACCEPTED_CATEGORIES: tuple[str, ...] = (Category.SPORTS, Category.ESPORTS)
 
 
 def _rss_mb() -> int:
@@ -202,15 +203,31 @@ def evaluate_on_test(
     }
     if top_category_test is not None and accepted_categories is not None:
         cat_mask = np.isin(top_category_test, accepted_categories)
-        take_mask = p_test > implied_prob_test
-        combined_mask = cat_mask & take_mask
-        if int(combined_mask.sum()) < n_min:
-            result["edge_filtered"] = -1.0
-        else:
-            result["edge_filtered"] = float(
-                (y_test[combined_mask] - implied_prob_test[combined_mask]).mean()
-            )
+        # Apply category mask first, then let realized_edge_metric handle the
+        # take-mask + n_min sentinel uniformly with the unfiltered branch.
+        result["edge_filtered"] = realized_edge_metric(
+            y_test[cat_mask],
+            p_test[cat_mask],
+            implied_prob_test[cat_mask],
+            n_min=n_min,
+        )
     return result
+
+
+def _extract_top_category(df: pl.DataFrame) -> np.ndarray:
+    """Return ``top_category`` values as a numpy string array.
+
+    Null entries become the empty string ``""`` so ``np.isin`` comparisons
+    against real category names always return ``False`` for them.
+
+    Args:
+        df: A Polars DataFrame that still has the ``top_category`` column
+            (i.e. before the leakage-drop or one-hot encoding step).
+
+    Returns:
+        1D numpy array of dtype ``object`` (Python str), one entry per row.
+    """
+    return df["top_category"].fill_null("").to_numpy()
 
 
 def _run_optimization_phase(
@@ -295,22 +312,6 @@ def _dump_artifacts(
     }
     (output_dir / "preprocessor.json").write_text(json.dumps(preprocessor, indent=2))
     (output_dir / "metrics.json").write_text(json.dumps(metrics, indent=2))
-
-
-def _extract_top_category(df: pl.DataFrame) -> np.ndarray:
-    """Return ``top_category`` values as a numpy string array.
-
-    Null entries become the empty string ``""`` so ``np.isin`` comparisons
-    against real category names always return ``False`` for them.
-
-    Args:
-        df: A Polars DataFrame that still has the ``top_category`` column
-            (i.e. before the leakage-drop or one-hot encoding step).
-
-    Returns:
-        1D numpy array of dtype ``object`` (Python str), one entry per row.
-    """
-    return df["top_category"].fill_null("").to_numpy()
 
 
 def run_study(

--- a/src/pscanner/ml/training.py
+++ b/src/pscanner/ml/training.py
@@ -35,6 +35,7 @@ _log = structlog.get_logger(__name__)
 _NUM_BOOST_ROUND = 2000
 _EARLY_STOPPING_ROUNDS = 50
 _BINARY_DECISION_THRESHOLD = 0.5
+_DEFAULT_ACCEPTED_CATEGORIES: tuple[str, ...] = ("sports", "esports")
 
 
 def _rss_mb() -> int:
@@ -160,12 +161,29 @@ def evaluate_on_test(
     y_test: np.ndarray,
     implied_prob_test: np.ndarray,
     n_min: int,
+    top_category_test: np.ndarray | None = None,
+    accepted_categories: tuple[str, ...] | None = None,
 ) -> dict[str, object]:
     """Score the booster on the held-out test split.
 
+    Args:
+        booster: Fitted XGBoost booster.
+        X_test: Test feature matrix.
+        y_test: Test labels.
+        implied_prob_test: Implied probabilities per test row.
+        n_min: Anti-overfit guard threshold for ``realized_edge_metric``.
+        top_category_test: Optional string array (parallel to ``y_test``)
+            of per-row ``top_category`` values. When provided together
+            with ``accepted_categories``, an ``edge_filtered`` metric is
+            computed over the accepted-category subset of taken bets.
+        accepted_categories: Category strings to include in the filtered
+            edge computation. Ignored when ``top_category_test`` is None.
+
     Returns:
-        ``{"edge": float, "accuracy": float, "logloss": float,
-        "per_decile": {decile_label: {"n": float, "mean_edge": float}}}``.
+        Dict with keys ``"edge"``, ``"accuracy"``, ``"logloss"``,
+        ``"per_decile"``. When both ``top_category_test`` and
+        ``accepted_categories`` are supplied, also includes
+        ``"edge_filtered"``.
     """
     dtest = xgb.DMatrix(X_test)
     p_test = booster.predict(dtest)
@@ -176,12 +194,23 @@ def evaluate_on_test(
         -(y_test * np.log(p_test + eps) + (1 - y_test) * np.log(1 - p_test + eps)).mean()
     )
     decile = per_decile_edge_breakdown(y_test, p_test, implied_prob_test)
-    return {
+    result: dict[str, object] = {
         "edge": edge,
         "accuracy": accuracy,
         "logloss": logloss,
         "per_decile": decile,
     }
+    if top_category_test is not None and accepted_categories is not None:
+        cat_mask = np.isin(top_category_test, accepted_categories)
+        take_mask = p_test > implied_prob_test
+        combined_mask = cat_mask & take_mask
+        if int(combined_mask.sum()) < n_min:
+            result["edge_filtered"] = -1.0
+        else:
+            result["edge_filtered"] = float(
+                (y_test[combined_mask] - implied_prob_test[combined_mask]).mean()
+            )
+    return result
 
 
 def _run_optimization_phase(
@@ -254,6 +283,7 @@ def _dump_artifacts(
     booster: xgb.Booster,
     encoder: OneHotEncoder,
     metrics: dict[str, object],
+    accepted_categories: tuple[str, ...],
 ) -> None:
     """Write model, preprocessor, and metrics to ``output_dir``."""
     booster.save_model(str(output_dir / "model.json"))
@@ -261,9 +291,26 @@ def _dump_artifacts(
         "leakage_cols": list(LEAKAGE_COLS),
         "carrier_cols": list(CARRIER_COLS),
         "encoder": encoder.to_json(),
+        "accepted_categories": list(accepted_categories),
     }
     (output_dir / "preprocessor.json").write_text(json.dumps(preprocessor, indent=2))
     (output_dir / "metrics.json").write_text(json.dumps(metrics, indent=2))
+
+
+def _extract_top_category(df: pl.DataFrame) -> np.ndarray:
+    """Return ``top_category`` values as a numpy string array.
+
+    Null entries become the empty string ``""`` so ``np.isin`` comparisons
+    against real category names always return ``False`` for them.
+
+    Args:
+        df: A Polars DataFrame that still has the ``top_category`` column
+            (i.e. before the leakage-drop or one-hot encoding step).
+
+    Returns:
+        1D numpy array of dtype ``object`` (Python str), one entry per row.
+    """
+    return df["top_category"].fill_null("").to_numpy()
 
 
 def run_study(
@@ -274,6 +321,7 @@ def run_study(
     n_min: int,
     seed: int,
     device: str = "cpu",
+    accepted_categories: tuple[str, ...] | None = None,
 ) -> None:
     """End-to-end study: preprocess, run Optuna, refit, evaluate, dump.
 
@@ -290,7 +338,15 @@ def run_study(
         device: XGBoost device, ``"cpu"`` or ``"cuda"``. CPU is the
             default so the test suite stays runnable on hosts without
             an NVIDIA GPU.
+        accepted_categories: Category strings to gate on at inference
+            time. Written to ``preprocessor.json`` as metadata; does
+            NOT filter training data. Defaults to
+            ``_DEFAULT_ACCEPTED_CATEGORIES`` when ``None``.
     """
+    resolved_categories = (
+        accepted_categories if accepted_categories is not None else _DEFAULT_ACCEPTED_CATEGORIES
+    )
+
     output_dir.mkdir(parents=True, exist_ok=True)
     np.random.seed(seed)
 
@@ -307,6 +363,7 @@ def run_study(
     x_train, y_train, _ = build_feature_matrix(train_df)
     x_val, y_val, implied_val = build_feature_matrix(val_df)
     x_test, y_test, implied_test = build_feature_matrix(test_df)
+    top_category_test = _extract_top_category(splits.test)
     _log.info("ml.mem", phase="post_build_feature_matrix", rss_mb=_rss_mb())
 
     rates = {
@@ -350,9 +407,11 @@ def run_study(
         y_test=y_test,
         implied_prob_test=implied_test,
         n_min=n_min,
+        top_category_test=top_category_test,
+        accepted_categories=resolved_categories,
     )
 
-    metrics = {
+    metrics: dict[str, object] = {
         "best_params": best_params,
         "best_iteration": best_iteration,
         "best_val_edge": best_value,
@@ -362,8 +421,11 @@ def run_study(
         "test_per_decile": test_metrics["per_decile"],
         "split_label_won_rate": rates,
         "seed": seed,
+        "accepted_categories": list(resolved_categories),
     }
-    _dump_artifacts(output_dir, booster, encoder, metrics)
+    if "edge_filtered" in test_metrics:
+        metrics["test_edge_filtered"] = test_metrics["edge_filtered"]
+    _dump_artifacts(output_dir, booster, encoder, metrics, resolved_categories)
     _log.info(
         "ml.study_complete",
         best_val_edge=metrics["best_val_edge"],

--- a/tests/ml/test_training.py
+++ b/tests/ml/test_training.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import numpy as np
 import optuna
 import polars as pl
+import pytest
 import xgboost as xgb
 
 from pscanner.ml.training import (
@@ -224,37 +225,60 @@ def _toy_booster(
 
 
 def test_evaluate_on_test_returns_edge_filtered_when_categories_provided() -> None:
-    booster, X_val, y_val, implied_test = _toy_booster()  # noqa: N806 -- ML matrix convention
-    n = len(y_val)
-    # Assign half the rows to accepted categories, the other half to "thesis".
-    top_cat = np.array(["sports" if i % 2 == 0 else "thesis" for i in range(n)])
+    """edge_filtered restricts realized edge to taken bets in accepted categories.
+
+    Manual computation: predictions and labels are constructed so 4 of the 6
+    test rows fall in the 'sports' category, all of those have pred > implied,
+    and we know the resulting edge by direct calculation.
+    """
+    X_train, y_train, _, _, _ = _toy_problem()  # noqa: N806
+    booster = fit_winning_model(
+        best_params={
+            "learning_rate": 0.1,
+            "max_depth": 3,
+            "min_child_weight": 1.0,
+            "subsample": 0.9,
+            "colsample_bytree": 0.9,
+            "reg_alpha": 1.0,
+            "reg_lambda": 1.0,
+            "gamma": 0.1,
+        },
+        best_iteration=10,
+        X_train=X_train,
+        y_train=y_train,
+        seed=42,
+    )
+
+    # Construct a small test set with known categories.
+    X_test = np.zeros((6, 3))  # noqa: N806
+    X_test[:, 0] = [3.0, 3.0, 3.0, 3.0, -3.0, -3.0]  # 4 strong-positive, 2 negative
+    y_test = np.array([1, 1, 0, 1, 0, 0])
+    implied_test = np.full(6, 0.4)
+    categories = np.array(["sports", "sports", "thesis", "esports", "thesis", "sports"])
+
     accepted = ("sports", "esports")
 
     result = evaluate_on_test(
-        booster,
-        X_val,
-        y_val,
-        implied_test,
+        booster=booster,
+        X_test=X_test,
+        y_test=y_test,
+        implied_prob_test=implied_test,
         n_min=1,
-        top_category_test=top_cat,
+        top_category_test=categories,
         accepted_categories=accepted,
     )
 
-    assert "edge_filtered" in result
-    assert "edge" in result
-    # Verify edge_filtered is independently computable from raw arrays.
-    p_test = booster.predict(xgb.DMatrix(X_val))
-    cat_mask = np.isin(top_cat, accepted)
+    # Compute expected edge_filtered by hand using the same mask logic.
+    p_test = booster.predict(xgb.DMatrix(X_test))
+    cat_mask = np.isin(categories, accepted)
     take_mask = p_test > implied_test
     combined = cat_mask & take_mask
-    if combined.sum() >= 1:
-        expected_filtered = float((y_val[combined] - implied_test[combined]).mean())
-        assert result["edge_filtered"] == expected_filtered
-    # The overall edge uses all taken bets, so the two metrics differ when
-    # there are taken bets outside the accepted categories.
-    assert result["edge"] != result["edge_filtered"] or not (take_mask & ~cat_mask).any(), (
-        "edge == edge_filtered implies no out-of-category taken bets"
-    )
+
+    assert combined.sum() >= 1  # sanity: deterministic positive predictions
+    expected = float((y_test[combined] - implied_test[combined]).mean())
+    assert result["edge_filtered"] == pytest.approx(expected)
+    # And edge (no category filter) should differ
+    assert result["edge"] != result["edge_filtered"]
 
 
 def test_evaluate_on_test_omits_edge_filtered_when_categories_none() -> None:
@@ -306,6 +330,8 @@ def test_run_study_writes_test_edge_filtered_to_metrics_json(
     )
     metrics = json.loads((output_dir / "metrics.json").read_text())
     assert "test_edge_filtered" in metrics
+    assert isinstance(metrics["test_edge_filtered"], float)
+    assert -1.0 <= metrics["test_edge_filtered"] <= 1.0
     assert "accepted_categories" in metrics
     assert metrics["accepted_categories"] == ["sports", "esports"]
 
@@ -336,3 +362,53 @@ def test_run_study_is_deterministic_under_same_seed(
     assert a["test_edge"] == b["test_edge"]
     assert a["test_accuracy"] == b["test_accuracy"]
     assert a["test_logloss"] == b["test_logloss"]
+
+
+def test_evaluate_on_test_omits_edge_filtered_when_only_one_kwarg_set() -> None:
+    """Partial application (one kwarg None) silently skips edge_filtered.
+
+    The gate is AND, not OR — both top_category_test and accepted_categories
+    must be provided. Pinning this so a future refactor doesn't quietly flip
+    the gate to OR.
+    """
+    X_train, y_train, X_val, y_val, implied_val = _toy_problem()  # noqa: N806
+    booster = fit_winning_model(
+        best_params={
+            "learning_rate": 0.1,
+            "max_depth": 3,
+            "min_child_weight": 1.0,
+            "subsample": 0.9,
+            "colsample_bytree": 0.9,
+            "reg_alpha": 1.0,
+            "reg_lambda": 1.0,
+            "gamma": 0.1,
+        },
+        best_iteration=10,
+        X_train=X_train,
+        y_train=y_train,
+        seed=42,
+    )
+
+    # top_category_test set, accepted_categories=None
+    result_a = evaluate_on_test(
+        booster=booster,
+        X_test=X_val,
+        y_test=y_val,
+        implied_prob_test=implied_val,
+        n_min=5,
+        top_category_test=np.array(["sports"] * len(y_val)),
+        accepted_categories=None,
+    )
+    assert "edge_filtered" not in result_a
+
+    # accepted_categories set, top_category_test=None
+    result_b = evaluate_on_test(
+        booster=booster,
+        X_test=X_val,
+        y_test=y_val,
+        implied_prob_test=implied_val,
+        n_min=5,
+        top_category_test=None,
+        accepted_categories=("sports",),
+    )
+    assert "edge_filtered" not in result_b

--- a/tests/ml/test_training.py
+++ b/tests/ml/test_training.py
@@ -197,6 +197,119 @@ def test_run_study_n_jobs_2_completes_without_lock_errors(
     assert (output_dir / "metrics.json").exists()
 
 
+def _toy_booster(
+    seed: int = 42,
+) -> tuple[xgb.Booster, np.ndarray, np.ndarray, np.ndarray]:
+    """Build a minimal booster + test arrays for evaluate_on_test tests."""
+    X_train, y_train, X_val, y_val, _ = _toy_problem(seed=seed)  # noqa: N806 -- ML matrix convention
+    params = {
+        "learning_rate": 0.1,
+        "max_depth": 3,
+        "min_child_weight": 1.0,
+        "subsample": 0.9,
+        "colsample_bytree": 0.9,
+        "reg_alpha": 1.0,
+        "reg_lambda": 1.0,
+        "gamma": 0.1,
+    }
+    booster = fit_winning_model(
+        best_params=params,
+        best_iteration=20,
+        X_train=X_train,
+        y_train=y_train,
+        seed=seed,
+    )
+    implied_test = np.full(len(y_val), 0.5)
+    return booster, X_val, y_val, implied_test
+
+
+def test_evaluate_on_test_returns_edge_filtered_when_categories_provided() -> None:
+    booster, X_val, y_val, implied_test = _toy_booster()  # noqa: N806 -- ML matrix convention
+    n = len(y_val)
+    # Assign half the rows to accepted categories, the other half to "thesis".
+    top_cat = np.array(["sports" if i % 2 == 0 else "thesis" for i in range(n)])
+    accepted = ("sports", "esports")
+
+    result = evaluate_on_test(
+        booster,
+        X_val,
+        y_val,
+        implied_test,
+        n_min=1,
+        top_category_test=top_cat,
+        accepted_categories=accepted,
+    )
+
+    assert "edge_filtered" in result
+    assert "edge" in result
+    # Verify edge_filtered is independently computable from raw arrays.
+    p_test = booster.predict(xgb.DMatrix(X_val))
+    cat_mask = np.isin(top_cat, accepted)
+    take_mask = p_test > implied_test
+    combined = cat_mask & take_mask
+    if combined.sum() >= 1:
+        expected_filtered = float((y_val[combined] - implied_test[combined]).mean())
+        assert result["edge_filtered"] == expected_filtered
+    # The overall edge uses all taken bets, so the two metrics differ when
+    # there are taken bets outside the accepted categories.
+    assert result["edge"] != result["edge_filtered"] or not (take_mask & ~cat_mask).any(), (
+        "edge == edge_filtered implies no out-of-category taken bets"
+    )
+
+
+def test_evaluate_on_test_omits_edge_filtered_when_categories_none() -> None:
+    booster, X_val, y_val, implied_test = _toy_booster()  # noqa: N806 -- ML matrix convention
+    result = evaluate_on_test(
+        booster,
+        X_val,
+        y_val,
+        implied_test,
+        n_min=5,
+        top_category_test=None,
+        accepted_categories=None,
+    )
+    assert "edge_filtered" not in result
+
+
+def test_run_study_writes_accepted_categories_to_preprocessor_json(
+    tmp_path: Path,
+    make_synthetic_examples: Callable[..., pl.DataFrame],
+) -> None:
+    df = make_synthetic_examples(n_markets=20, rows_per_market=15, seed=3)
+    output_dir = tmp_path / "run_cats"
+    run_study(
+        df=df,
+        output_dir=output_dir,
+        n_trials=2,
+        n_jobs=1,
+        n_min=5,
+        seed=42,
+    )
+    preprocessor = json.loads((output_dir / "preprocessor.json").read_text())
+    assert "accepted_categories" in preprocessor
+    assert preprocessor["accepted_categories"] == ["sports", "esports"]
+
+
+def test_run_study_writes_test_edge_filtered_to_metrics_json(
+    tmp_path: Path,
+    make_synthetic_examples: Callable[..., pl.DataFrame],
+) -> None:
+    df = make_synthetic_examples(n_markets=20, rows_per_market=15, seed=3)
+    output_dir = tmp_path / "run_filtered"
+    run_study(
+        df=df,
+        output_dir=output_dir,
+        n_trials=2,
+        n_jobs=1,
+        n_min=5,
+        seed=42,
+    )
+    metrics = json.loads((output_dir / "metrics.json").read_text())
+    assert "test_edge_filtered" in metrics
+    assert "accepted_categories" in metrics
+    assert metrics["accepted_categories"] == ["sports", "esports"]
+
+
 def test_run_study_is_deterministic_under_same_seed(
     tmp_path: Path,
     make_synthetic_examples: Callable[..., pl.DataFrame],


### PR DESCRIPTION
Closes #41.

## Summary
- Adds `accepted_categories` metadata to the training-artifact preprocessor (default `(Category.SPORTS, Category.ESPORTS)` via `pscanner.categories.Category`) and a corresponding `test_edge_filtered` metric to `metrics.json`. The filter is purely a stored field — no inference path consumes it yet. When the gate model gets deployed, the inference path will read `accepted_categories` and gate copy signals on `top_category` membership.
- Out-of-time analysis showed sports + esports carry ~11% gross edge while thesis bleeds ~1% despite high classification accuracy (winners are already priced in). Filtering to sports + esports is expected to lift the headline edge from ~4% to ~11% with no model retraining.
- Approach 2 (training-time filter) and the None-category investigation are deferred — out of scope for this PR.

## Test plan
- [x] 5 new tests in `tests/ml/test_training.py` covering the new fields + behavior:
  - `test_evaluate_on_test_returns_edge_filtered_when_categories_provided` — deterministic 6-row test, math-checked
  - `test_evaluate_on_test_omits_edge_filtered_when_categories_none`
  - `test_evaluate_on_test_omits_edge_filtered_when_only_one_kwarg_set` — pins AND-gate, not OR
  - `test_run_study_writes_accepted_categories_to_preprocessor_json`
  - `test_run_study_writes_test_edge_filtered_to_metrics_json` — type+range checked
- [x] Full suite: 873 passed, ruff/format/ty clean.
- [ ] After PR #47 (edge-based early-stopping) merges, rebase this PR onto main and resolve any minor conflicts (low risk; touches different functions in the same file).

## Notes for reviewer
- Conflict surface with PR #47: both PRs touch `src/pscanner/ml/training.py` but in non-overlapping functions. #47 modifies `run_single_trial` and adds `_make_edge_eval_metric`; this PR modifies `evaluate_on_test`/`_dump_artifacts`/`run_study` and adds `_extract_top_category`. Imports section may have one or two intersection points — mechanical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)