### PR TITLE
feat(manifold): Stage 1 — REST client + WS stream + repos + ids + tables (#37)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,16 @@ evaluators. 734 tests.
 - Default `gamma_rpm = 50`, `data_rpm = 50`. Cold-start bottlenecks: smart-money refresh + events catalog sweep both compete for gamma budget; cluster + smart-money depend on watched-wallet `wallet_first_seen` populated by TradeCollector.
 - `/trades` and `/activity` REST cap at `offset=3000` (server: `"max historical activity offset of 3000 exceeded"`, newest-first sort). No documented `before`/`after`/`cursor` workaround — verified May 2026 against ~15 parameter variants and four candidate alt-endpoints. Beyond 3000 trades requires on-chain via Polygon RPC (`OrderFilled` events from CTF Exchange `0x4bFb41d5B3570DeFd03C39a9A4D8dE6Bd8B8982E`). Phase 1 of #42 landed the decoder + `asset_index` resolver; Phase 2 (RPC client + CLI) is queued.
 
+## Manifold API quirks (will bite you)
+- **Mana-denominated**: bets are in mana (play money), NOT USD. Never aggregate Manifold bet amounts into real-money totals or mix with Polymarket/Kalshi volumes.
+- **No traditional orderbook**: limit orders are encoded as bets with a `limitProb` parameter. Fetch open limit orders via `GET /v0/bets?kinds=open-limit`.
+- **CFMM markets**: many Manifold markets are multi-outcome (CFMM mechanism, `outcomeType != "BINARY"`). Stage 1 only supports binary YES/NO. Filter non-binary at the collector layer (`ManifoldMarket.is_binary` property). Non-binary markets still parse — `prob` will be `None`.
+- **Rate limit**: 500 req/min per IP, applied globally across all endpoints. Multi-IP rotation is prohibited per Manifold ToS. The `ManifoldClient._TokenBucket` enforces this with capacity=500, rate=500/60.
+- **WS auth-free**: subscribe to `global/new-bet` for the bet firehose; 30-60s pings required. `ManifoldStream` uses `websockets`' built-in `ping_interval=45, ping_timeout=20`. Unknown-topic frames (e.g. `global/new-contract`) that arrive on the same connection are silently skipped.
+- **Identifiers**: hash strings, not numeric or 0x-prefixed hex. `ManifoldMarketId` and `ManifoldUserId` are `NewType[str]` wrappers — don't alias to Polymarket's `MarketId` or `ConditionId`.
+- **Pagination cursor**: both `/v0/markets` and `/v0/bets` use a `before=<id>` cursor (the `id` of the last item from the previous page), not an offset. Pass `before=None` to start from the most recent.
+- **Tables**: `manifold_markets`, `manifold_bets`, `manifold_users` live in `pscanner.manifold.db`. Apply via `init_manifold_tables(conn)` — separate from `init_db()` (daemon) and `init_corpus_db()` (corpus).
+
 ## Test gotchas
 - `pyproject.toml` has `filterwarnings = ["error"]` — every warning fails tests. Clean up resources (httpx/respx fixtures especially).
 - NEVER `monkeypatch.setattr(asyncio, "sleep", AsyncMock())` — deadlocks the suite (sibling detector loops become CPU spinners). Use `FakeClock` from `pscanner.util.clock` instead; inject via `clock=` ctor kwarg, drive with `await fake_clock.advance(seconds)`.

--- a/src/pscanner/manifold/__init__.py
+++ b/src/pscanner/manifold/__init__.py
@@ -1,0 +1,13 @@
+"""Manifold Markets data-ingest module.
+
+Mana-denominated prediction markets (play money). Public REST and WebSocket
+APIs require no authentication.
+
+Sub-modules:
+    ids      — ``ManifoldMarketId``, ``ManifoldUserId`` ``NewType`` wrappers.
+    models   — Pydantic models for markets, bets, and users.
+    client   — ``ManifoldClient``: async httpx wrapper with 500-rpm rate limit.
+    ws       — ``ManifoldStream``: global bet firehose via WebSocket.
+    db       — ``CREATE TABLE`` statements for ``manifold_*`` daemon tables.
+    repos    — ``ManifoldMarketsRepo``, ``ManifoldBetsRepo``, ``ManifoldUsersRepo``.
+"""

--- a/src/pscanner/manifold/client.py
+++ b/src/pscanner/manifold/client.py
@@ -1,0 +1,378 @@
+"""Async HTTP client for the Manifold Markets REST API.
+
+Public REST endpoints require no authentication. The IP-shared 500-req/min
+rate limit applies globally across all endpoints — a single ``_TokenBucket``
+instance enforces this for all concurrent callers sharing a ``ManifoldClient``.
+
+Tenacity retries on 429 and 5xx transient failures with exponential backoff.
+
+Example::
+
+    async with ManifoldClient() as client:
+        markets = await client.get_markets(limit=100)
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from email.utils import parsedate_to_datetime
+from types import TracebackType
+from typing import Any, Self
+
+import httpx
+import structlog
+from tenacity import (
+    AsyncRetrying,
+    RetryCallState,
+    retry_if_exception,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+from pscanner.manifold.ids import ManifoldMarketId, ManifoldUserId
+from pscanner.manifold.models import ManifoldBet, ManifoldMarket
+
+_BASE_URL = "https://api.manifold.markets"
+_USER_AGENT = "pscanner/0.1"
+
+# Manifold's global IP-shared rate limit.
+_RPM_LIMIT = 500
+_RATE_PER_SECOND = _RPM_LIMIT / 60.0
+
+_STATUS_TOO_MANY_REQUESTS = 429
+_RETRYABLE_STATUS = frozenset({_STATUS_TOO_MANY_REQUESTS, 502, 503, 504})
+_RETRYABLE_TRANSPORT_EXC: tuple[type[BaseException], ...] = (
+    httpx.TimeoutException,
+    httpx.NetworkError,
+    httpx.RemoteProtocolError,
+)
+_MAX_ATTEMPTS = 5
+_BACKOFF_MIN_SECONDS = 1.0
+_BACKOFF_MAX_SECONDS = 30.0
+
+_LOG = structlog.get_logger(__name__)
+
+
+class _TokenBucket:
+    """Async token bucket: capacity tokens, refilled at ``rate`` per second."""
+
+    def __init__(self, *, capacity: int, rate_per_second: float) -> None:
+        self._capacity = float(capacity)
+        self._rate = rate_per_second
+        self._tokens = float(capacity)
+        self._last_refill = asyncio.get_running_loop().time()
+        self._lock = asyncio.Lock()
+
+    @property
+    def tokens(self) -> float:
+        """Current token count (without refill)."""
+        return self._tokens
+
+    async def acquire(self) -> None:
+        """Block until one token is available, then consume it."""
+        loop = asyncio.get_running_loop()
+        async with self._lock:
+            while True:
+                now = loop.time()
+                elapsed = now - self._last_refill
+                if elapsed > 0:
+                    self._tokens = min(self._capacity, self._tokens + elapsed * self._rate)
+                    self._last_refill = now
+                if self._tokens >= 1.0:
+                    self._tokens -= 1.0
+                    return
+                deficit = 1.0 - self._tokens
+                wait_seconds = deficit / self._rate
+                await asyncio.sleep(wait_seconds)
+
+
+class _RetryableStatusError(Exception):
+    """Raised internally to trigger tenacity retry on retryable HTTP status codes."""
+
+    def __init__(self, response: httpx.Response) -> None:
+        super().__init__(f"retryable status {response.status_code}")
+        self.response = response
+
+
+def _parse_retry_after(value: str) -> float | None:
+    """Parse a ``Retry-After`` header into a non-negative wait in seconds.
+
+    Args:
+        value: Raw header value (integer seconds or HTTP-date).
+
+    Returns:
+        Seconds to wait, or ``None`` if unparseable.
+    """
+    stripped = value.strip()
+    if not stripped:
+        return None
+    try:
+        seconds = float(stripped)
+    except ValueError:
+        pass
+    else:
+        return max(0.0, seconds)
+    try:
+        when = parsedate_to_datetime(stripped)
+    except (TypeError, ValueError):
+        return None
+    if when.tzinfo is None:
+        when = when.replace(tzinfo=UTC)
+    delta = (when - datetime.now(tz=UTC)).total_seconds()
+    return max(0.0, delta)
+
+
+def _is_retryable(exc: BaseException) -> bool:
+    """Predicate for tenacity: True for retryable status or transient transport error."""
+    if isinstance(exc, _RetryableStatusError):
+        return True
+    return isinstance(exc, _RETRYABLE_TRANSPORT_EXC)
+
+
+def _before_sleep_log(retry_state: RetryCallState) -> None:
+    """Tenacity hook: log a warning before each retry sleep."""
+    outcome = retry_state.outcome
+    if outcome is None:
+        return
+    exc = outcome.exception()
+    if not isinstance(exc, _RetryableStatusError):
+        return
+    response = exc.response
+    _LOG.warning(
+        "manifold_http_retry",
+        attempt=retry_state.attempt_number,
+        status_code=response.status_code,
+        url=str(response.request.url) if response.request else None,
+        retry_after=response.headers.get("Retry-After"),
+    )
+
+
+class ManifoldClient:
+    """Async HTTP client for the public Manifold Markets REST API.
+
+    Enforces the IP-shared 500-req/min budget via an internal ``_TokenBucket``
+    and retries 429/5xx with tenacity exponential backoff.
+
+    The client is a long-lived singleton. Open once, share across callers,
+    close on shutdown. Both context-manager and explicit ``aclose()`` patterns
+    are supported.
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: str = _BASE_URL,
+        timeout_seconds: float = 30.0,
+    ) -> None:
+        """Configure the client without opening any connections.
+
+        Args:
+            base_url: Manifold API base URL (override for testing).
+            timeout_seconds: Per-request timeout.
+        """
+        if timeout_seconds <= 0:
+            raise ValueError(f"timeout_seconds must be positive, got {timeout_seconds}")
+        self._base_url = base_url
+        self._timeout_seconds = timeout_seconds
+        self._http: httpx.AsyncClient | None = None
+        self._bucket: _TokenBucket | None = None
+        self._init_lock = asyncio.Lock()
+        self._closed = False
+
+    async def _ensure_ready(self) -> tuple[httpx.AsyncClient, _TokenBucket]:
+        """Lazily create the shared httpx client and token bucket."""
+        if self._closed:
+            raise RuntimeError("ManifoldClient is closed")
+        if self._http is not None and self._bucket is not None:
+            return self._http, self._bucket
+        async with self._init_lock:
+            if self._http is None:
+                self._http = httpx.AsyncClient(
+                    base_url=self._base_url,
+                    timeout=httpx.Timeout(self._timeout_seconds),
+                    headers={"User-Agent": _USER_AGENT},
+                )
+            if self._bucket is None:
+                self._bucket = _TokenBucket(
+                    capacity=_RPM_LIMIT,
+                    rate_per_second=_RATE_PER_SECOND,
+                )
+            return self._http, self._bucket
+
+    async def _get_raw(
+        self,
+        path: str,
+        *,
+        params: Mapping[str, Any] | None = None,
+    ) -> dict[str, Any] | list[Any]:
+        """GET ``base_url + path`` with rate-limiting and retries.
+
+        Args:
+            path: Path-only fragment (must start with ``/``).
+            params: Optional query-string parameters.
+
+        Returns:
+            Parsed JSON: either a dict or list.
+
+        Raises:
+            httpx.HTTPStatusError: On non-retryable 4xx or exhausted retries.
+            httpx.HTTPError: On transport-level failures.
+        """
+        http, bucket = await self._ensure_ready()
+        retrying = AsyncRetrying(
+            retry=retry_if_exception(_is_retryable),
+            stop=stop_after_attempt(_MAX_ATTEMPTS),
+            wait=wait_exponential(
+                multiplier=1.0,
+                min=_BACKOFF_MIN_SECONDS,
+                max=_BACKOFF_MAX_SECONDS,
+            ),
+            before_sleep=_before_sleep_log,
+            reraise=True,
+        )
+        response: httpx.Response | None = None
+        try:
+            async for attempt in retrying:
+                with attempt:
+                    response = await self._send_once(http, bucket, path, params)
+        except _RetryableStatusError as exc:
+            exc.response.raise_for_status()
+            raise  # pragma: no cover
+        if response is None:  # pragma: no cover
+            raise RuntimeError("retry loop produced no response")
+        return response.json()  # type: ignore[no-any-return]
+
+    async def _send_once(
+        self,
+        http: httpx.AsyncClient,
+        bucket: _TokenBucket,
+        path: str,
+        params: Mapping[str, Any] | None,
+    ) -> httpx.Response:
+        """Single request attempt with token-bucket gating and Retry-After honour."""
+        await bucket.acquire()
+        response = await http.get(path, params=dict(params) if params else None)
+        if response.status_code in _RETRYABLE_STATUS:
+            if response.status_code == _STATUS_TOO_MANY_REQUESTS:
+                raw = response.headers.get("Retry-After")
+                if raw is not None:
+                    wait = _parse_retry_after(raw)
+                    if wait is not None and wait > 0:
+                        await asyncio.sleep(wait)
+            raise _RetryableStatusError(response)
+        response.raise_for_status()
+        return response
+
+    async def get_markets(
+        self,
+        *,
+        limit: int = 1000,
+        before: str | None = None,
+    ) -> list[ManifoldMarket]:
+        """Fetch one page of markets using Manifold's ``before`` cursor.
+
+        Args:
+            limit: Maximum markets to return (server default is 500; capped at 1000).
+            before: Opaque cursor — the ``id`` of the last market from the previous
+                page. Pass ``None`` to start from the most recent.
+
+        Returns:
+            List of ``ManifoldMarket`` models.
+        """
+        params: dict[str, Any] = {"limit": limit}
+        if before is not None:
+            params["before"] = before
+        payload = await self._get_raw("/v0/markets", params=params)
+        if not isinstance(payload, list):
+            return []
+        return [ManifoldMarket.model_validate(item) for item in payload]
+
+    async def get_market(self, market_id: ManifoldMarketId) -> ManifoldMarket:
+        """Fetch a single market by its opaque hash ID.
+
+        Args:
+            market_id: Manifold market ID (not the slug).
+
+        Returns:
+            ``ManifoldMarket`` model.
+        """
+        payload = await self._get_raw(f"/v0/market/{market_id}")
+        return ManifoldMarket.model_validate(payload)
+
+    async def search_markets(
+        self,
+        query: str,
+        *,
+        limit: int = 100,
+    ) -> list[ManifoldMarket]:
+        """Search markets by text query.
+
+        Args:
+            query: Full-text search string.
+            limit: Maximum results to return.
+
+        Returns:
+            List of ``ManifoldMarket`` models.
+        """
+        payload = await self._get_raw("/v0/search-markets", params={"term": query, "limit": limit})
+        if not isinstance(payload, list):
+            return []
+        return [ManifoldMarket.model_validate(item) for item in payload]
+
+    async def get_bets(
+        self,
+        *,
+        market_id: ManifoldMarketId | None = None,
+        user_id: ManifoldUserId | None = None,
+        limit: int = 1000,
+        before: str | None = None,
+    ) -> list[ManifoldBet]:
+        """Fetch bets, optionally scoped to a market or user.
+
+        Pass ``kinds="open-limit"`` queries aren't exposed as a typed parameter here;
+        call ``_get_raw`` directly if you need open-limit-order filtering.
+
+        Args:
+            market_id: Filter to bets on a specific market.
+            user_id: Filter to bets by a specific user.
+            limit: Maximum bets to return.
+            before: Opaque cursor (bet ``id``) for pagination.
+
+        Returns:
+            List of ``ManifoldBet`` models.
+        """
+        params: dict[str, Any] = {"limit": limit}
+        if market_id is not None:
+            params["contractId"] = market_id
+        if user_id is not None:
+            params["userId"] = user_id
+        if before is not None:
+            params["before"] = before
+        payload = await self._get_raw("/v0/bets", params=params)
+        if not isinstance(payload, list):
+            return []
+        return [ManifoldBet.model_validate(item) for item in payload]
+
+    async def aclose(self) -> None:
+        """Close the underlying httpx client and release connections."""
+        self._closed = True
+        http = self._http
+        self._http = None
+        if http is not None:
+            await http.aclose()
+
+    async def __aenter__(self) -> Self:
+        """Async context-manager entry — ensures the client is initialised."""
+        await self._ensure_ready()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        """Async context-manager exit — calls :meth:`aclose`."""
+        await self.aclose()

--- a/src/pscanner/manifold/db.py
+++ b/src/pscanner/manifold/db.py
@@ -1,0 +1,75 @@
+"""SQLite schema for Manifold Markets daemon tables.
+
+All ``CREATE TABLE`` statements are idempotent (``IF NOT EXISTS``). These tables
+are Manifold-specific and parallel the Polymarket daemon tables without sharing
+them — Manifold market IDs are opaque hash strings incompatible with Polymarket
+CLOB asset IDs or Kalshi tickers.
+
+Call :func:`init_manifold_tables` on an open ``sqlite3.Connection`` to apply
+the schema. This is intentionally separate from ``pscanner.store.db.init_db``
+so the tables are added lazily when the Manifold module is first used.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+_SCHEMA_STATEMENTS: tuple[str, ...] = (
+    """
+    CREATE TABLE IF NOT EXISTS manifold_markets (
+      id TEXT PRIMARY KEY,
+      creator_id TEXT NOT NULL,
+      question TEXT NOT NULL,
+      outcome_type TEXT NOT NULL,
+      mechanism TEXT NOT NULL,
+      prob_at_last_seen REAL,
+      volume REAL NOT NULL DEFAULT 0.0,
+      total_liquidity REAL NOT NULL DEFAULT 0.0,
+      is_resolved INTEGER NOT NULL DEFAULT 0,
+      resolution_time INTEGER,
+      close_time INTEGER,
+      raw_json TEXT NOT NULL
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS manifold_bets (
+      id TEXT PRIMARY KEY,
+      user_id TEXT NOT NULL,
+      contract_id TEXT NOT NULL,
+      outcome TEXT NOT NULL,
+      amount REAL NOT NULL,
+      prob_before REAL NOT NULL,
+      prob_after REAL NOT NULL,
+      created_time INTEGER NOT NULL,
+      is_filled INTEGER,
+      is_cancelled INTEGER,
+      limit_prob REAL
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS manifold_users (
+      id TEXT PRIMARY KEY,
+      username TEXT NOT NULL,
+      name TEXT NOT NULL,
+      created_time INTEGER NOT NULL,
+      raw_json TEXT NOT NULL
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_manifold_bets_contract ON manifold_bets(contract_id)",
+    "CREATE INDEX IF NOT EXISTS idx_manifold_bets_user ON manifold_bets(user_id)",
+    "CREATE INDEX IF NOT EXISTS idx_manifold_bets_time ON manifold_bets(created_time)",
+    "CREATE INDEX IF NOT EXISTS idx_manifold_markets_resolved ON manifold_markets(is_resolved)",
+)
+
+
+def init_manifold_tables(conn: sqlite3.Connection) -> None:
+    """Apply all Manifold schema statements to ``conn``.
+
+    Idempotent — safe to call on an already-initialised database.
+
+    Args:
+        conn: Open ``sqlite3.Connection`` with WAL mode already set.
+    """
+    for statement in _SCHEMA_STATEMENTS:
+        conn.execute(statement)
+    conn.commit()

--- a/src/pscanner/manifold/ids.py
+++ b/src/pscanner/manifold/ids.py
@@ -1,0 +1,24 @@
+"""Typed identifier wrappers for Manifold Markets entities.
+
+Manifold Markets uses hash-based string IDs (not numeric or hex-prefixed). They
+are URL-friendly opaque strings, e.g. ``"abc123XYZ"``.  Mixing them with
+Polymarket or Kalshi identifiers would produce silent query bugs — these
+``NewType`` wrappers give ``ty`` enough information to catch such mistakes at
+type-check time with zero runtime cost.
+
+Conventions:
+- ``ManifoldMarketId``: Manifold's opaque hash market ID (e.g. ``"kjPkT2HECV"``).
+  This is the ``id`` field on contract objects, NOT the slug.
+- ``ManifoldUserId``: Manifold's opaque hash user ID (e.g. ``"igi2zGXsfxYPgB0DJTXVJVmwCOr2"``).
+  Distinct from the username (a human-readable handle).
+
+Do not alias these to ``pscanner.poly.ids`` types — a Manifold hash ID passed
+to a Polymarket hex-condition-ID query would silently corrupt results.
+"""
+
+from __future__ import annotations
+
+from typing import NewType
+
+ManifoldMarketId = NewType("ManifoldMarketId", str)
+ManifoldUserId = NewType("ManifoldUserId", str)

--- a/src/pscanner/manifold/ids.py
+++ b/src/pscanner/manifold/ids.py
@@ -22,3 +22,8 @@ from typing import NewType
 
 ManifoldMarketId = NewType("ManifoldMarketId", str)
 ManifoldUserId = NewType("ManifoldUserId", str)
+# ManifoldSlug is the URL-friendly handle (e.g. "will-trump-be-president"),
+# distinct from ManifoldMarketId which is the opaque hash primary key
+# (e.g. "j3ZE85L2QVxKFP6N3VLs"). Slugs appear in market URLs and search
+# results; IDs are used in all API calls.
+ManifoldSlug = NewType("ManifoldSlug", str)

--- a/src/pscanner/manifold/models.py
+++ b/src/pscanner/manifold/models.py
@@ -14,7 +14,7 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from pscanner.manifold.ids import ManifoldMarketId, ManifoldUserId
+from pscanner.manifold.ids import ManifoldMarketId, ManifoldSlug, ManifoldUserId
 
 _BASE_CONFIG: ConfigDict = ConfigDict(
     populate_by_name=True,
@@ -38,13 +38,13 @@ class ManifoldMarket(BaseModel):
     outcome_type: str = Field(alias="outcomeType")
     mechanism: str
     prob: float | None = None
-    volume: float
+    volume: float = 0.0
     total_liquidity: float = Field(alias="totalLiquidity", default=0.0)
     is_resolved: bool = Field(alias="isResolved")
     resolution_time: int | None = Field(alias="resolutionTime", default=None)
     close_time: int | None = Field(alias="closeTime", default=None)
     url: str | None = None
-    slug: str | None = None
+    slug: ManifoldSlug | None = None
 
     @property
     def is_binary(self) -> bool:

--- a/src/pscanner/manifold/models.py
+++ b/src/pscanner/manifold/models.py
@@ -1,0 +1,93 @@
+"""Pydantic models for Manifold Markets REST payloads.
+
+Field names follow Manifold's camelCase JSON convention via pydantic aliases.
+All models use ``extra="ignore"`` so unknown fields from future API versions
+don't cause validation errors.
+
+Note: Manifold amounts are in **mana** (play money) — never aggregate them
+into real-money USD totals.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from pscanner.manifold.ids import ManifoldMarketId, ManifoldUserId
+
+_BASE_CONFIG: ConfigDict = ConfigDict(
+    populate_by_name=True,
+    extra="ignore",
+)
+
+
+class ManifoldMarket(BaseModel):
+    """A Manifold Markets contract (market).
+
+    Supports binary YES/NO markets (``outcome_type == "BINARY"``). Multi-outcome
+    CFMM markets are represented by the same model but the ``prob`` field may be
+    ``None`` for non-binary types.
+    """
+
+    model_config = _BASE_CONFIG
+
+    id: ManifoldMarketId
+    creator_id: ManifoldUserId = Field(alias="creatorId")
+    question: str
+    outcome_type: str = Field(alias="outcomeType")
+    mechanism: str
+    prob: float | None = None
+    volume: float
+    total_liquidity: float = Field(alias="totalLiquidity", default=0.0)
+    is_resolved: bool = Field(alias="isResolved")
+    resolution_time: int | None = Field(alias="resolutionTime", default=None)
+    close_time: int | None = Field(alias="closeTime", default=None)
+    url: str | None = None
+    slug: str | None = None
+
+    @property
+    def is_binary(self) -> bool:
+        """True iff this is a binary YES/NO market."""
+        return self.outcome_type == "BINARY"
+
+
+class ManifoldBet(BaseModel):
+    """A single bet (trade) on a Manifold market.
+
+    Amounts are in mana (play money). ``limit_prob`` is non-``None`` only for
+    limit orders; ``None`` indicates a market order.
+    """
+
+    model_config = _BASE_CONFIG
+
+    id: str
+    user_id: ManifoldUserId = Field(alias="userId")
+    contract_id: ManifoldMarketId = Field(alias="contractId")
+    outcome: str
+    amount: float
+    prob_before: float = Field(alias="probBefore")
+    prob_after: float = Field(alias="probAfter")
+    created_time: int = Field(alias="createdTime")
+    is_filled: bool | None = Field(alias="isFilled", default=None)
+    is_cancelled: bool | None = Field(alias="isCancelled", default=None)
+    limit_prob: float | None = Field(alias="limitProb", default=None)
+    shares: float | None = None
+    fees: dict[str, Any] | None = None
+
+
+class ManifoldUser(BaseModel):
+    """A Manifold Markets user.
+
+    The ``id`` field is an opaque hash (``ManifoldUserId``); ``username`` is the
+    human-readable handle (e.g. ``"alice"``).
+    """
+
+    model_config = _BASE_CONFIG
+
+    id: ManifoldUserId
+    username: str
+    name: str
+    created_time: int = Field(alias="createdTime")
+    balance: float | None = None
+    avatar_url: str | None = Field(alias="avatarUrl", default=None)

--- a/src/pscanner/manifold/repos.py
+++ b/src/pscanner/manifold/repos.py
@@ -1,0 +1,302 @@
+"""Repositories for Manifold Markets daemon tables.
+
+Each repo wraps a single table with typed insert/get/query methods. All writes
+commit immediately. Reads use the connection's current transaction state.
+
+All repos receive a ``sqlite3.Connection`` at construction — the connection must
+have the Manifold schema already applied (via ``init_manifold_tables``).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterator
+
+from pscanner.manifold.ids import ManifoldMarketId, ManifoldUserId
+from pscanner.manifold.models import ManifoldBet, ManifoldMarket, ManifoldUser
+
+
+class ManifoldMarketsRepo:
+    """Manage the ``manifold_markets`` table.
+
+    Stores Manifold contracts (markets) by their opaque hash ID. ``raw_json``
+    preserves the full API payload for forward compatibility.
+    """
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        """Bind to an already-initialised connection.
+
+        Args:
+            conn: Open ``sqlite3.Connection`` with manifold schema applied.
+        """
+        self._conn = conn
+
+    def insert_or_replace(self, market: ManifoldMarket) -> None:
+        """Upsert a market row. Replaces all columns on conflict.
+
+        Args:
+            market: ``ManifoldMarket`` model to persist.
+        """
+        self._conn.execute(
+            """
+            INSERT OR REPLACE INTO manifold_markets (
+              id, creator_id, question, outcome_type, mechanism,
+              prob_at_last_seen, volume, total_liquidity, is_resolved,
+              resolution_time, close_time, raw_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                market.id,
+                market.creator_id,
+                market.question,
+                market.outcome_type,
+                market.mechanism,
+                market.prob,
+                market.volume,
+                market.total_liquidity,
+                int(market.is_resolved),
+                market.resolution_time,
+                market.close_time,
+                market.model_dump_json(by_alias=True),
+            ),
+        )
+        self._conn.commit()
+
+    def get_by_id(self, market_id: ManifoldMarketId) -> ManifoldMarket | None:
+        """Fetch a single market by ID, or ``None`` if absent.
+
+        Args:
+            market_id: Manifold market hash ID.
+
+        Returns:
+            ``ManifoldMarket`` model or ``None``.
+        """
+        row = self._conn.execute(
+            "SELECT raw_json FROM manifold_markets WHERE id = ?",
+            (market_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        return ManifoldMarket.model_validate_json(row[0])
+
+    def iter_chronological(self) -> Iterator[ManifoldMarket]:
+        """Yield all markets ordered by ``close_time`` ascending (nulls last).
+
+        Yields:
+            ``ManifoldMarket`` models in close-time order.
+        """
+        rows = self._conn.execute(
+            "SELECT raw_json FROM manifold_markets ORDER BY close_time ASC NULLS LAST"
+        ).fetchall()
+        for (raw,) in rows:
+            yield ManifoldMarket.model_validate_json(raw)
+
+
+class ManifoldBetsRepo:
+    """Manage the ``manifold_bets`` table.
+
+    Stores individual bets (trades) by their opaque ID. Amounts are in mana.
+    """
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        """Bind to an already-initialised connection.
+
+        Args:
+            conn: Open ``sqlite3.Connection`` with manifold schema applied.
+        """
+        self._conn = conn
+
+    def insert_or_replace(self, bet: ManifoldBet) -> None:
+        """Upsert a bet row. Replaces all columns on conflict.
+
+        Args:
+            bet: ``ManifoldBet`` model to persist.
+        """
+        self._conn.execute(
+            """
+            INSERT OR REPLACE INTO manifold_bets (
+              id, user_id, contract_id, outcome, amount,
+              prob_before, prob_after, created_time,
+              is_filled, is_cancelled, limit_prob
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                bet.id,
+                bet.user_id,
+                bet.contract_id,
+                bet.outcome,
+                bet.amount,
+                bet.prob_before,
+                bet.prob_after,
+                bet.created_time,
+                int(bet.is_filled) if bet.is_filled is not None else None,
+                int(bet.is_cancelled) if bet.is_cancelled is not None else None,
+                bet.limit_prob,
+            ),
+        )
+        self._conn.commit()
+
+    def get_by_id(self, bet_id: str) -> ManifoldBet | None:
+        """Fetch a single bet by ID, or ``None`` if absent.
+
+        Args:
+            bet_id: Bet ID string.
+
+        Returns:
+            ``ManifoldBet`` model or ``None``.
+        """
+        row = self._conn.execute(
+            """
+            SELECT id, user_id, contract_id, outcome, amount,
+                   prob_before, prob_after, created_time,
+                   is_filled, is_cancelled, limit_prob
+            FROM manifold_bets WHERE id = ?
+            """,
+            (bet_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        return _row_to_bet(row)
+
+    def iter_chronological(
+        self,
+        *,
+        market_id: ManifoldMarketId | None = None,
+    ) -> Iterator[ManifoldBet]:
+        """Yield bets ordered by ``created_time`` ascending.
+
+        Args:
+            market_id: If provided, restrict to bets on this market.
+
+        Yields:
+            ``ManifoldBet`` models in creation-time order.
+        """
+        if market_id is not None:
+            rows = self._conn.execute(
+                """
+                SELECT id, user_id, contract_id, outcome, amount,
+                       prob_before, prob_after, created_time,
+                       is_filled, is_cancelled, limit_prob
+                FROM manifold_bets
+                WHERE contract_id = ?
+                ORDER BY created_time ASC
+                """,
+                (market_id,),
+            ).fetchall()
+        else:
+            rows = self._conn.execute(
+                """
+                SELECT id, user_id, contract_id, outcome, amount,
+                       prob_before, prob_after, created_time,
+                       is_filled, is_cancelled, limit_prob
+                FROM manifold_bets
+                ORDER BY created_time ASC
+                """
+            ).fetchall()
+        for row in rows:
+            yield _row_to_bet(row)
+
+
+class ManifoldUsersRepo:
+    """Manage the ``manifold_users`` table.
+
+    Stores Manifold user profiles by their opaque hash ID. ``raw_json``
+    preserves the full API payload.
+    """
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        """Bind to an already-initialised connection.
+
+        Args:
+            conn: Open ``sqlite3.Connection`` with manifold schema applied.
+        """
+        self._conn = conn
+
+    def insert_or_replace(self, user: ManifoldUser) -> None:
+        """Upsert a user row. Replaces all columns on conflict.
+
+        Args:
+            user: ``ManifoldUser`` model to persist.
+        """
+        self._conn.execute(
+            """
+            INSERT OR REPLACE INTO manifold_users (
+              id, username, name, created_time, raw_json
+            ) VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                user.id,
+                user.username,
+                user.name,
+                user.created_time,
+                user.model_dump_json(by_alias=True),
+            ),
+        )
+        self._conn.commit()
+
+    def get_by_id(self, user_id: ManifoldUserId) -> ManifoldUser | None:
+        """Fetch a single user by ID, or ``None`` if absent.
+
+        Args:
+            user_id: Manifold user hash ID.
+
+        Returns:
+            ``ManifoldUser`` model or ``None``.
+        """
+        row = self._conn.execute(
+            "SELECT raw_json FROM manifold_users WHERE id = ?",
+            (user_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        return ManifoldUser.model_validate_json(row[0])
+
+    def iter_chronological(self) -> Iterator[ManifoldUser]:
+        """Yield all users ordered by ``created_time`` ascending.
+
+        Yields:
+            ``ManifoldUser`` models in creation-time order.
+        """
+        rows = self._conn.execute(
+            "SELECT raw_json FROM manifold_users ORDER BY created_time ASC"
+        ).fetchall()
+        for (raw,) in rows:
+            yield ManifoldUser.model_validate_json(raw)
+
+
+def _row_to_bet(row: sqlite3.Row) -> ManifoldBet:
+    """Reconstruct a ``ManifoldBet`` from a raw DB row.
+
+    Args:
+        row: Row from ``manifold_bets`` with columns in the standard select order.
+
+    Returns:
+        ``ManifoldBet`` model.
+    """
+    (
+        bet_id,
+        user_id,
+        contract_id,
+        outcome,
+        amount,
+        prob_before,
+        prob_after,
+        created_time,
+        is_filled_raw,
+        is_cancelled_raw,
+        limit_prob,
+    ) = row
+    data = {
+        "id": bet_id,
+        "userId": user_id,
+        "contractId": contract_id,
+        "outcome": outcome,
+        "amount": amount,
+        "probBefore": prob_before,
+        "probAfter": prob_after,
+        "createdTime": created_time,
+        "isFilled": bool(is_filled_raw) if is_filled_raw is not None else None,
+        "isCancelled": bool(is_cancelled_raw) if is_cancelled_raw is not None else None,
+        "limitProb": limit_prob,
+    }
+    return ManifoldBet.model_validate(data)

--- a/src/pscanner/manifold/repos.py
+++ b/src/pscanner/manifold/repos.py
@@ -96,6 +96,11 @@ class ManifoldBetsRepo:
     """Manage the ``manifold_bets`` table.
 
     Stores individual bets (trades) by their opaque ID. Amounts are in mana.
+
+    Note: ``ManifoldBet.shares`` and ``ManifoldBet.fees`` are NOT persisted by
+    this repo (the table schema omits them). After a DB round-trip both will be
+    ``None``. If a future use case needs CFMM position sizing analysis, add the
+    columns to the schema migration before relying on these fields downstream.
     """
 
     def __init__(self, conn: sqlite3.Connection) -> None:

--- a/src/pscanner/manifold/ws.py
+++ b/src/pscanner/manifold/ws.py
@@ -52,6 +52,12 @@ class ManifoldStream:
 
     Unknown-topic messages that arrive on the socket are silently dropped,
     so callers don't need to handle unexpected event types.
+
+    On connection loss the iteration raises ``ManifoldStreamError``; callers
+    are responsible for wrapping the stream in their own reconnect loop. This
+    is a deliberate divergence from the auto-reconnecting ``poly.clob_ws``
+    pattern — the Manifold WS protocol's frame-loss-on-reconnect semantics
+    make blind retry problematic, so we surface drops to let callers decide.
     """
 
     def __init__(

--- a/src/pscanner/manifold/ws.py
+++ b/src/pscanner/manifold/ws.py
@@ -1,0 +1,168 @@
+"""Async WebSocket consumer for the Manifold Markets global bet firehose.
+
+Subscribes to ``global/new-bet`` and yields ``ManifoldBet`` objects as they
+arrive. The ``websockets`` library handles ping/pong keepalive natively via
+``ping_interval`` and ``ping_timeout`` constructor arguments.
+
+Unknown topics (e.g. ``global/new-contract``) that arrive on the same connection
+are silently skipped — the firehose may deliver events for other topics the
+server decides to push without an explicit subscription request.
+
+Example::
+
+    async with ManifoldStream() as stream:
+        async for bet in stream:
+            print(bet.id, bet.amount)
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+from collections.abc import AsyncIterator
+from types import TracebackType
+from typing import Any, Self
+
+import structlog
+from pydantic import ValidationError
+from websockets.asyncio.client import ClientConnection, connect
+from websockets.exceptions import ConnectionClosed
+
+from pscanner.manifold.models import ManifoldBet
+
+_WS_URL = "wss://api.manifold.markets/ws"
+_PING_INTERVAL_SECONDS = 45.0
+_PING_TIMEOUT_SECONDS = 20.0
+_GLOBAL_NEW_BET_TOPIC = "global/new-bet"
+
+_LOG = structlog.get_logger(__name__)
+
+
+class ManifoldStreamError(Exception):
+    """Raised on fatal protocol-level errors from the Manifold WebSocket."""
+
+
+class ManifoldStream:
+    """Async context manager yielding ``ManifoldBet`` from the global firehose.
+
+    Subscribes to ``global/new-bet`` on connect. The ``websockets`` library
+    sends WebSocket-level ping frames every ``ping_interval`` seconds (default
+    45 s) and raises ``ConnectionClosed`` if a pong isn't received within
+    ``ping_timeout`` seconds (default 20 s).
+
+    Unknown-topic messages that arrive on the socket are silently dropped,
+    so callers don't need to handle unexpected event types.
+    """
+
+    def __init__(
+        self,
+        *,
+        url: str = _WS_URL,
+        ping_interval: float = _PING_INTERVAL_SECONDS,
+        ping_timeout: float = _PING_TIMEOUT_SECONDS,
+    ) -> None:
+        """Configure without opening a connection.
+
+        Args:
+            url: WebSocket URL (override for testing).
+            ping_interval: Seconds between WebSocket-level pings.
+            ping_timeout: Seconds to wait for a pong before treating the
+                connection as dead.
+        """
+        self._url = url
+        self._ping_interval = ping_interval
+        self._ping_timeout = ping_timeout
+        self._ws: ClientConnection | None = None
+
+    async def _open(self) -> None:
+        """Open the WebSocket connection and send the subscription frame."""
+        self._ws = await connect(
+            self._url,
+            ping_interval=self._ping_interval,
+            ping_timeout=self._ping_timeout,
+        )
+        await self._subscribe()
+        _LOG.info("manifold_ws.connected", url=self._url)
+
+    async def _subscribe(self) -> None:
+        """Send the ``global/new-bet`` subscription frame."""
+        if self._ws is None:
+            return
+        payload = json.dumps({"type": "subscribe", "channel": _GLOBAL_NEW_BET_TOPIC})
+        await self._ws.send(payload)
+        _LOG.debug("manifold_ws.subscribed", channel=_GLOBAL_NEW_BET_TOPIC)
+
+    async def _close(self) -> None:
+        """Close the WebSocket connection gracefully."""
+        ws = self._ws
+        self._ws = None
+        if ws is not None:
+            with contextlib.suppress(ConnectionClosed, OSError):
+                await ws.close()
+
+    def __aiter__(self) -> AsyncIterator[ManifoldBet]:
+        """Return self — this object IS the async iterator."""
+        return self._iter_bets()
+
+    async def _iter_bets(self) -> AsyncIterator[ManifoldBet]:
+        """Yield ``ManifoldBet`` objects from the open WebSocket until closed."""
+        if self._ws is None:
+            raise ManifoldStreamError("ManifoldStream must be used as an async context manager")
+        try:
+            async for raw in self._ws:
+                bet = _parse_bet_frame(raw)
+                if bet is not None:
+                    yield bet
+        except ConnectionClosed as exc:
+            rcvd = exc.rcvd
+            raise ManifoldStreamError(
+                f"manifold WebSocket closed unexpectedly: "
+                f"code={rcvd.code if rcvd else None}, "
+                f"reason={rcvd.reason if rcvd else None}"
+            ) from exc
+
+    async def __aenter__(self) -> Self:
+        """Open the connection and return self."""
+        await self._open()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        """Close the connection."""
+        await self._close()
+
+
+def _parse_bet_frame(raw: str | bytes) -> ManifoldBet | None:
+    """Parse one WebSocket frame into a ``ManifoldBet`` or ``None`` to skip.
+
+    Frames that are not JSON, not dicts, not ``global/new-bet`` topic, or fail
+    pydantic validation are silently dropped.
+
+    Args:
+        raw: Text or bytes frame from the WebSocket.
+
+    Returns:
+        A ``ManifoldBet`` if the frame carries a new-bet payload, else ``None``.
+    """
+    text = raw.decode() if isinstance(raw, bytes) else raw
+    try:
+        decoded: Any = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(decoded, dict):
+        return None
+    topic = decoded.get("topic") or decoded.get("channel")
+    if topic != _GLOBAL_NEW_BET_TOPIC:
+        return None
+    data = decoded.get("data")
+    if not isinstance(data, dict):
+        return None
+    try:
+        return ManifoldBet.model_validate(data)
+    except ValidationError as exc:
+        _LOG.warning("manifold_ws.bet_validation_failed", error=str(exc))
+        return None

--- a/tests/manifold/test_client.py
+++ b/tests/manifold/test_client.py
@@ -1,0 +1,283 @@
+"""Tests for ``pscanner.manifold.client.ManifoldClient``."""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import pytest
+import respx
+
+from pscanner.manifold.client import ManifoldClient
+from pscanner.manifold.ids import ManifoldMarketId, ManifoldUserId
+
+_BASE = "https://api.manifold.markets"
+
+_MARKET_PAYLOAD = {
+    "id": "mkABC123",
+    "creatorId": "userXYZ",
+    "question": "Will the market resolve YES?",
+    "outcomeType": "BINARY",
+    "mechanism": "cpmm-1",
+    "prob": 0.5,
+    "volume": 1000.0,
+    "totalLiquidity": 200.0,
+    "isResolved": False,
+    "resolutionTime": None,
+    "closeTime": 1_800_000_000_000,
+}
+
+_BET_PAYLOAD = {
+    "id": "betXYZ",
+    "userId": "userXYZ",
+    "contractId": "mkABC123",
+    "outcome": "YES",
+    "amount": 10.0,
+    "probBefore": 0.49,
+    "probAfter": 0.50,
+    "createdTime": 1_714_000_000_000,
+    "isFilled": True,
+    "isCancelled": False,
+    "limitProb": None,
+}
+
+
+@pytest.fixture
+def client() -> ManifoldClient:
+    """Fresh client per test — high implicit timeout, won't hit real network."""
+    return ManifoldClient(base_url=_BASE, timeout_seconds=5.0)
+
+
+@respx.mock
+async def test_get_markets_returns_list(client: ManifoldClient) -> None:
+    respx.get(f"{_BASE}/v0/markets").mock(
+        return_value=httpx.Response(200, json=[_MARKET_PAYLOAD]),
+    )
+    try:
+        markets = await client.get_markets(limit=10)
+    finally:
+        await client.aclose()
+
+    assert len(markets) == 1
+    assert markets[0].id == "mkABC123"
+    assert markets[0].is_binary is True
+
+
+@respx.mock
+async def test_get_markets_passes_before_cursor(client: ManifoldClient) -> None:
+    route = respx.get(f"{_BASE}/v0/markets", params={"limit": "5", "before": "cursor99"}).mock(
+        return_value=httpx.Response(200, json=[]),
+    )
+    try:
+        result = await client.get_markets(limit=5, before="cursor99")
+    finally:
+        await client.aclose()
+
+    assert result == []
+    assert route.called
+
+
+@respx.mock
+async def test_get_market_single(client: ManifoldClient) -> None:
+    mid = ManifoldMarketId("mkABC123")
+    respx.get(f"{_BASE}/v0/market/{mid}").mock(
+        return_value=httpx.Response(200, json=_MARKET_PAYLOAD),
+    )
+    try:
+        market = await client.get_market(mid)
+    finally:
+        await client.aclose()
+
+    assert market.id == mid
+    assert market.question == "Will the market resolve YES?"
+
+
+@respx.mock
+async def test_search_markets(client: ManifoldClient) -> None:
+    route = respx.get(f"{_BASE}/v0/search-markets", params={"term": "AI", "limit": "5"}).mock(
+        return_value=httpx.Response(200, json=[_MARKET_PAYLOAD]),
+    )
+    try:
+        results = await client.search_markets("AI", limit=5)
+    finally:
+        await client.aclose()
+
+    assert len(results) == 1
+    assert route.called
+
+
+@respx.mock
+async def test_get_bets_no_filter(client: ManifoldClient) -> None:
+    respx.get(f"{_BASE}/v0/bets").mock(
+        return_value=httpx.Response(200, json=[_BET_PAYLOAD]),
+    )
+    try:
+        bets = await client.get_bets(limit=10)
+    finally:
+        await client.aclose()
+
+    assert len(bets) == 1
+    assert bets[0].id == "betXYZ"
+    assert bets[0].amount == 10.0
+
+
+@respx.mock
+async def test_get_bets_with_market_filter(client: ManifoldClient) -> None:
+    mid = ManifoldMarketId("mkABC123")
+    route = respx.get(
+        f"{_BASE}/v0/bets",
+        params={"contractId": mid, "limit": "1000"},
+    ).mock(return_value=httpx.Response(200, json=[_BET_PAYLOAD]))
+    try:
+        bets = await client.get_bets(market_id=mid)
+    finally:
+        await client.aclose()
+
+    assert len(bets) == 1
+    assert route.called
+
+
+@respx.mock
+async def test_get_bets_with_user_filter(client: ManifoldClient) -> None:
+    uid = ManifoldUserId("userXYZ")
+    route = respx.get(
+        f"{_BASE}/v0/bets",
+        params={"userId": uid, "limit": "1000"},
+    ).mock(return_value=httpx.Response(200, json=[_BET_PAYLOAD]))
+    try:
+        bets = await client.get_bets(user_id=uid)
+    finally:
+        await client.aclose()
+
+    assert len(bets) == 1
+    assert route.called
+
+
+@respx.mock
+async def test_get_bets_with_before_cursor(client: ManifoldClient) -> None:
+    route = respx.get(
+        f"{_BASE}/v0/bets",
+        params={"before": "bet-prev", "limit": "1000"},
+    ).mock(return_value=httpx.Response(200, json=[]))
+    try:
+        await client.get_bets(before="bet-prev")
+    finally:
+        await client.aclose()
+
+    assert route.called
+
+
+@respx.mock
+async def test_429_retries_and_succeeds(client: ManifoldClient) -> None:
+    route = respx.get(f"{_BASE}/v0/markets").mock(
+        side_effect=[
+            httpx.Response(429, headers={"Retry-After": "0"}, json={"err": "rl"}),
+            httpx.Response(200, json=[_MARKET_PAYLOAD]),
+        ],
+    )
+    try:
+        markets = await client.get_markets(limit=1)
+    finally:
+        await client.aclose()
+
+    assert markets[0].id == "mkABC123"
+    assert route.call_count == 2
+
+
+@respx.mock
+async def test_503_retries_then_succeeds(client: ManifoldClient) -> None:
+    route = respx.get(f"{_BASE}/v0/markets").mock(
+        side_effect=[
+            httpx.Response(503),
+            httpx.Response(200, json=[_MARKET_PAYLOAD]),
+        ],
+    )
+    try:
+        markets = await client.get_markets()
+    finally:
+        await client.aclose()
+
+    assert markets[0].id == "mkABC123"
+    assert route.call_count == 2
+
+
+@respx.mock
+async def test_persistent_503_raises_after_max_attempts(client: ManifoldClient) -> None:
+    route = respx.get(f"{_BASE}/v0/markets").mock(
+        return_value=httpx.Response(503, json={"err": "down"}),
+    )
+    try:
+        with pytest.raises(httpx.HTTPStatusError) as exc_info:
+            await client.get_markets()
+    finally:
+        await client.aclose()
+
+    assert exc_info.value.response.status_code == 503
+    assert route.call_count == 5
+
+
+@respx.mock
+async def test_404_not_retried(client: ManifoldClient) -> None:
+    route = respx.get(f"{_BASE}/v0/market/gone").mock(
+        return_value=httpx.Response(404, json={"error": "not found"}),
+    )
+    try:
+        with pytest.raises(httpx.HTTPStatusError) as exc_info:
+            await client.get_market(ManifoldMarketId("gone"))
+    finally:
+        await client.aclose()
+
+    assert exc_info.value.response.status_code == 404
+    assert route.call_count == 1
+
+
+@respx.mock
+async def test_rate_limit_token_bucket_blocks_when_exhausted() -> None:
+    """Draining bucket forces acquire to wait until tokens refill."""
+    client = ManifoldClient(base_url=_BASE, timeout_seconds=5.0)
+    respx.get(f"{_BASE}/v0/markets").mock(
+        return_value=httpx.Response(200, json=[]),
+    )
+    try:
+        _, bucket = await client._ensure_ready()
+        loop = asyncio.get_running_loop()
+        bucket._tokens = 0.0  # type: ignore[attr-defined]
+        bucket._last_refill = loop.time()  # type: ignore[attr-defined]
+        # With rate=500/60 ≈ 8.33/s, waiting for 1 token takes ~0.12s
+        start = loop.time()
+        await client.get_markets()
+        elapsed = loop.time() - start
+    finally:
+        await client.aclose()
+
+    assert elapsed >= 0.05
+
+
+async def test_aclose_idempotent() -> None:
+    client = ManifoldClient(base_url=_BASE)
+    await client.aclose()
+    await client.aclose()
+
+
+async def test_get_after_close_raises() -> None:
+    client = ManifoldClient(base_url=_BASE)
+    await client.aclose()
+    with pytest.raises(RuntimeError, match="closed"):
+        await client.get_markets()
+
+
+def test_invalid_timeout_rejected() -> None:
+    with pytest.raises(ValueError, match="timeout_seconds"):
+        ManifoldClient(timeout_seconds=0.0)
+
+
+@respx.mock
+async def test_async_context_manager_closes_on_exit() -> None:
+    respx.get(f"{_BASE}/v0/markets").mock(
+        return_value=httpx.Response(200, json=[]),
+    )
+    async with ManifoldClient(base_url=_BASE) as client:
+        await client.get_markets()
+        underlying = client._http
+    assert underlying is not None
+    assert underlying.is_closed is True

--- a/tests/manifold/test_ids.py
+++ b/tests/manifold/test_ids.py
@@ -1,0 +1,27 @@
+"""Tests for ``pscanner.manifold.ids`` NewType wrappers."""
+
+from __future__ import annotations
+
+from pscanner.manifold.ids import ManifoldMarketId, ManifoldUserId
+
+
+def test_market_id_is_str_at_runtime() -> None:
+    mid = ManifoldMarketId("kjPkT2HECV")
+    assert isinstance(mid, str)
+    assert mid == "kjPkT2HECV"
+
+
+def test_user_id_is_str_at_runtime() -> None:
+    uid = ManifoldUserId("igi2zGXsfxYPgB0DJTXVJVmwCOr2")
+    assert isinstance(uid, str)
+    assert uid == "igi2zGXsfxYPgB0DJTXVJVmwCOr2"
+
+
+def test_ids_are_distinct_types() -> None:
+    """ManifoldMarketId and ManifoldUserId do not share an identity at runtime."""
+    mid = ManifoldMarketId("same-value")
+    uid = ManifoldUserId("same-value")
+    # Both are plain str at runtime — equality holds.
+    assert mid == uid
+    # But their constructors are distinct callables (NewType wrappers).
+    assert ManifoldMarketId is not ManifoldUserId

--- a/tests/manifold/test_models.py
+++ b/tests/manifold/test_models.py
@@ -1,0 +1,165 @@
+"""Tests for ``pscanner.manifold.models`` pydantic round-trip."""
+
+from __future__ import annotations
+
+import pytest
+
+from pscanner.manifold.models import ManifoldBet, ManifoldMarket, ManifoldUser
+
+_BINARY_MARKET = {
+    "id": "kjPkT2HECV",
+    "creatorId": "igi2zGXsfxYPgB0DJTXVJVmwCOr2",
+    "question": "Will AI surpass human performance on MATH by 2026?",
+    "outcomeType": "BINARY",
+    "mechanism": "cpmm-1",
+    "prob": 0.62,
+    "volume": 15000.0,
+    "totalLiquidity": 1200.0,
+    "isResolved": False,
+    "resolutionTime": None,
+    "closeTime": 1_800_000_000_000,
+    "url": "https://manifold.markets/alice/will-ai-surpass",
+    "slug": "will-ai-surpass",
+}
+
+_MULTIPLE_CHOICE_MARKET = {
+    "id": "MCMktABC123",
+    "creatorId": "userXYZ",
+    "question": "Who wins the 2026 World Cup?",
+    "outcomeType": "MULTIPLE_CHOICE",
+    "mechanism": "cpmm-multi-1",
+    "volume": 5000.0,
+    "totalLiquidity": 800.0,
+    "isResolved": False,
+    # No prob — multi-outcome markets don't have a single prob
+}
+
+_BET = {
+    "id": "bet-abc-123",
+    "userId": "igi2zGXsfxYPgB0DJTXVJVmwCOr2",
+    "contractId": "kjPkT2HECV",
+    "outcome": "YES",
+    "amount": 25.0,
+    "probBefore": 0.60,
+    "probAfter": 0.62,
+    "createdTime": 1_714_000_000_000,
+    "isFilled": True,
+    "isCancelled": False,
+    "limitProb": None,
+    "shares": 40.0,
+}
+
+_LIMIT_BET = {
+    **_BET,
+    "id": "bet-limit-456",
+    "isFilled": False,
+    "limitProb": 0.55,
+}
+
+_USER = {
+    "id": "igi2zGXsfxYPgB0DJTXVJVmwCOr2",
+    "username": "alice",
+    "name": "Alice Wonderland",
+    "createdTime": 1_700_000_000_000,
+    "balance": 500.0,
+    "avatarUrl": "https://example.com/avatar.png",
+}
+
+
+def test_binary_market_parses_all_fields() -> None:
+    market = ManifoldMarket.model_validate(_BINARY_MARKET)
+    assert market.id == "kjPkT2HECV"
+    assert market.creator_id == "igi2zGXsfxYPgB0DJTXVJVmwCOr2"
+    assert market.question == "Will AI surpass human performance on MATH by 2026?"
+    assert market.outcome_type == "BINARY"
+    assert market.mechanism == "cpmm-1"
+    assert market.prob == pytest.approx(0.62)
+    assert market.volume == 15000.0
+    assert market.total_liquidity == 1200.0
+    assert market.is_resolved is False
+    assert market.resolution_time is None
+    assert market.close_time == 1_800_000_000_000
+
+
+def test_binary_market_is_binary_property() -> None:
+    market = ManifoldMarket.model_validate(_BINARY_MARKET)
+    assert market.is_binary is True
+
+
+def test_multiple_choice_market_is_not_binary() -> None:
+    market = ManifoldMarket.model_validate(_MULTIPLE_CHOICE_MARKET)
+    assert market.is_binary is False
+    assert market.prob is None
+
+
+def test_market_extra_fields_ignored() -> None:
+    """Unknown API fields must not raise ValidationError."""
+    payload = {**_BINARY_MARKET, "unknownFutureField": "surprise", "anotherOne": 42}
+    market = ManifoldMarket.model_validate(payload)
+    assert market.id == "kjPkT2HECV"
+
+
+def test_market_roundtrip_via_json() -> None:
+    market = ManifoldMarket.model_validate(_BINARY_MARKET)
+    json_str = market.model_dump_json(by_alias=True)
+    market2 = ManifoldMarket.model_validate_json(json_str)
+    assert market2.id == market.id
+    assert market2.prob == market.prob
+
+
+def test_bet_parses_market_order() -> None:
+    bet = ManifoldBet.model_validate(_BET)
+    assert bet.id == "bet-abc-123"
+    assert bet.user_id == "igi2zGXsfxYPgB0DJTXVJVmwCOr2"
+    assert bet.contract_id == "kjPkT2HECV"
+    assert bet.outcome == "YES"
+    assert bet.amount == 25.0
+    assert bet.prob_before == pytest.approx(0.60)
+    assert bet.prob_after == pytest.approx(0.62)
+    assert bet.is_filled is True
+    assert bet.is_cancelled is False
+    assert bet.limit_prob is None
+
+
+def test_bet_parses_limit_order() -> None:
+    bet = ManifoldBet.model_validate(_LIMIT_BET)
+    assert bet.limit_prob == pytest.approx(0.55)
+    assert bet.is_filled is False
+
+
+def test_bet_extra_fields_ignored() -> None:
+    payload = {**_BET, "fees": {"creatorFee": 0.1, "platformFee": 0.05}}
+    bet = ManifoldBet.model_validate(payload)
+    assert bet.id == "bet-abc-123"
+
+
+def test_bet_roundtrip_via_json() -> None:
+    bet = ManifoldBet.model_validate(_BET)
+    json_str = bet.model_dump_json(by_alias=True)
+    bet2 = ManifoldBet.model_validate_json(json_str)
+    assert bet2.id == bet.id
+    assert bet2.amount == bet.amount
+
+
+def test_user_parses_all_fields() -> None:
+    user = ManifoldUser.model_validate(_USER)
+    assert user.id == "igi2zGXsfxYPgB0DJTXVJVmwCOr2"
+    assert user.username == "alice"
+    assert user.name == "Alice Wonderland"
+    assert user.created_time == 1_700_000_000_000
+    assert user.balance == 500.0
+    assert user.avatar_url == "https://example.com/avatar.png"
+
+
+def test_user_extra_fields_ignored() -> None:
+    payload = {**_USER, "profitCached": {"weekly": 100.0}}
+    user = ManifoldUser.model_validate(payload)
+    assert user.username == "alice"
+
+
+def test_user_roundtrip_via_json() -> None:
+    user = ManifoldUser.model_validate(_USER)
+    json_str = user.model_dump_json(by_alias=True)
+    user2 = ManifoldUser.model_validate_json(json_str)
+    assert user2.id == user.id
+    assert user2.username == user.username

--- a/tests/manifold/test_repos.py
+++ b/tests/manifold/test_repos.py
@@ -1,0 +1,323 @@
+"""Tests for ``pscanner.manifold.repos.*`` CRUD operations."""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterator
+
+import pytest
+
+from pscanner.manifold.db import init_manifold_tables
+from pscanner.manifold.ids import ManifoldMarketId, ManifoldUserId
+from pscanner.manifold.models import ManifoldBet, ManifoldMarket, ManifoldUser
+from pscanner.manifold.repos import ManifoldBetsRepo, ManifoldMarketsRepo, ManifoldUsersRepo
+
+
+@pytest.fixture
+def mdb() -> Iterator[sqlite3.Connection]:
+    """In-memory SQLite connection with Manifold schema applied."""
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    init_manifold_tables(conn)
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+def _market(market_id: str = "mkABC") -> ManifoldMarket:
+    return ManifoldMarket.model_validate(
+        {
+            "id": market_id,
+            "creatorId": "userXYZ",
+            "question": f"Will {market_id} resolve YES?",
+            "outcomeType": "BINARY",
+            "mechanism": "cpmm-1",
+            "prob": 0.5,
+            "volume": 1000.0,
+            "totalLiquidity": 100.0,
+            "isResolved": False,
+            "resolutionTime": None,
+            "closeTime": 1_800_000_000_000,
+        }
+    )
+
+
+def _bet(bet_id: str = "betXYZ", *, market_id: str = "mkABC", ts: int = 1_000) -> ManifoldBet:
+    return ManifoldBet.model_validate(
+        {
+            "id": bet_id,
+            "userId": "userXYZ",
+            "contractId": market_id,
+            "outcome": "YES",
+            "amount": 10.0,
+            "probBefore": 0.49,
+            "probAfter": 0.50,
+            "createdTime": ts,
+            "isFilled": True,
+            "isCancelled": False,
+            "limitProb": None,
+        }
+    )
+
+
+def _user(user_id: str = "userXYZ") -> ManifoldUser:
+    return ManifoldUser.model_validate(
+        {
+            "id": user_id,
+            "username": "alice",
+            "name": "Alice Wonderland",
+            "createdTime": 1_700_000_000_000,
+            "balance": 500.0,
+        }
+    )
+
+
+# ---- ManifoldMarketsRepo ----
+
+
+def test_markets_insert_and_get(mdb: sqlite3.Connection) -> None:
+    repo = ManifoldMarketsRepo(mdb)
+    m = _market()
+    repo.insert_or_replace(m)
+    result = repo.get_by_id(ManifoldMarketId("mkABC"))
+    assert result is not None
+    assert result.id == "mkABC"
+    assert result.question == "Will mkABC resolve YES?"
+
+
+def test_markets_get_missing_returns_none(mdb: sqlite3.Connection) -> None:
+    repo = ManifoldMarketsRepo(mdb)
+    result = repo.get_by_id(ManifoldMarketId("nonexistent"))
+    assert result is None
+
+
+def test_markets_insert_or_replace_updates_row(mdb: sqlite3.Connection) -> None:
+    repo = ManifoldMarketsRepo(mdb)
+    m1 = _market()
+    repo.insert_or_replace(m1)
+    # Simulate an update: same ID, different prob.
+    updated = ManifoldMarket.model_validate(
+        {
+            **m1.model_dump(by_alias=True),
+            "prob": 0.75,
+        }
+    )
+    repo.insert_or_replace(updated)
+    result = repo.get_by_id(ManifoldMarketId("mkABC"))
+    assert result is not None
+    assert result.prob == pytest.approx(0.75)
+
+
+def test_markets_iter_chronological_empty(mdb: sqlite3.Connection) -> None:
+    repo = ManifoldMarketsRepo(mdb)
+    assert list(repo.iter_chronological()) == []
+
+
+def test_markets_iter_chronological_order(mdb: sqlite3.Connection) -> None:
+    repo = ManifoldMarketsRepo(mdb)
+    m1 = ManifoldMarket.model_validate(
+        {
+            "id": "early",
+            "creatorId": "u",
+            "question": "Early market",
+            "outcomeType": "BINARY",
+            "mechanism": "cpmm-1",
+            "volume": 100.0,
+            "totalLiquidity": 10.0,
+            "isResolved": False,
+            "closeTime": 1_000_000,
+        }
+    )
+    m2 = ManifoldMarket.model_validate(
+        {
+            "id": "late",
+            "creatorId": "u",
+            "question": "Late market",
+            "outcomeType": "BINARY",
+            "mechanism": "cpmm-1",
+            "volume": 200.0,
+            "totalLiquidity": 20.0,
+            "isResolved": False,
+            "closeTime": 2_000_000,
+        }
+    )
+    repo.insert_or_replace(m2)
+    repo.insert_or_replace(m1)
+    markets = list(repo.iter_chronological())
+    assert [m.id for m in markets] == ["early", "late"]
+
+
+def test_markets_null_close_time_last(mdb: sqlite3.Connection) -> None:
+    repo = ManifoldMarketsRepo(mdb)
+    m_with_time = ManifoldMarket.model_validate(
+        {
+            "id": "timed",
+            "creatorId": "u",
+            "question": "Q",
+            "outcomeType": "BINARY",
+            "mechanism": "cpmm-1",
+            "volume": 0.0,
+            "totalLiquidity": 0.0,
+            "isResolved": False,
+            "closeTime": 1_000,
+        }
+    )
+    m_no_time = ManifoldMarket.model_validate(
+        {
+            "id": "notimed",
+            "creatorId": "u",
+            "question": "Q2",
+            "outcomeType": "BINARY",
+            "mechanism": "cpmm-1",
+            "volume": 0.0,
+            "totalLiquidity": 0.0,
+            "isResolved": False,
+        }
+    )
+    repo.insert_or_replace(m_no_time)
+    repo.insert_or_replace(m_with_time)
+    from pscanner.manifold.ids import ManifoldMarketId as MID
+
+    ids = [m.id for m in repo.iter_chronological()]
+    assert ids.index(MID("timed")) < ids.index(MID("notimed"))
+
+
+# ---- ManifoldBetsRepo ----
+
+
+def test_bets_insert_and_get(mdb: sqlite3.Connection) -> None:
+    repo = ManifoldBetsRepo(mdb)
+    b = _bet()
+    repo.insert_or_replace(b)
+    result = repo.get_by_id("betXYZ")
+    assert result is not None
+    assert result.id == "betXYZ"
+    assert result.amount == 10.0
+    assert result.outcome == "YES"
+
+
+def test_bets_get_missing_returns_none(mdb: sqlite3.Connection) -> None:
+    repo = ManifoldBetsRepo(mdb)
+    assert repo.get_by_id("nonexistent") is None
+
+
+def test_bets_insert_or_replace_updates(mdb: sqlite3.Connection) -> None:
+    repo = ManifoldBetsRepo(mdb)
+    b = _bet()
+    repo.insert_or_replace(b)
+    updated = ManifoldBet.model_validate(
+        {
+            **b.model_dump(by_alias=True),
+            "amount": 99.0,
+        }
+    )
+    repo.insert_or_replace(updated)
+    result = repo.get_by_id("betXYZ")
+    assert result is not None
+    assert result.amount == 99.0
+
+
+def test_bets_iter_chronological_all(mdb: sqlite3.Connection) -> None:
+    repo = ManifoldBetsRepo(mdb)
+    repo.insert_or_replace(_bet("b2", ts=2000))
+    repo.insert_or_replace(_bet("b1", ts=1000))
+    bets = list(repo.iter_chronological())
+    assert [b.id for b in bets] == ["b1", "b2"]
+
+
+def test_bets_iter_chronological_market_filter(mdb: sqlite3.Connection) -> None:
+    repo = ManifoldBetsRepo(mdb)
+    repo.insert_or_replace(_bet("b1", market_id="mkt1", ts=1000))
+    repo.insert_or_replace(_bet("b2", market_id="mkt2", ts=2000))
+    bets = list(repo.iter_chronological(market_id=ManifoldMarketId("mkt1")))
+    assert [b.id for b in bets] == ["b1"]
+
+
+def test_bets_limit_prob_round_trips(mdb: sqlite3.Connection) -> None:
+    repo = ManifoldBetsRepo(mdb)
+    limit_bet = ManifoldBet.model_validate(
+        {
+            "id": "limit1",
+            "userId": "u",
+            "contractId": "m",
+            "outcome": "NO",
+            "amount": 5.0,
+            "probBefore": 0.6,
+            "probAfter": 0.59,
+            "createdTime": 100,
+            "isFilled": False,
+            "isCancelled": False,
+            "limitProb": 0.55,
+        }
+    )
+    repo.insert_or_replace(limit_bet)
+    result = repo.get_by_id("limit1")
+    assert result is not None
+    assert result.limit_prob == pytest.approx(0.55)
+    assert result.is_filled is False
+
+
+# ---- ManifoldUsersRepo ----
+
+
+def test_users_insert_and_get(mdb: sqlite3.Connection) -> None:
+    repo = ManifoldUsersRepo(mdb)
+    u = _user()
+    repo.insert_or_replace(u)
+    result = repo.get_by_id(ManifoldUserId("userXYZ"))
+    assert result is not None
+    assert result.username == "alice"
+    assert result.name == "Alice Wonderland"
+
+
+def test_users_get_missing_returns_none(mdb: sqlite3.Connection) -> None:
+    repo = ManifoldUsersRepo(mdb)
+    assert repo.get_by_id(ManifoldUserId("nobody")) is None
+
+
+def test_users_insert_or_replace_updates(mdb: sqlite3.Connection) -> None:
+    repo = ManifoldUsersRepo(mdb)
+    u = _user()
+    repo.insert_or_replace(u)
+    updated = ManifoldUser.model_validate(
+        {
+            **u.model_dump(by_alias=True),
+            "name": "Alice Updated",
+        }
+    )
+    repo.insert_or_replace(updated)
+    result = repo.get_by_id(ManifoldUserId("userXYZ"))
+    assert result is not None
+    assert result.name == "Alice Updated"
+
+
+def test_users_iter_chronological(mdb: sqlite3.Connection) -> None:
+    repo = ManifoldUsersRepo(mdb)
+    u1 = ManifoldUser.model_validate(
+        {
+            "id": "u1",
+            "username": "a",
+            "name": "A",
+            "createdTime": 1000,
+        }
+    )
+    u2 = ManifoldUser.model_validate(
+        {
+            "id": "u2",
+            "username": "b",
+            "name": "B",
+            "createdTime": 2000,
+        }
+    )
+    repo.insert_or_replace(u2)
+    repo.insert_or_replace(u1)
+    users = list(repo.iter_chronological())
+    assert [u.id for u in users] == ["u1", "u2"]
+
+
+def test_init_manifold_tables_idempotent(mdb: sqlite3.Connection) -> None:
+    """Calling init_manifold_tables twice must not raise."""
+    init_manifold_tables(mdb)
+    init_manifold_tables(mdb)

--- a/tests/manifold/test_repos.py
+++ b/tests/manifold/test_repos.py
@@ -178,10 +178,8 @@ def test_markets_null_close_time_last(mdb: sqlite3.Connection) -> None:
     )
     repo.insert_or_replace(m_no_time)
     repo.insert_or_replace(m_with_time)
-    from pscanner.manifold.ids import ManifoldMarketId as MID
-
     ids = [m.id for m in repo.iter_chronological()]
-    assert ids.index(MID("timed")) < ids.index(MID("notimed"))
+    assert ids.index(ManifoldMarketId("timed")) < ids.index(ManifoldMarketId("notimed"))
 
 
 # ---- ManifoldBetsRepo ----

--- a/tests/manifold/test_ws.py
+++ b/tests/manifold/test_ws.py
@@ -1,0 +1,217 @@
+"""Tests for ``pscanner.manifold.ws.ManifoldStream``.
+
+Uses a real ``websockets.asyncio.server.serve`` on a random localhost port —
+same pattern as ``tests/poly/test_clob_ws.py`` — so we exercise the actual
+library code paths.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import AsyncIterator, Awaitable, Callable
+
+import pytest
+from websockets.asyncio.server import ServerConnection, serve
+
+from pscanner.manifold.ws import ManifoldStream, ManifoldStreamError
+
+ServerHandler = Callable[[ServerConnection], Awaitable[None]]
+
+_BET_DATA = {
+    "id": "betXYZ",
+    "userId": "userXYZ",
+    "contractId": "mkABC123",
+    "outcome": "YES",
+    "amount": 25.0,
+    "probBefore": 0.49,
+    "probAfter": 0.51,
+    "createdTime": 1_714_000_000_000,
+    "isFilled": True,
+    "isCancelled": False,
+    "limitProb": None,
+}
+
+
+class ServerState:
+    """Shared in-memory state captured by test server handlers."""
+
+    def __init__(self) -> None:
+        self.received: list[str] = []
+        self.outbound: asyncio.Queue[str | None] = asyncio.Queue()
+        self.connections: int = 0
+
+
+async def _drain_inbound(ws: ServerConnection, state: ServerState) -> None:
+    try:
+        async for message in ws:
+            text = message.decode() if isinstance(message, bytes) else message
+            state.received.append(text)
+    except Exception:
+        return
+
+
+async def _pump_outbound(ws: ServerConnection, state: ServerState) -> None:
+    while True:
+        item = await state.outbound.get()
+        if item is None:
+            return
+        try:
+            await ws.send(item)
+        except Exception:
+            return
+
+
+def _make_handler(state: ServerState) -> ServerHandler:
+    async def handler(ws: ServerConnection) -> None:
+        state.connections += 1
+        inbound = asyncio.create_task(_drain_inbound(ws, state))
+        outbound = asyncio.create_task(_pump_outbound(ws, state))
+        try:
+            await asyncio.gather(inbound, outbound)
+        finally:
+            inbound.cancel()
+            outbound.cancel()
+
+    return handler
+
+
+@pytest.fixture
+async def server() -> AsyncIterator[tuple[str, ServerState]]:
+    """Start a websockets server on a random port, yield ``(url, state)``."""
+    state = ServerState()
+    handler = _make_handler(state)
+    # Use small ping params for the server side to not interfere with client
+    async with serve(handler, "127.0.0.1", 0) as server_obj:
+        sock = next(iter(server_obj.sockets))
+        port = sock.getsockname()[1]
+        url = f"ws://127.0.0.1:{port}"
+        yield url, state
+        await state.outbound.put(None)
+
+
+def _new_bet_frame(data: dict) -> str:
+    """Wrap a bet dict in a ``global/new-bet`` frame."""
+    return json.dumps({"topic": "global/new-bet", "data": data})
+
+
+async def test_stream_yields_bet_from_new_bet_frame(
+    server: tuple[str, ServerState],
+) -> None:
+    url, state = server
+    stream = ManifoldStream(url=url, ping_interval=600.0, ping_timeout=30.0)
+    await state.outbound.put(_new_bet_frame(_BET_DATA))
+    async with stream:
+        bet = await asyncio.wait_for(stream.__aiter__().__anext__(), timeout=2.0)
+    assert bet.id == "betXYZ"
+    assert bet.outcome == "YES"
+    assert bet.amount == 25.0
+
+
+async def test_stream_sends_subscription_on_connect(
+    server: tuple[str, ServerState],
+) -> None:
+    url, state = server
+    stream = ManifoldStream(url=url, ping_interval=600.0, ping_timeout=30.0)
+    async with stream:
+        await asyncio.sleep(0.1)
+    assert any("global/new-bet" in msg for msg in state.received)
+
+
+async def test_stream_skips_unknown_topic(
+    server: tuple[str, ServerState],
+) -> None:
+    """Frames for other topics must not be yielded."""
+    url, state = server
+    stream = ManifoldStream(url=url, ping_interval=600.0, ping_timeout=30.0)
+    other_frame = json.dumps({"topic": "global/new-contract", "data": {"id": "c1"}})
+    valid_frame = _new_bet_frame(_BET_DATA)
+    await state.outbound.put(other_frame)
+    await state.outbound.put(valid_frame)
+    async with stream:
+        bet = await asyncio.wait_for(stream.__aiter__().__anext__(), timeout=2.0)
+    # The unknown topic frame was skipped; we got the valid bet.
+    assert bet.id == "betXYZ"
+
+
+async def test_stream_skips_invalid_json(
+    server: tuple[str, ServerState],
+) -> None:
+    """Non-JSON frames must be silently skipped."""
+    url, state = server
+    stream = ManifoldStream(url=url, ping_interval=600.0, ping_timeout=30.0)
+    await state.outbound.put("not-json!!!")
+    await state.outbound.put(_new_bet_frame(_BET_DATA))
+    async with stream:
+        bet = await asyncio.wait_for(stream.__aiter__().__anext__(), timeout=2.0)
+    assert bet.id == "betXYZ"
+
+
+async def test_stream_skips_frame_missing_data(
+    server: tuple[str, ServerState],
+) -> None:
+    """A ``global/new-bet`` frame without ``data`` key must be skipped."""
+    url, state = server
+    stream = ManifoldStream(url=url, ping_interval=600.0, ping_timeout=30.0)
+    bad_frame = json.dumps({"topic": "global/new-bet"})
+    await state.outbound.put(bad_frame)
+    await state.outbound.put(_new_bet_frame(_BET_DATA))
+    async with stream:
+        bet = await asyncio.wait_for(stream.__aiter__().__anext__(), timeout=2.0)
+    assert bet.id == "betXYZ"
+
+
+async def test_stream_multiple_bets(
+    server: tuple[str, ServerState],
+) -> None:
+    url, state = server
+    bet2 = {**_BET_DATA, "id": "betABC", "amount": 50.0}
+    await state.outbound.put(_new_bet_frame(_BET_DATA))
+    await state.outbound.put(_new_bet_frame(bet2))
+    stream = ManifoldStream(url=url, ping_interval=600.0, ping_timeout=30.0)
+    collected: list[str] = []
+    async with stream:
+        it = stream.__aiter__()
+        b1 = await asyncio.wait_for(it.__anext__(), timeout=2.0)
+        b2 = await asyncio.wait_for(it.__anext__(), timeout=2.0)
+        collected.extend([b1.id, b2.id])
+    assert set(collected) == {"betXYZ", "betABC"}
+
+
+async def test_stream_raises_manifold_stream_error_on_server_close(
+    server: tuple[str, ServerState],
+) -> None:
+    """Server closing the connection mid-stream raises ``ManifoldStreamError``."""
+    _url, state = server
+
+    async def closing_handler(ws: ServerConnection) -> None:
+        state.connections += 1
+        await asyncio.sleep(0.05)
+        await ws.close(code=1011, reason="server going away")
+
+    # Override: spin up a second server that immediately closes.
+    async with serve(closing_handler, "127.0.0.1", 0) as s:
+        sock2 = next(iter(s.sockets))
+        port2 = sock2.getsockname()[1]
+        close_url = f"ws://127.0.0.1:{port2}"
+
+        stream = ManifoldStream(url=close_url, ping_interval=600.0, ping_timeout=30.0)
+        with pytest.raises(ManifoldStreamError):
+            async with stream:
+                await asyncio.wait_for(stream.__aiter__().__anext__(), timeout=2.0)
+
+
+async def test_stream_used_outside_context_manager_raises() -> None:
+    stream = ManifoldStream(url="ws://127.0.0.1:9999")
+    with pytest.raises(ManifoldStreamError, match="context manager"):
+        await stream.__aiter__().__anext__()
+
+
+async def test_stream_connection_count(
+    server: tuple[str, ServerState],
+) -> None:
+    url, state = server
+    stream = ManifoldStream(url=url, ping_interval=600.0, ping_timeout=30.0)
+    async with stream:
+        await asyncio.sleep(0.05)
+    assert state.connections == 1


### PR DESCRIPTION
Closes #37 (Stage 1).

## Summary
Adds the `pscanner.manifold` module mirroring `pscanner.poly`'s shape. Read-only, mana-denominated, no auth.

- `pscanner.manifold.ids` — `ManifoldMarketId`, `ManifoldUserId`, `ManifoldSlug` `NewType`s (per RFC §2 / PR G).
- `pscanner.manifold.client.ManifoldClient` — async httpx wrapper enforcing the IP-shared 500-rpm rate limit; tenacity backoff on 429/5xx.
- `pscanner.manifold.ws.ManifoldStream` — websocket consumer with 30-60s ping keepalive, subscribed to `global/new-bet`. Connection drops surface as `ManifoldStreamError` (no auto-reconnect — deliberate divergence from `poly.clob_ws`, documented in the class docstring).
- `pscanner.manifold.models` — pydantic models for markets/bets/users.
- `pscanner.manifold.db` / `.repos` — `manifold_markets`, `manifold_bets`, `manifold_users` tables with standard `insert_or_replace` / `get_by_id` / `iter_chronological` repos.

## What was deferred
- `ManifoldTradeCollector` (RFC PR H)
- CFMM (multi-outcome) market support — Stage 1 is binary YES/NO via the `is_binary` filter
- Write API
- Detector instances per platform
- `platform` column on shared corpus tables (RFC PR A)

## Notes
- `ManifoldBetsRepo` does NOT persist `shares` and `fees` (table schema omits those columns); after a DB round-trip both are `None`. Documented in the repo class docstring.
- `_TokenBucket` is duplicated from `pscanner.poly.http` — flagged for a future refactor PR to extract into a shared util module (poly/http + manifold/client + onchain_rpc all have copies that will diverge).

## Test plan
- [x] 58 new tests in `tests/manifold/`
- [x] Full suite: 949 passed, ruff/format/ty clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)