### PR TITLE
feat(kalshi): Stage 1 — REST client + repos + ids + tables (#36)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,17 @@ evaluators. 734 tests.
 - Default `gamma_rpm = 50`, `data_rpm = 50`. Cold-start bottlenecks: smart-money refresh + events catalog sweep both compete for gamma budget; cluster + smart-money depend on watched-wallet `wallet_first_seen` populated by TradeCollector.
 - `/trades` and `/activity` REST cap at `offset=3000` (server: `"max historical activity offset of 3000 exceeded"`, newest-first sort). No documented `before`/`after`/`cursor` workaround — verified May 2026 against ~15 parameter variants and four candidate alt-endpoints. Beyond 3000 trades requires on-chain via Polygon RPC (`OrderFilled` events from CTF Exchange `0x4bFb41d5B3570DeFd03C39a9A4D8dE6Bd8B8982E`). Phase 1 of #42 landed the decoder + `asset_index` resolver; Phase 2 (RPC client + CLI) is queued.
 
+## Kalshi API quirks (will bite you)
+- **Pricing**: cents expressed as dollar strings on the wire (`"0.0900"` = 9 cents). Convert to probability via `price_dollars` (already a float 0.0-1.0) or use the `.last_price_cents` property (integer 0-100). Contracts settle to $0 or $1.
+- **Identifiers**: ticker strings (`"KXELONMARS-99"`), not hex. `KalshiMarketTicker`, `KalshiEventTicker`, `KalshiSeriesTicker` are `NewType[str]` in `pscanner.kalshi.ids` — distinct from `pscanner.poly.ids` per the multi-platform RFC. Pass `KalshiMarketTicker(...)` at call sites so `ty` catches cross-platform confusion.
+- **Series fan-out**: a series (e.g. `"KXELONMARS"`) groups multiple events; an event groups multiple markets. On simple binary contracts the event ticker and market ticker are equal (e.g. both `"KXELONMARS-99"`).
+- **Settlement**: $0 or $1 per share (0 or 100 cents). No mid-resolution prices.
+- **Trades endpoint**: market trades live at `GET /markets/trades?ticker=TICKER`, NOT at `GET /markets/{ticker}/trades` (that path returns 404). `KalshiClient.get_market_trades` uses the correct URL.
+- **Public REST is unauth**; WS streaming requires a Kalshi account + RSA-signed handshake (Stage 2, not yet implemented).
+- **Base URL**: `https://api.elections.kalshi.com/trade-api/v2` (verified 2026-05-04).
+- **Volume/size fields**: returned as fixed-point strings (`"1.00"`), coerced to `float` by pydantic. The `count_fp` on trades is a contract count, not a dollar amount.
+- **Kalshi schema tables** (`kalshi_markets`, `kalshi_trades`, `kalshi_orderbook_snapshots`) are registered into `store/db.py:_SCHEMA_STATEMENTS` via `KALSHI_SCHEMA_STATEMENTS` from `pscanner.kalshi.db`. They are created by `init_db` alongside the Polymarket daemon tables — `tmp_db` in tests includes them automatically.
+
 ## Test gotchas
 - `pyproject.toml` has `filterwarnings = ["error"]` — every warning fails tests. Clean up resources (httpx/respx fixtures especially).
 - NEVER `monkeypatch.setattr(asyncio, "sleep", AsyncMock())` — deadlocks the suite (sibling detector loops become CPU spinners). Use `FakeClock` from `pscanner.util.clock` instead; inject via `clock=` ctor kwarg, drive with `await fake_clock.advance(seconds)`.

--- a/src/pscanner/kalshi/__init__.py
+++ b/src/pscanner/kalshi/__init__.py
@@ -1,0 +1,8 @@
+"""Kalshi ingest module for pscanner.
+
+Provides REST client, pydantic models, SQLite repos, and typed identifiers
+for the Kalshi prediction-market platform. REST-only (Stage 1); WebSocket
+streaming with RSA-signed auth is deferred to Stage 2.
+
+See: https://api.elections.kalshi.com/trade-api/v2/
+"""

--- a/src/pscanner/kalshi/client.py
+++ b/src/pscanner/kalshi/client.py
@@ -1,0 +1,394 @@
+"""Async REST client for the Kalshi public API.
+
+Wraps ``httpx.AsyncClient`` with a token-bucket rate limiter and ``tenacity``
+retries honouring ``Retry-After`` on 429/5xx, mirroring the shape of
+:class:`pscanner.poly.http.PolyHttpClient`.
+
+Public REST endpoints require no authentication. WebSocket streaming with
+RSA-signed auth is deferred to Stage 2.
+
+Base URL: ``https://api.elections.kalshi.com/trade-api/v2``
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from email.utils import parsedate_to_datetime
+from types import TracebackType
+from typing import Any, Final, Self
+
+import httpx
+import structlog
+from tenacity import (
+    AsyncRetrying,
+    RetryCallState,
+    retry_if_exception,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+from pscanner.kalshi.ids import KalshiMarketTicker
+from pscanner.kalshi.models import (
+    KalshiMarket,
+    KalshiMarketsPage,
+    KalshiOrderbook,
+    KalshiTrade,
+    KalshiTradesPage,
+)
+
+_LOG = structlog.get_logger(__name__)
+
+_BASE_URL: Final[str] = "https://api.elections.kalshi.com/trade-api/v2"
+_USER_AGENT: Final[str] = "pscanner/0.1"
+
+_STATUS_TOO_MANY_REQUESTS: Final[int] = 429
+_RETRYABLE_STATUS: Final[frozenset[int]] = frozenset({_STATUS_TOO_MANY_REQUESTS, 502, 503, 504})
+_RETRYABLE_TRANSPORT_EXC: tuple[type[BaseException], ...] = (
+    httpx.TimeoutException,
+    httpx.NetworkError,
+    httpx.RemoteProtocolError,
+)
+_MAX_ATTEMPTS: Final[int] = 5
+_BACKOFF_MIN_SECONDS: Final[float] = 1.0
+_BACKOFF_MAX_SECONDS: Final[float] = 30.0
+
+_DEFAULT_RPM: Final[int] = 60
+_DEFAULT_TIMEOUT: Final[float] = 30.0
+
+
+class _TokenBucket:
+    """Async token bucket: capacity tokens, refilled at ``rate`` per second."""
+
+    def __init__(self, *, capacity: int, rate_per_second: float) -> None:
+        self._capacity = float(capacity)
+        self._rate = rate_per_second
+        self._tokens = float(capacity)
+        self._last_refill = asyncio.get_running_loop().time()
+        self._lock = asyncio.Lock()
+
+    async def acquire(self) -> None:
+        """Block until one token is available, then consume it."""
+        loop = asyncio.get_running_loop()
+        async with self._lock:
+            while True:
+                now = loop.time()
+                elapsed = now - self._last_refill
+                if elapsed > 0:
+                    self._tokens = min(self._capacity, self._tokens + elapsed * self._rate)
+                    self._last_refill = now
+                if self._tokens >= 1.0:
+                    self._tokens -= 1.0
+                    return
+                deficit = 1.0 - self._tokens
+                wait_seconds = deficit / self._rate
+                await asyncio.sleep(wait_seconds)
+
+
+class _RetryableStatusError(Exception):
+    """Raised internally to trigger tenacity retry on retryable status codes."""
+
+    def __init__(self, response: httpx.Response) -> None:
+        super().__init__(f"retryable status {response.status_code}")
+        self.response = response
+
+
+def _parse_retry_after(value: str) -> float | None:
+    """Parse a ``Retry-After`` header into a non-negative seconds delay.
+
+    Args:
+        value: Raw header value (integer seconds or HTTP-date string).
+
+    Returns:
+        Seconds to wait, or ``None`` if the header is unparseable.
+    """
+    stripped = value.strip()
+    if not stripped:
+        return None
+    try:
+        return max(0.0, float(stripped))
+    except ValueError:
+        pass
+    try:
+        when = parsedate_to_datetime(stripped)
+    except (TypeError, ValueError):
+        return None
+    if when.tzinfo is None:
+        when = when.replace(tzinfo=UTC)
+    return max(0.0, (when - datetime.now(tz=UTC)).total_seconds())
+
+
+def _retry_after_seconds(response: httpx.Response) -> float | None:
+    """Read and parse the ``Retry-After`` header off ``response``."""
+    raw = response.headers.get("Retry-After")
+    return None if raw is None else _parse_retry_after(raw)
+
+
+def _is_retryable(exc: BaseException) -> bool:
+    """Predicate for tenacity: retry on retryable status or transient transport error."""
+    if isinstance(exc, _RetryableStatusError):
+        return True
+    return isinstance(exc, _RETRYABLE_TRANSPORT_EXC)
+
+
+def _before_sleep_log(retry_state: RetryCallState) -> None:
+    """Tenacity hook: log a warning before each retry sleep."""
+    outcome = retry_state.outcome
+    if outcome is None:
+        return
+    exc = outcome.exception()
+    if not isinstance(exc, _RetryableStatusError):
+        return
+    response = exc.response
+    _LOG.warning(
+        "kalshi_http_retry",
+        attempt=retry_state.attempt_number,
+        status_code=response.status_code,
+        url=str(response.request.url) if response.request else None,
+        retry_after=response.headers.get("Retry-After"),
+    )
+
+
+class KalshiClient:
+    """Async client for the Kalshi public REST API.
+
+    The client is a long-lived singleton — open once, share across collectors,
+    close on shutdown. The httpx client and token bucket are created lazily on
+    first use.
+
+    Attributes:
+        rpm: Requests-per-minute ceiling enforced by the token bucket.
+        timeout_seconds: Per-request timeout passed to :mod:`httpx`.
+    """
+
+    def __init__(
+        self,
+        *,
+        rpm: int = _DEFAULT_RPM,
+        timeout_seconds: float = _DEFAULT_TIMEOUT,
+        base_url: str = _BASE_URL,
+    ) -> None:
+        """Store config without opening any sockets.
+
+        Args:
+            rpm: Requests-per-minute budget (default 60).
+            timeout_seconds: Default per-request timeout (default 30 s).
+            base_url: Override the base URL (useful in tests).
+        """
+        if rpm <= 0:
+            raise ValueError(f"rpm must be positive, got {rpm}")
+        if timeout_seconds <= 0:
+            raise ValueError(f"timeout_seconds must be positive, got {timeout_seconds}")
+        self.rpm = rpm
+        self.timeout_seconds = timeout_seconds
+        self._base_url = base_url
+        self._client: httpx.AsyncClient | None = None
+        self._bucket: _TokenBucket | None = None
+        self._init_lock = asyncio.Lock()
+        self._closed = False
+
+    async def _ensure_ready(self) -> tuple[httpx.AsyncClient, _TokenBucket]:
+        """Lazily create the shared httpx client and token bucket."""
+        if self._closed:
+            raise RuntimeError("KalshiClient is closed")
+        if self._client is not None and self._bucket is not None:
+            return self._client, self._bucket
+        async with self._init_lock:
+            if self._client is None:
+                self._client = httpx.AsyncClient(
+                    base_url=self._base_url,
+                    timeout=httpx.Timeout(self.timeout_seconds),
+                    headers={"User-Agent": _USER_AGENT},
+                )
+            if self._bucket is None:
+                self._bucket = _TokenBucket(
+                    capacity=self.rpm,
+                    rate_per_second=self.rpm / 60.0,
+                )
+            return self._client, self._bucket
+
+    async def _get(
+        self,
+        path: str,
+        *,
+        params: Mapping[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """GET ``base_url + path`` with rate limiting and retries.
+
+        Args:
+            path: Path-only URL fragment (must start with ``/``).
+            params: Optional query-string parameters.
+
+        Returns:
+            Parsed JSON object (dict).
+
+        Raises:
+            httpx.HTTPStatusError: On non-retryable 4xx, or after retries on 429/5xx.
+            TypeError: If the response body is not a JSON object.
+        """
+        client, bucket = await self._ensure_ready()
+        retrying = AsyncRetrying(
+            retry=retry_if_exception(_is_retryable),
+            stop=stop_after_attempt(_MAX_ATTEMPTS),
+            wait=wait_exponential(
+                multiplier=1.0,
+                min=_BACKOFF_MIN_SECONDS,
+                max=_BACKOFF_MAX_SECONDS,
+            ),
+            before_sleep=_before_sleep_log,
+            reraise=True,
+        )
+        response: httpx.Response | None = None
+        try:
+            async for attempt in retrying:
+                with attempt:
+                    response = await self._send_once(client, bucket, path, params)
+        except _RetryableStatusError as exc:
+            exc.response.raise_for_status()
+            raise  # pragma: no cover - raise_for_status always raises
+        if response is None:  # pragma: no cover - tenacity guarantees one attempt
+            raise RuntimeError("retry loop produced no response")
+        payload = response.json()
+        if not isinstance(payload, dict):
+            msg = f"expected JSON object from {path}, got {type(payload).__name__}"
+            raise TypeError(msg)
+        return payload  # type: ignore[return-value]
+
+    async def _send_once(
+        self,
+        client: httpx.AsyncClient,
+        bucket: _TokenBucket,
+        path: str,
+        params: Mapping[str, Any] | None,
+    ) -> httpx.Response:
+        """Single request attempt with token-bucket gating and Retry-After support."""
+        await bucket.acquire()
+        response = await client.get(path, params=dict(params) if params else None)
+        if response.status_code in _RETRYABLE_STATUS:
+            if response.status_code == _STATUS_TOO_MANY_REQUESTS:
+                wait = _retry_after_seconds(response)
+                if wait is not None and wait > 0:
+                    await asyncio.sleep(wait)
+            raise _RetryableStatusError(response)
+        response.raise_for_status()
+        return response
+
+    async def get_markets(
+        self,
+        *,
+        status: str | None = None,
+        limit: int = 100,
+        cursor: str | None = None,
+    ) -> KalshiMarketsPage:
+        """Fetch a page of markets from ``GET /markets``.
+
+        Args:
+            status: Filter by market status (e.g. ``"active"``, ``"closed"``).
+            limit: Maximum markets to return (1-200, default 100).
+            cursor: Pagination cursor from a previous response.
+
+        Returns:
+            A page of markets and the next cursor (empty string when exhausted).
+        """
+        params: dict[str, Any] = {"limit": limit}
+        if status is not None:
+            params["status"] = status
+        if cursor:
+            params["cursor"] = cursor
+        payload = await self._get("/markets", params=params)
+        return KalshiMarketsPage.model_validate(payload)
+
+    async def get_market(self, ticker: KalshiMarketTicker) -> KalshiMarket:
+        """Fetch a single market by ticker from ``GET /markets/{ticker}``.
+
+        Args:
+            ticker: Kalshi market ticker (e.g. ``"KXELONMARS-99"``).
+
+        Returns:
+            The market detail.
+
+        Raises:
+            httpx.HTTPStatusError: On 404 or other non-retryable errors.
+        """
+        payload = await self._get(f"/markets/{ticker}")
+        market_data = payload.get("market", payload)
+        return KalshiMarket.model_validate(market_data)
+
+    async def get_orderbook(self, ticker: KalshiMarketTicker) -> KalshiOrderbook:
+        """Fetch the current orderbook from ``GET /markets/{ticker}/orderbook``.
+
+        Args:
+            ticker: Kalshi market ticker.
+
+        Returns:
+            The orderbook snapshot with YES and NO bid levels.
+
+        Raises:
+            httpx.HTTPStatusError: On 404 or other non-retryable errors.
+        """
+        payload = await self._get(f"/markets/{ticker}/orderbook")
+        return KalshiOrderbook.model_validate(payload)
+
+    async def get_market_trades(
+        self,
+        ticker: KalshiMarketTicker,
+        *,
+        limit: int = 100,
+        cursor: str | None = None,
+    ) -> KalshiTradesPage:
+        """Fetch a page of trades from ``GET /markets/trades``.
+
+        Args:
+            ticker: Kalshi market ticker to filter by.
+            limit: Maximum trades to return (default 100).
+            cursor: Pagination cursor from a previous response.
+
+        Returns:
+            A page of trades and the next cursor.
+
+        Note:
+            The live Kalshi API returns trades via ``/markets/trades?ticker=TICKER``
+            (global trades endpoint with a ticker filter), not via
+            ``/markets/{ticker}/trades`` which returns 404.
+        """
+        params: dict[str, Any] = {"ticker": ticker, "limit": limit}
+        if cursor:
+            params["cursor"] = cursor
+        payload = await self._get("/markets/trades", params=params)
+        return KalshiTradesPage.model_validate(payload)
+
+    async def get_single_trade(self, trade_id: str) -> KalshiTrade:
+        """Fetch a single trade by trade ID from ``GET /trades/{trade_id}``.
+
+        Args:
+            trade_id: UUID of the trade.
+
+        Returns:
+            The trade detail.
+        """
+        payload = await self._get(f"/trades/{trade_id}")
+        trade_data = payload.get("trade", payload)
+        return KalshiTrade.model_validate(trade_data)
+
+    async def aclose(self) -> None:
+        """Close the underlying :class:`httpx.AsyncClient` and release sockets."""
+        self._closed = True
+        client = self._client
+        self._client = None
+        if client is not None:
+            await client.aclose()
+
+    async def __aenter__(self) -> Self:
+        """Async context-manager entry — returns ``self`` for the with-block."""
+        await self._ensure_ready()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        """Async context-manager exit — calls :meth:`aclose`."""
+        await self.aclose()

--- a/src/pscanner/kalshi/db.py
+++ b/src/pscanner/kalshi/db.py
@@ -1,0 +1,66 @@
+"""SQLite table definitions for Kalshi data.
+
+These statements are registered into the daemon DB via ``init_db`` in
+``pscanner.store.db``. All CREATE statements use ``IF NOT EXISTS`` so
+calling them on an existing database is safe.
+
+Tables:
+    kalshi_markets: Latest snapshot of each Kalshi market by ticker.
+    kalshi_trades: Executed trades fetched from the Kalshi REST API.
+    kalshi_orderbook_snapshots: Point-in-time orderbook snapshots.
+"""
+
+from __future__ import annotations
+
+KALSHI_SCHEMA_STATEMENTS: tuple[str, ...] = (
+    """
+    CREATE TABLE IF NOT EXISTS kalshi_markets (
+      ticker                    TEXT PRIMARY KEY,
+      event_ticker              TEXT NOT NULL,
+      title                     TEXT NOT NULL,
+      status                    TEXT NOT NULL,
+      market_type               TEXT NOT NULL DEFAULT '',
+      open_time                 TEXT NOT NULL DEFAULT '',
+      close_time                TEXT NOT NULL DEFAULT '',
+      expected_expiration_time  TEXT NOT NULL DEFAULT '',
+      yes_sub_title             TEXT NOT NULL DEFAULT '',
+      no_sub_title              TEXT NOT NULL DEFAULT '',
+      last_price_cents          INTEGER NOT NULL DEFAULT 0,
+      yes_bid_cents             INTEGER NOT NULL DEFAULT 0,
+      yes_ask_cents             INTEGER NOT NULL DEFAULT 0,
+      no_bid_cents              INTEGER NOT NULL DEFAULT 0,
+      no_ask_cents              INTEGER NOT NULL DEFAULT 0,
+      volume_fp                 REAL NOT NULL DEFAULT 0.0,
+      volume_24h_fp             REAL NOT NULL DEFAULT 0.0,
+      open_interest_fp          REAL NOT NULL DEFAULT 0.0,
+      cached_at                 INTEGER NOT NULL
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_kalshi_markets_event ON kalshi_markets(event_ticker)",
+    "CREATE INDEX IF NOT EXISTS idx_kalshi_markets_status ON kalshi_markets(status)",
+    """
+    CREATE TABLE IF NOT EXISTS kalshi_trades (
+      trade_id      TEXT PRIMARY KEY,
+      ticker        TEXT NOT NULL,
+      taker_side    TEXT NOT NULL,
+      yes_price_cents INTEGER NOT NULL,
+      no_price_cents  INTEGER NOT NULL,
+      count_fp      REAL NOT NULL,
+      created_time  TEXT NOT NULL,
+      recorded_at   INTEGER NOT NULL
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_kalshi_trades_ticker ON kalshi_trades(ticker)",
+    "CREATE INDEX IF NOT EXISTS idx_kalshi_trades_created ON kalshi_trades(created_time DESC)",
+    """
+    CREATE TABLE IF NOT EXISTS kalshi_orderbook_snapshots (
+      id            INTEGER PRIMARY KEY AUTOINCREMENT,
+      ticker        TEXT NOT NULL,
+      ts            INTEGER NOT NULL,
+      yes_bids_json TEXT NOT NULL,
+      no_bids_json  TEXT NOT NULL
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_kalshi_ob_ticker_ts "
+    "ON kalshi_orderbook_snapshots(ticker, ts DESC)",
+)

--- a/src/pscanner/kalshi/ids.py
+++ b/src/pscanner/kalshi/ids.py
@@ -1,0 +1,34 @@
+"""Typed identifier wrappers for Kalshi entities.
+
+Kalshi and Polymarket both use string identifiers, but they are structurally
+and semantically incompatible:
+
+- Kalshi tickers are human-readable slugs (e.g. ``"KXELONMARS-99"``).
+- Polymarket ``ConditionId`` values are 0x-prefixed 66-character hex strings.
+- Polymarket ``AssetId`` values are 78-digit decimal strings.
+
+Mixing these across platforms produces silent bugs — a Kalshi ticker passed
+to a Polymarket DB query would silently produce empty results or corrupt rows.
+These ``NewType`` wrappers give ``ty`` enough structure to catch such bugs at
+type-check time without any runtime cost.
+
+Per the multi-platform RFC (Decision 2), each platform keeps its own ``ids``
+module with no shared supertype. Cross-platform boundaries are mediated by
+normalized dataclasses whose fields are plain ``str``.
+
+Conventions:
+- ``KalshiMarketTicker``: per-market ticker (e.g. ``"KXELONMARS-99"``).
+- ``KalshiEventTicker``: event-level ticker grouping related markets
+  (e.g. ``"KXELONMARS-99"`` — on simple events the event ticker equals the
+  market ticker; on multi-outcome events it is shared across legs).
+- ``KalshiSeriesTicker``: series ticker grouping related events
+  (e.g. ``"KXELONMARS"``).
+"""
+
+from __future__ import annotations
+
+from typing import NewType
+
+KalshiMarketTicker = NewType("KalshiMarketTicker", str)
+KalshiEventTicker = NewType("KalshiEventTicker", str)
+KalshiSeriesTicker = NewType("KalshiSeriesTicker", str)

--- a/src/pscanner/kalshi/models.py
+++ b/src/pscanner/kalshi/models.py
@@ -1,0 +1,178 @@
+"""Pydantic models for Kalshi REST API payloads.
+
+Field names follow Kalshi's JSON casing where reasonable. Prices are expressed
+as ``str`` dollar amounts by the API (e.g. ``"0.0900"`` = 9 cents); the models
+expose them as ``float`` in dollar terms and provide a ``_cents`` computed
+property for the integer-cent representation used in DB storage.
+
+Verified against live ``https://api.elections.kalshi.com/trade-api/v2/``
+responses on 2026-05-04.
+
+Note on pricing units:
+    Kalshi prices are in dollars on the wire (``"0.09"`` = 9 cents = $0.09 per
+    share). Contracts settle to $0 or $1. The ``yes_price_cents`` and
+    ``no_price_cents`` helpers return the rounded integer-cent value (1-99).
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from pydantic import BaseModel, ConfigDict, Field
+
+_BASE_CONFIG: ConfigDict = ConfigDict(populate_by_name=True, extra="ignore")
+
+
+def _dollars_to_cents(dollars: float) -> int:
+    """Convert a dollar price (0.0-1.0) to integer cents (0-100)."""
+    return round(dollars * 100)
+
+
+class KalshiMarket(BaseModel):
+    """A single Kalshi binary market.
+
+    Maps to one row in the ``kalshi_markets`` table.
+    """
+
+    model_config = _BASE_CONFIG
+
+    ticker: str
+    event_ticker: str
+    title: str
+    status: str
+    market_type: str = ""
+    open_time: str = ""
+    close_time: str = ""
+    expected_expiration_time: str = ""
+    yes_sub_title: str = ""
+    no_sub_title: str = ""
+
+    # Prices are returned as dollar strings like "0.0900"; coerce to float.
+    last_price_dollars: Annotated[float, Field(default=0.0)]
+    yes_bid_dollars: Annotated[float, Field(default=0.0)]
+    yes_ask_dollars: Annotated[float, Field(default=0.0)]
+    no_bid_dollars: Annotated[float, Field(default=0.0)]
+    no_ask_dollars: Annotated[float, Field(default=0.0)]
+
+    # Volume and open-interest come back as fixed-point strings ("0.00").
+    volume_fp: Annotated[float, Field(default=0.0)]
+    volume_24h_fp: Annotated[float, Field(default=0.0)]
+    open_interest_fp: Annotated[float, Field(default=0.0)]
+
+    @property
+    def last_price_cents(self) -> int:
+        """Integer-cent representation of ``last_price_dollars`` (0-100)."""
+        return _dollars_to_cents(self.last_price_dollars)
+
+    @property
+    def yes_bid_cents(self) -> int:
+        """Integer cents for the YES bid price."""
+        return _dollars_to_cents(self.yes_bid_dollars)
+
+    @property
+    def yes_ask_cents(self) -> int:
+        """Integer cents for the YES ask price."""
+        return _dollars_to_cents(self.yes_ask_dollars)
+
+
+class _OrderbookInner(BaseModel):
+    """Inner object under the ``orderbook_fp`` key in orderbook responses."""
+
+    model_config = _BASE_CONFIG
+
+    yes_dollars: list[list[str]] = Field(default_factory=list)
+    no_dollars: list[list[str]] = Field(default_factory=list)
+
+
+class KalshiOrderbook(BaseModel):
+    """Kalshi orderbook snapshot for a single market.
+
+    Each level in ``yes_dollars`` / ``no_dollars`` is a ``[price, size]``
+    pair of dollar-string values. The ``yes_bids`` property returns the list
+    directly; callers that need cents should convert with ``round(float(p)*100)``.
+    """
+
+    model_config = _BASE_CONFIG
+
+    orderbook_fp: _OrderbookInner
+
+    @property
+    def yes_bids(self) -> list[list[str]]:
+        """YES-side bid levels as ``[price_dollars, size]`` string pairs."""
+        return self.orderbook_fp.yes_dollars
+
+    @property
+    def no_bids(self) -> list[list[str]]:
+        """NO-side bid levels as ``[price_dollars, size]`` string pairs."""
+        return self.orderbook_fp.no_dollars
+
+
+class KalshiTrade(BaseModel):
+    """A single executed trade returned by ``/markets/trades``.
+
+    ``taker_side`` is ``"yes"`` or ``"no"``.
+    ``count_fp`` is the contract count as a fixed-point string (``"1.00"``).
+    Prices are dollar strings (``"0.0900"``).
+    """
+
+    model_config = _BASE_CONFIG
+
+    trade_id: str
+    ticker: str
+    taker_side: str
+    yes_price_dollars: Annotated[float, Field(default=0.0)]
+    no_price_dollars: Annotated[float, Field(default=0.0)]
+    count_fp: Annotated[float, Field(default=0.0)]
+    created_time: str = ""
+
+    @property
+    def yes_price_cents(self) -> int:
+        """Integer-cent representation of the YES price."""
+        return _dollars_to_cents(self.yes_price_dollars)
+
+    @property
+    def no_price_cents(self) -> int:
+        """Integer-cent representation of the NO price."""
+        return _dollars_to_cents(self.no_price_dollars)
+
+
+class KalshiMarketsPage(BaseModel):
+    """Paginated response from ``GET /markets``."""
+
+    model_config = _BASE_CONFIG
+
+    markets: list[KalshiMarket] = Field(default_factory=list)
+    cursor: str = ""
+
+
+class KalshiTradesPage(BaseModel):
+    """Paginated response from ``GET /markets/trades``."""
+
+    model_config = _BASE_CONFIG
+
+    trades: list[KalshiTrade] = Field(default_factory=list)
+    cursor: str = ""
+
+
+class KalshiEvent(BaseModel):
+    """A Kalshi event grouping one or more markets."""
+
+    model_config = _BASE_CONFIG
+
+    event_ticker: str
+    series_ticker: str = ""
+    title: str = ""
+    sub_title: str = ""
+    category: str = ""
+    mutually_exclusive: bool = False
+
+
+class KalshiSeries(BaseModel):
+    """A Kalshi series grouping related events."""
+
+    model_config = _BASE_CONFIG
+
+    ticker: str
+    title: str = ""
+    category: str = ""
+    frequency: str = ""

--- a/src/pscanner/kalshi/models.py
+++ b/src/pscanner/kalshi/models.py
@@ -74,6 +74,16 @@ class KalshiMarket(BaseModel):
         """Integer cents for the YES ask price."""
         return _dollars_to_cents(self.yes_ask_dollars)
 
+    @property
+    def no_bid_cents(self) -> int:
+        """Integer cents for the NO bid price."""
+        return _dollars_to_cents(self.no_bid_dollars)
+
+    @property
+    def no_ask_cents(self) -> int:
+        """Integer cents for the NO ask price."""
+        return _dollars_to_cents(self.no_ask_dollars)
+
 
 class _OrderbookInner(BaseModel):
     """Inner object under the ``orderbook_fp`` key in orderbook responses."""

--- a/src/pscanner/kalshi/repos.py
+++ b/src/pscanner/kalshi/repos.py
@@ -1,0 +1,355 @@
+"""SQLite repository classes for Kalshi tables.
+
+Each repo accepts an already-initialised ``sqlite3.Connection`` (obtained via
+``pscanner.store.db.init_db``, which also runs the Kalshi schema statements)
+and uses parameterised SQL exclusively. Writes commit on the bound connection.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+from dataclasses import dataclass
+
+from pscanner.kalshi.models import KalshiMarket, KalshiOrderbook, KalshiTrade
+
+
+def _now_seconds() -> int:
+    """Return the current Unix timestamp in whole seconds."""
+    return int(time.time())
+
+
+@dataclass(frozen=True, slots=True)
+class KalshiMarketRow:
+    """A cached Kalshi market as stored in ``kalshi_markets``."""
+
+    ticker: str
+    event_ticker: str
+    title: str
+    status: str
+    market_type: str
+    open_time: str
+    close_time: str
+    expected_expiration_time: str
+    yes_sub_title: str
+    no_sub_title: str
+    last_price_cents: int
+    yes_bid_cents: int
+    yes_ask_cents: int
+    no_bid_cents: int
+    no_ask_cents: int
+    volume_fp: float
+    volume_24h_fp: float
+    open_interest_fp: float
+    cached_at: int
+
+
+@dataclass(frozen=True, slots=True)
+class KalshiTradeRow:
+    """A single Kalshi trade as stored in ``kalshi_trades``."""
+
+    trade_id: str
+    ticker: str
+    taker_side: str
+    yes_price_cents: int
+    no_price_cents: int
+    count_fp: float
+    created_time: str
+    recorded_at: int
+
+
+@dataclass(frozen=True, slots=True)
+class KalshiOrderbookSnapshotRow:
+    """A kalshi orderbook snapshot as stored in ``kalshi_orderbook_snapshots``."""
+
+    id: int | None
+    ticker: str
+    ts: int
+    yes_bids_json: str
+    no_bids_json: str
+
+
+class KalshiMarketsRepo:
+    """CRUD for the ``kalshi_markets`` table."""
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        """Bind the repo to an already-initialised connection."""
+        self._conn = conn
+
+    def upsert(self, market: KalshiMarket) -> None:
+        """Insert or replace a market, refreshing ``cached_at``.
+
+        Args:
+            market: Validated :class:`~pscanner.kalshi.models.KalshiMarket`.
+        """
+        self._conn.execute(
+            """
+            INSERT OR REPLACE INTO kalshi_markets (
+              ticker, event_ticker, title, status, market_type,
+              open_time, close_time, expected_expiration_time,
+              yes_sub_title, no_sub_title,
+              last_price_cents, yes_bid_cents, yes_ask_cents,
+              no_bid_cents, no_ask_cents,
+              volume_fp, volume_24h_fp, open_interest_fp, cached_at
+            ) VALUES (
+              ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+              ?, ?, ?, ?, ?, ?, ?, ?, ?
+            )
+            """,
+            (
+                market.ticker,
+                market.event_ticker,
+                market.title,
+                market.status,
+                market.market_type,
+                market.open_time,
+                market.close_time,
+                market.expected_expiration_time,
+                market.yes_sub_title,
+                market.no_sub_title,
+                market.last_price_cents,
+                market.yes_bid_cents,
+                market.yes_ask_cents,
+                _dollars_to_cents(market.no_bid_dollars),
+                _dollars_to_cents(market.no_ask_dollars),
+                market.volume_fp,
+                market.volume_24h_fp,
+                market.open_interest_fp,
+                _now_seconds(),
+            ),
+        )
+        self._conn.commit()
+
+    def get(self, ticker: str) -> KalshiMarketRow | None:
+        """Fetch a single market by ticker, or ``None`` if not cached.
+
+        Args:
+            ticker: Kalshi market ticker.
+
+        Returns:
+            The cached market row, or ``None``.
+        """
+        row = self._conn.execute(
+            "SELECT * FROM kalshi_markets WHERE ticker = ?", (ticker,)
+        ).fetchone()
+        return _market_row(row) if row is not None else None
+
+    def list_by_status(self, status: str) -> list[KalshiMarketRow]:
+        """Return all cached markets with the given status.
+
+        Args:
+            status: Market status string (e.g. ``"active"``, ``"closed"``).
+
+        Returns:
+            List of matching market rows.
+        """
+        rows = self._conn.execute(
+            "SELECT * FROM kalshi_markets WHERE status = ? ORDER BY ticker", (status,)
+        ).fetchall()
+        return [_market_row(r) for r in rows]
+
+    def list_by_event(self, event_ticker: str) -> list[KalshiMarketRow]:
+        """Return all cached markets for the given event ticker.
+
+        Args:
+            event_ticker: Kalshi event ticker.
+
+        Returns:
+            List of matching market rows.
+        """
+        rows = self._conn.execute(
+            "SELECT * FROM kalshi_markets WHERE event_ticker = ? ORDER BY ticker",
+            (event_ticker,),
+        ).fetchall()
+        return [_market_row(r) for r in rows]
+
+
+class KalshiTradesRepo:
+    """CRUD for the ``kalshi_trades`` table."""
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        """Bind the repo to an already-initialised connection."""
+        self._conn = conn
+
+    def insert_batch(self, trades: list[KalshiTrade]) -> int:
+        """Insert trades, skipping duplicates by ``trade_id``.
+
+        Args:
+            trades: List of validated :class:`~pscanner.kalshi.models.KalshiTrade`.
+
+        Returns:
+            Number of rows actually inserted (existing rows are ignored).
+        """
+        now = _now_seconds()
+        inserted = 0
+        for trade in trades:
+            cursor = self._conn.execute(
+                """
+                INSERT OR IGNORE INTO kalshi_trades (
+                  trade_id, ticker, taker_side, yes_price_cents, no_price_cents,
+                  count_fp, created_time, recorded_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    trade.trade_id,
+                    trade.ticker,
+                    trade.taker_side,
+                    trade.yes_price_cents,
+                    trade.no_price_cents,
+                    trade.count_fp,
+                    trade.created_time,
+                    now,
+                ),
+            )
+            inserted += cursor.rowcount
+        self._conn.commit()
+        return inserted
+
+    def get(self, trade_id: str) -> KalshiTradeRow | None:
+        """Fetch a single trade by trade ID, or ``None`` if not found.
+
+        Args:
+            trade_id: UUID string identifying the trade.
+
+        Returns:
+            The trade row, or ``None``.
+        """
+        row = self._conn.execute(
+            "SELECT * FROM kalshi_trades WHERE trade_id = ?", (trade_id,)
+        ).fetchone()
+        return _trade_row(row) if row is not None else None
+
+    def list_by_ticker(self, ticker: str, *, limit: int = 500) -> list[KalshiTradeRow]:
+        """Return the most recent trades for a given market ticker.
+
+        Args:
+            ticker: Kalshi market ticker.
+            limit: Maximum number of rows to return (default 500).
+
+        Returns:
+            List of trade rows ordered newest-first.
+        """
+        rows = self._conn.execute(
+            "SELECT * FROM kalshi_trades WHERE ticker = ? ORDER BY created_time DESC LIMIT ?",
+            (ticker, limit),
+        ).fetchall()
+        return [_trade_row(r) for r in rows]
+
+
+class KalshiOrderbookSnapshotsRepo:
+    """CRUD for the ``kalshi_orderbook_snapshots`` table."""
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        """Bind the repo to an already-initialised connection."""
+        self._conn = conn
+
+    def insert(self, ticker: str, orderbook: KalshiOrderbook) -> None:
+        """Insert an orderbook snapshot for the given ticker.
+
+        Args:
+            ticker: Kalshi market ticker.
+            orderbook: Validated :class:`~pscanner.kalshi.models.KalshiOrderbook`.
+        """
+        self._conn.execute(
+            """
+            INSERT INTO kalshi_orderbook_snapshots (ticker, ts, yes_bids_json, no_bids_json)
+            VALUES (?, ?, ?, ?)
+            """,
+            (
+                ticker,
+                _now_seconds(),
+                json.dumps(orderbook.yes_bids),
+                json.dumps(orderbook.no_bids),
+            ),
+        )
+        self._conn.commit()
+
+    def latest(self, ticker: str) -> KalshiOrderbookSnapshotRow | None:
+        """Return the most recent orderbook snapshot for a ticker, or ``None``.
+
+        Args:
+            ticker: Kalshi market ticker.
+
+        Returns:
+            The most recent snapshot row, or ``None`` if none exist.
+        """
+        row = self._conn.execute(
+            "SELECT * FROM kalshi_orderbook_snapshots WHERE ticker = ? "
+            "ORDER BY ts DESC, id DESC LIMIT 1",
+            (ticker,),
+        ).fetchone()
+        return _snapshot_row(row) if row is not None else None
+
+    def list_by_ticker(self, ticker: str, *, limit: int = 10) -> list[KalshiOrderbookSnapshotRow]:
+        """Return recent orderbook snapshots for a ticker, newest-first.
+
+        Args:
+            ticker: Kalshi market ticker.
+            limit: Maximum number of snapshots (default 10).
+
+        Returns:
+            List of snapshot rows, newest first.
+        """
+        rows = self._conn.execute(
+            "SELECT * FROM kalshi_orderbook_snapshots WHERE ticker = ? "
+            "ORDER BY ts DESC, id DESC LIMIT ?",
+            (ticker, limit),
+        ).fetchall()
+        return [_snapshot_row(r) for r in rows]
+
+
+# ---------------------------------------------------------------------------
+# Internal row-mapper helpers
+# ---------------------------------------------------------------------------
+
+
+def _dollars_to_cents(dollars: float) -> int:
+    return round(dollars * 100)
+
+
+def _market_row(row: sqlite3.Row) -> KalshiMarketRow:
+    return KalshiMarketRow(
+        ticker=row["ticker"],
+        event_ticker=row["event_ticker"],
+        title=row["title"],
+        status=row["status"],
+        market_type=row["market_type"],
+        open_time=row["open_time"],
+        close_time=row["close_time"],
+        expected_expiration_time=row["expected_expiration_time"],
+        yes_sub_title=row["yes_sub_title"],
+        no_sub_title=row["no_sub_title"],
+        last_price_cents=row["last_price_cents"],
+        yes_bid_cents=row["yes_bid_cents"],
+        yes_ask_cents=row["yes_ask_cents"],
+        no_bid_cents=row["no_bid_cents"],
+        no_ask_cents=row["no_ask_cents"],
+        volume_fp=row["volume_fp"],
+        volume_24h_fp=row["volume_24h_fp"],
+        open_interest_fp=row["open_interest_fp"],
+        cached_at=row["cached_at"],
+    )
+
+
+def _trade_row(row: sqlite3.Row) -> KalshiTradeRow:
+    return KalshiTradeRow(
+        trade_id=row["trade_id"],
+        ticker=row["ticker"],
+        taker_side=row["taker_side"],
+        yes_price_cents=row["yes_price_cents"],
+        no_price_cents=row["no_price_cents"],
+        count_fp=row["count_fp"],
+        created_time=row["created_time"],
+        recorded_at=row["recorded_at"],
+    )
+
+
+def _snapshot_row(row: sqlite3.Row) -> KalshiOrderbookSnapshotRow:
+    return KalshiOrderbookSnapshotRow(
+        id=row["id"],
+        ticker=row["ticker"],
+        ts=row["ts"],
+        yes_bids_json=row["yes_bids_json"],
+        no_bids_json=row["no_bids_json"],
+    )

--- a/src/pscanner/kalshi/repos.py
+++ b/src/pscanner/kalshi/repos.py
@@ -111,8 +111,8 @@ class KalshiMarketsRepo:
                 market.last_price_cents,
                 market.yes_bid_cents,
                 market.yes_ask_cents,
-                _dollars_to_cents(market.no_bid_dollars),
-                _dollars_to_cents(market.no_ask_dollars),
+                market.no_bid_cents,
+                market.no_ask_cents,
                 market.volume_fp,
                 market.volume_24h_fp,
                 market.open_interest_fp,
@@ -302,10 +302,6 @@ class KalshiOrderbookSnapshotsRepo:
 # ---------------------------------------------------------------------------
 # Internal row-mapper helpers
 # ---------------------------------------------------------------------------
-
-
-def _dollars_to_cents(dollars: float) -> int:
-    return round(dollars * 100)
 
 
 def _market_row(row: sqlite3.Row) -> KalshiMarketRow:

--- a/src/pscanner/store/db.py
+++ b/src/pscanner/store/db.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import sqlite3
 from pathlib import Path
 
+from pscanner.kalshi.db import KALSHI_SCHEMA_STATEMENTS
+
 _SCHEMA_STATEMENTS: tuple[str, ...] = (
     """
     CREATE TABLE IF NOT EXISTS tracked_wallets (
@@ -260,6 +262,10 @@ _SCHEMA_STATEMENTS: tuple[str, ...] = (
     "CREATE INDEX IF NOT EXISTS idx_paper_trades_open "
     "ON paper_trades(condition_id, asset_id) WHERE trade_kind = 'entry'",
     "CREATE INDEX IF NOT EXISTS idx_paper_trades_parent ON paper_trades(parent_trade_id)",
+    # Kalshi tables — registered here so init_db creates them alongside the
+    # Polymarket daemon tables. The CREATE statements are defined in
+    # pscanner.kalshi.db to keep platform code co-located.
+    *KALSHI_SCHEMA_STATEMENTS,
 )
 
 _MIGRATIONS: tuple[str, ...] = (

--- a/tests/kalshi/test_client.py
+++ b/tests/kalshi/test_client.py
@@ -216,6 +216,47 @@ async def test_get_market_trades_with_cursor(client: KalshiClient) -> None:
     assert route.called
 
 
+def _trade(trade_id: str) -> dict[str, str]:
+    """Minimal trade dict with the required fields per KalshiTrade."""
+    return {
+        "trade_id": trade_id,
+        "ticker": "KXFOO-99",
+        "taker_side": "yes",
+        "yes_price_dollars": "0.0900",
+        "no_price_dollars": "0.9100",
+        "count_fp": "1.00",
+        "created_time": "2026-05-04T12:00:00Z",
+    }
+
+
+@respx.mock
+async def test_get_market_trades_paginates_across_two_pages(
+    client: KalshiClient,
+) -> None:
+    """Cursor in the first response feeds into the second call."""
+    page_1 = {"trades": [_trade("t1"), _trade("t2")], "cursor": "page2"}
+    page_2 = {"trades": [_trade("t3"), _trade("t4")], "cursor": ""}
+
+    def _route(request: httpx.Request) -> httpx.Response:
+        if "cursor=page2" in str(request.url):
+            return httpx.Response(200, json=page_2)
+        return httpx.Response(200, json=page_1)
+
+    respx.get(url__regex=r".*/markets/trades.*").mock(side_effect=_route)
+    try:
+        first = await client.get_market_trades(KalshiMarketTicker("KXFOO-99"), limit=2)
+        second = await client.get_market_trades(
+            KalshiMarketTicker("KXFOO-99"), limit=2, cursor=first.cursor
+        )
+    finally:
+        await client.aclose()
+
+    assert len(first.trades) == 2
+    assert first.cursor == "page2"
+    assert len(second.trades) == 2
+    assert second.cursor in ("", None)
+
+
 # ---------------------------------------------------------------------------
 # Retry behaviour
 # ---------------------------------------------------------------------------

--- a/tests/kalshi/test_client.py
+++ b/tests/kalshi/test_client.py
@@ -1,0 +1,321 @@
+"""Tests for :mod:`pscanner.kalshi.client.KalshiClient`.
+
+All HTTP calls are intercepted by respx. Tests verify pagination, 429/retry,
+and error-propagation paths.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from pscanner.kalshi.client import KalshiClient
+from pscanner.kalshi.ids import KalshiMarketTicker
+from pscanner.kalshi.models import KalshiMarketsPage, KalshiOrderbook, KalshiTradesPage
+
+_BASE = "https://test.kalshi.invalid/v2"
+
+_MARKET_PAYLOAD = {
+    "ticker": "KXELONMARS-99",
+    "event_ticker": "KXELONMARS-99",
+    "title": "Will Elon Musk visit Mars?",
+    "status": "active",
+    "last_price_dollars": "0.0900",
+    "yes_bid_dollars": "0.0800",
+    "yes_ask_dollars": "0.1000",
+    "no_bid_dollars": "0.9000",
+    "no_ask_dollars": "0.9200",
+    "volume_fp": "100.00",
+    "volume_24h_fp": "10.00",
+    "open_interest_fp": "50.00",
+}
+
+_TRADE_PAYLOAD = {
+    "trade_id": "abc-123",
+    "ticker": "KXELONMARS-99",
+    "taker_side": "yes",
+    "yes_price_dollars": "0.0900",
+    "no_price_dollars": "0.9100",
+    "count_fp": "1.00",
+    "created_time": "2026-05-04T12:00:00Z",
+}
+
+
+@pytest.fixture
+def client() -> KalshiClient:
+    """A fresh client per test with a mock base URL (high rpm to avoid rate delays)."""
+    return KalshiClient(rpm=600, timeout_seconds=5.0, base_url=_BASE)
+
+
+# ---------------------------------------------------------------------------
+# get_markets
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+async def test_get_markets_returns_page(client: KalshiClient) -> None:
+    respx.get(f"{_BASE}/markets").mock(
+        return_value=httpx.Response(200, json={"markets": [_MARKET_PAYLOAD], "cursor": "next_abc"})
+    )
+    try:
+        page = await client.get_markets()
+    finally:
+        await client.aclose()
+    assert isinstance(page, KalshiMarketsPage)
+    assert len(page.markets) == 1
+    assert page.markets[0].ticker == "KXELONMARS-99"
+    assert page.cursor == "next_abc"
+
+
+@respx.mock
+async def test_get_markets_with_status_filter(client: KalshiClient) -> None:
+    route = respx.get(f"{_BASE}/markets", params={"status": "active", "limit": 100}).mock(
+        return_value=httpx.Response(200, json={"markets": [], "cursor": ""})
+    )
+    try:
+        await client.get_markets(status="active")
+    finally:
+        await client.aclose()
+    assert route.called
+
+
+@respx.mock
+async def test_get_markets_with_cursor(client: KalshiClient) -> None:
+    route = respx.get(f"{_BASE}/markets", params={"cursor": "page2", "limit": 100}).mock(
+        return_value=httpx.Response(200, json={"markets": [], "cursor": ""})
+    )
+    try:
+        await client.get_markets(cursor="page2")
+    finally:
+        await client.aclose()
+    assert route.called
+
+
+@respx.mock
+async def test_get_markets_pagination_exhausted_returns_empty_cursor(
+    client: KalshiClient,
+) -> None:
+    respx.get(f"{_BASE}/markets").mock(
+        return_value=httpx.Response(200, json={"markets": [], "cursor": ""})
+    )
+    try:
+        page = await client.get_markets()
+    finally:
+        await client.aclose()
+    assert page.cursor == ""
+
+
+# ---------------------------------------------------------------------------
+# get_market
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+async def test_get_market_single(client: KalshiClient) -> None:
+    ticker = KalshiMarketTicker("KXELONMARS-99")
+    respx.get(f"{_BASE}/markets/{ticker}").mock(
+        return_value=httpx.Response(200, json={"market": _MARKET_PAYLOAD})
+    )
+    try:
+        market = await client.get_market(ticker)
+    finally:
+        await client.aclose()
+    assert market.ticker == "KXELONMARS-99"
+    assert market.last_price_cents == 9
+
+
+@respx.mock
+async def test_get_market_404_raises(client: KalshiClient) -> None:
+    ticker = KalshiMarketTicker("KXNOSUCH-1")
+    respx.get(f"{_BASE}/markets/{ticker}").mock(
+        return_value=httpx.Response(404, json={"detail": "not found"})
+    )
+    try:
+        with pytest.raises(httpx.HTTPStatusError) as exc_info:
+            await client.get_market(ticker)
+    finally:
+        await client.aclose()
+    assert exc_info.value.response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# get_orderbook
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+async def test_get_orderbook(client: KalshiClient) -> None:
+    ticker = KalshiMarketTicker("KXELONMARS-99")
+    payload = {
+        "orderbook_fp": {
+            "yes_dollars": [["0.0800", "100.00"]],
+            "no_dollars": [["0.9000", "200.00"]],
+        }
+    }
+    respx.get(f"{_BASE}/markets/{ticker}/orderbook").mock(
+        return_value=httpx.Response(200, json=payload)
+    )
+    try:
+        ob = await client.get_orderbook(ticker)
+    finally:
+        await client.aclose()
+    assert isinstance(ob, KalshiOrderbook)
+    assert ob.yes_bids[0] == ["0.0800", "100.00"]
+    assert ob.no_bids[0] == ["0.9000", "200.00"]
+
+
+@respx.mock
+async def test_get_orderbook_empty(client: KalshiClient) -> None:
+    ticker = KalshiMarketTicker("KXELONMARS-99")
+    respx.get(f"{_BASE}/markets/{ticker}/orderbook").mock(
+        return_value=httpx.Response(
+            200, json={"orderbook_fp": {"yes_dollars": [], "no_dollars": []}}
+        )
+    )
+    try:
+        ob = await client.get_orderbook(ticker)
+    finally:
+        await client.aclose()
+    assert ob.yes_bids == []
+    assert ob.no_bids == []
+
+
+# ---------------------------------------------------------------------------
+# get_market_trades
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+async def test_get_market_trades_returns_page(client: KalshiClient) -> None:
+    ticker = KalshiMarketTicker("KXELONMARS-99")
+    respx.get(f"{_BASE}/markets/trades", params={"ticker": ticker, "limit": 100}).mock(
+        return_value=httpx.Response(200, json={"trades": [_TRADE_PAYLOAD], "cursor": "next_trade"})
+    )
+    try:
+        page = await client.get_market_trades(ticker)
+    finally:
+        await client.aclose()
+    assert isinstance(page, KalshiTradesPage)
+    assert len(page.trades) == 1
+    assert page.trades[0].trade_id == "abc-123"
+    assert page.cursor == "next_trade"
+
+
+@respx.mock
+async def test_get_market_trades_with_cursor(client: KalshiClient) -> None:
+    ticker = KalshiMarketTicker("KXELONMARS-99")
+    route = respx.get(
+        f"{_BASE}/markets/trades",
+        params={"ticker": ticker, "limit": 50, "cursor": "cursor_xyz"},
+    ).mock(return_value=httpx.Response(200, json={"trades": [], "cursor": ""}))
+    try:
+        await client.get_market_trades(ticker, limit=50, cursor="cursor_xyz")
+    finally:
+        await client.aclose()
+    assert route.called
+
+
+# ---------------------------------------------------------------------------
+# Retry behaviour
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+async def test_429_retries_then_succeeds(client: KalshiClient) -> None:
+    route = respx.get(f"{_BASE}/markets").mock(
+        side_effect=[
+            httpx.Response(429, headers={"Retry-After": "0"}, json={"err": "rate limited"}),
+            httpx.Response(200, json={"markets": [], "cursor": ""}),
+        ]
+    )
+    try:
+        page = await client.get_markets()
+    finally:
+        await client.aclose()
+    assert page.markets == []
+    assert route.call_count == 2
+
+
+@respx.mock
+async def test_persistent_503_raises_after_max_attempts(client: KalshiClient) -> None:
+    route = respx.get(f"{_BASE}/markets").mock(
+        return_value=httpx.Response(503, json={"err": "down"})
+    )
+    try:
+        with pytest.raises(httpx.HTTPStatusError) as exc_info:
+            await client.get_markets()
+    finally:
+        await client.aclose()
+    assert exc_info.value.response.status_code == 503
+    assert route.call_count == 5
+
+
+@respx.mock
+async def test_500_not_retried(client: KalshiClient) -> None:
+    route = respx.get(f"{_BASE}/markets").mock(
+        return_value=httpx.Response(500, json={"err": "internal"})
+    )
+    try:
+        with pytest.raises(httpx.HTTPStatusError) as exc_info:
+            await client.get_markets()
+    finally:
+        await client.aclose()
+    assert exc_info.value.response.status_code == 500
+    assert route.call_count == 1
+
+
+@respx.mock
+async def test_read_timeout_retries_then_succeeds(client: KalshiClient) -> None:
+    route = respx.get(f"{_BASE}/markets").mock(
+        side_effect=[
+            httpx.ReadTimeout("stalled"),
+            httpx.Response(200, json={"markets": [], "cursor": ""}),
+        ]
+    )
+    try:
+        page = await client.get_markets()
+    finally:
+        await client.aclose()
+    assert page.markets == []
+    assert route.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+async def test_async_context_manager_closes_client() -> None:
+    respx.get(f"{_BASE}/markets").mock(
+        return_value=httpx.Response(200, json={"markets": [], "cursor": ""})
+    )
+    async with KalshiClient(rpm=600, base_url=_BASE) as client:
+        await client.get_markets()
+        underlying = client._client  # type: ignore[attr-defined]
+    assert underlying is not None
+    assert underlying.is_closed is True
+
+
+async def test_aclose_is_idempotent() -> None:
+    client = KalshiClient(rpm=600, base_url=_BASE)
+    await client.aclose()
+    await client.aclose()
+
+
+async def test_get_after_close_raises() -> None:
+    client = KalshiClient(rpm=600, base_url=_BASE)
+    await client.aclose()
+    with pytest.raises(RuntimeError, match="closed"):
+        await client.get_markets()
+
+
+def test_invalid_rpm_raises() -> None:
+    with pytest.raises(ValueError, match="rpm"):
+        KalshiClient(rpm=0)
+
+
+def test_invalid_timeout_raises() -> None:
+    with pytest.raises(ValueError, match="timeout"):
+        KalshiClient(rpm=60, timeout_seconds=0.0)

--- a/tests/kalshi/test_ids.py
+++ b/tests/kalshi/test_ids.py
@@ -1,0 +1,50 @@
+"""Tests for :mod:`pscanner.kalshi.ids`."""
+
+from __future__ import annotations
+
+import pscanner.kalshi.ids as kalshi_ids_module
+import pscanner.poly.ids as poly_ids_module
+from pscanner.kalshi.ids import KalshiEventTicker, KalshiMarketTicker, KalshiSeriesTicker
+from pscanner.poly.ids import MarketId
+
+
+def test_market_ticker_is_string() -> None:
+    ticker = KalshiMarketTicker("KXELONMARS-99")
+    assert ticker == "KXELONMARS-99"
+    assert isinstance(ticker, str)
+
+
+def test_event_ticker_is_string() -> None:
+    ticker = KalshiEventTicker("KXELONMARS-99")
+    assert ticker == "KXELONMARS-99"
+    assert isinstance(ticker, str)
+
+
+def test_series_ticker_is_string() -> None:
+    ticker = KalshiSeriesTicker("KXELONMARS")
+    assert ticker == "KXELONMARS"
+    assert isinstance(ticker, str)
+
+
+def test_types_have_str_supertype() -> None:
+    """All three Kalshi ID types are NewType wrappers over str."""
+    assert KalshiMarketTicker.__supertype__ is str  # type: ignore[attr-defined]
+    assert KalshiEventTicker.__supertype__ is str  # type: ignore[attr-defined]
+    assert KalshiSeriesTicker.__supertype__ is str  # type: ignore[attr-defined]
+
+
+def test_kalshi_market_ticker_is_str_at_runtime() -> None:
+    """Kalshi and Poly IDs are both plain str at runtime; NewType is a type-check-only primitive."""
+    poly_id = MarketId("540817")
+    kalshi_id = KalshiMarketTicker("KXELONMARS-99")
+    assert type(poly_id).__name__ == "str"
+    assert type(kalshi_id).__name__ == "str"
+    # Different module of origin — the modules are separate
+    assert KalshiMarketTicker.__supertype__ is MarketId.__supertype__  # type: ignore[attr-defined]
+
+
+def test_kalshi_ids_module_is_separate_from_poly() -> None:
+    """Kalshi IDs live in pscanner.kalshi.ids, not pscanner.poly.ids."""
+    assert kalshi_ids_module is not poly_ids_module
+    assert not hasattr(kalshi_ids_module, "MarketId")
+    assert not hasattr(poly_ids_module, "KalshiMarketTicker")

--- a/tests/kalshi/test_models.py
+++ b/tests/kalshi/test_models.py
@@ -1,0 +1,231 @@
+"""Tests for :mod:`pscanner.kalshi.models` — pydantic round-trip validation."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from pscanner.kalshi.models import (
+    KalshiEvent,
+    KalshiMarket,
+    KalshiMarketsPage,
+    KalshiOrderbook,
+    KalshiSeries,
+    KalshiTrade,
+    KalshiTradesPage,
+)
+
+# ---------------------------------------------------------------------------
+# Representative payloads captured from live API on 2026-05-04
+# ---------------------------------------------------------------------------
+
+_MARKET_PAYLOAD: dict = {
+    "ticker": "KXELONMARS-99",
+    "event_ticker": "KXELONMARS-99",
+    "title": "Will Elon Musk visit Mars in his lifetime?",
+    "status": "active",
+    "market_type": "binary",
+    "open_time": "2026-01-01T00:00:00Z",
+    "close_time": "2099-01-01T00:00:00Z",
+    "expected_expiration_time": "2099-01-01T00:00:00Z",
+    "yes_sub_title": "Yes",
+    "no_sub_title": "No",
+    "last_price_dollars": "0.0900",
+    "yes_bid_dollars": "0.0800",
+    "yes_ask_dollars": "0.1000",
+    "no_bid_dollars": "0.9000",
+    "no_ask_dollars": "0.9200",
+    "volume_fp": "12345.00",
+    "volume_24h_fp": "500.00",
+    "open_interest_fp": "1000.00",
+}
+
+_ORDERBOOK_PAYLOAD: dict = {
+    "orderbook_fp": {
+        "yes_dollars": [["0.0100", "49524.50"], ["0.0200", "4195.00"]],
+        "no_dollars": [["0.0100", "13551.00"], ["0.0400", "555.00"]],
+    }
+}
+
+_TRADE_PAYLOAD: dict = {
+    "trade_id": "5422e44d-d87a-67ad-2d8e-bc570f95d5da",
+    "ticker": "KXELONMARS-99",
+    "taker_side": "yes",
+    "yes_price_dollars": "0.0900",
+    "no_price_dollars": "0.9100",
+    "count_fp": "1.00",
+    "created_time": "2026-05-04T12:36:03.956406Z",
+}
+
+
+# ---------------------------------------------------------------------------
+# KalshiMarket
+# ---------------------------------------------------------------------------
+
+
+def test_market_basic_round_trip() -> None:
+    market = KalshiMarket.model_validate(_MARKET_PAYLOAD)
+    assert market.ticker == "KXELONMARS-99"
+    assert market.status == "active"
+    assert market.title == "Will Elon Musk visit Mars in his lifetime?"
+
+
+def test_market_prices_coerced_from_string() -> None:
+    market = KalshiMarket.model_validate(_MARKET_PAYLOAD)
+    assert abs(market.last_price_dollars - 0.09) < 1e-9
+    assert abs(market.yes_bid_dollars - 0.08) < 1e-9
+    assert abs(market.yes_ask_dollars - 0.10) < 1e-9
+
+
+def test_market_cents_computed_correctly() -> None:
+    market = KalshiMarket.model_validate(_MARKET_PAYLOAD)
+    assert market.last_price_cents == 9
+    assert market.yes_bid_cents == 8
+    assert market.yes_ask_cents == 10
+
+
+def test_market_volume_coerced_from_string() -> None:
+    market = KalshiMarket.model_validate(_MARKET_PAYLOAD)
+    assert market.volume_fp == pytest.approx(12345.0)
+    assert market.volume_24h_fp == pytest.approx(500.0)
+
+
+def test_market_extra_fields_ignored() -> None:
+    payload = dict(_MARKET_PAYLOAD)
+    payload["unknown_field_xyz"] = "ignored"
+    market = KalshiMarket.model_validate(payload)
+    assert not hasattr(market, "unknown_field_xyz")
+
+
+def test_market_defaults_for_optional_fields() -> None:
+    minimal = {
+        "ticker": "KXTEST-1",
+        "event_ticker": "KXTEST-1",
+        "title": "Test",
+        "status": "active",
+    }
+    market = KalshiMarket.model_validate(minimal)
+    assert market.market_type == ""
+    assert market.last_price_dollars == 0.0
+    assert market.last_price_cents == 0
+
+
+# ---------------------------------------------------------------------------
+# KalshiOrderbook
+# ---------------------------------------------------------------------------
+
+
+def test_orderbook_round_trip() -> None:
+    ob = KalshiOrderbook.model_validate(_ORDERBOOK_PAYLOAD)
+    assert ob.yes_bids[0] == ["0.0100", "49524.50"]
+    assert ob.no_bids[0] == ["0.0100", "13551.00"]
+
+
+def test_orderbook_empty_levels() -> None:
+    ob = KalshiOrderbook.model_validate({"orderbook_fp": {"yes_dollars": [], "no_dollars": []}})
+    assert ob.yes_bids == []
+    assert ob.no_bids == []
+
+
+# ---------------------------------------------------------------------------
+# KalshiTrade
+# ---------------------------------------------------------------------------
+
+
+def test_trade_round_trip() -> None:
+    trade = KalshiTrade.model_validate(_TRADE_PAYLOAD)
+    assert trade.trade_id == "5422e44d-d87a-67ad-2d8e-bc570f95d5da"
+    assert trade.taker_side == "yes"
+    assert trade.yes_price_cents == 9
+    assert trade.no_price_cents == 91
+
+
+def test_trade_count_fp_coerced() -> None:
+    trade = KalshiTrade.model_validate(_TRADE_PAYLOAD)
+    assert trade.count_fp == pytest.approx(1.0)
+
+
+def test_trade_missing_required_field_raises() -> None:
+    payload = dict(_TRADE_PAYLOAD)
+    del payload["trade_id"]
+    with pytest.raises(ValidationError):
+        KalshiTrade.model_validate(payload)
+
+
+# ---------------------------------------------------------------------------
+# KalshiMarketsPage
+# ---------------------------------------------------------------------------
+
+
+def test_markets_page_round_trip() -> None:
+    payload = {
+        "markets": [_MARKET_PAYLOAD],
+        "cursor": "abc123",
+    }
+    page = KalshiMarketsPage.model_validate(payload)
+    assert len(page.markets) == 1
+    assert page.cursor == "abc123"
+    assert page.markets[0].ticker == "KXELONMARS-99"
+
+
+def test_markets_page_empty() -> None:
+    page = KalshiMarketsPage.model_validate({"markets": [], "cursor": ""})
+    assert page.markets == []
+    assert page.cursor == ""
+
+
+def test_markets_page_cursor_defaults_to_empty() -> None:
+    page = KalshiMarketsPage.model_validate({"markets": []})
+    assert page.cursor == ""
+
+
+# ---------------------------------------------------------------------------
+# KalshiTradesPage
+# ---------------------------------------------------------------------------
+
+
+def test_trades_page_round_trip() -> None:
+    payload = {
+        "cursor": "XYZ",
+        "trades": [_TRADE_PAYLOAD],
+    }
+    page = KalshiTradesPage.model_validate(payload)
+    assert len(page.trades) == 1
+    assert page.cursor == "XYZ"
+
+
+# ---------------------------------------------------------------------------
+# KalshiEvent
+# ---------------------------------------------------------------------------
+
+
+def test_event_round_trip() -> None:
+    payload = {
+        "event_ticker": "KXELONMARS-99",
+        "series_ticker": "KXELONMARS",
+        "title": "Will Elon Musk visit Mars in his lifetime?",
+        "sub_title": "Before 2099",
+        "category": "World",
+        "mutually_exclusive": False,
+    }
+    event = KalshiEvent.model_validate(payload)
+    assert event.event_ticker == "KXELONMARS-99"
+    assert event.series_ticker == "KXELONMARS"
+    assert event.category == "World"
+
+
+# ---------------------------------------------------------------------------
+# KalshiSeries
+# ---------------------------------------------------------------------------
+
+
+def test_series_round_trip() -> None:
+    payload = {
+        "ticker": "KXELONMARS",
+        "title": "Elon Mars",
+        "category": "Politics",
+        "frequency": "custom",
+    }
+    series = KalshiSeries.model_validate(payload)
+    assert series.ticker == "KXELONMARS"
+    assert series.category == "Politics"

--- a/tests/kalshi/test_repos.py
+++ b/tests/kalshi/test_repos.py
@@ -1,0 +1,293 @@
+"""Tests for :mod:`pscanner.kalshi.repos` — CRUD against ``tmp_db``."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+
+import pytest
+
+from pscanner.kalshi.models import KalshiMarket, KalshiOrderbook, KalshiTrade
+from pscanner.kalshi.repos import (
+    KalshiMarketsRepo,
+    KalshiOrderbookSnapshotsRepo,
+    KalshiTradesRepo,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_MARKET_PAYLOAD = {
+    "ticker": "KXELONMARS-99",
+    "event_ticker": "KXELONMARS-99",
+    "title": "Will Elon Musk visit Mars?",
+    "status": "active",
+    "market_type": "binary",
+    "open_time": "2026-01-01T00:00:00Z",
+    "close_time": "2099-01-01T00:00:00Z",
+    "expected_expiration_time": "2099-01-01T00:00:00Z",
+    "yes_sub_title": "Yes",
+    "no_sub_title": "No",
+    "last_price_dollars": "0.0900",
+    "yes_bid_dollars": "0.0800",
+    "yes_ask_dollars": "0.1000",
+    "no_bid_dollars": "0.9000",
+    "no_ask_dollars": "0.9200",
+    "volume_fp": "12345.00",
+    "volume_24h_fp": "500.00",
+    "open_interest_fp": "1000.00",
+}
+
+_TRADE_PAYLOAD_1 = {
+    "trade_id": "trade-aaa",
+    "ticker": "KXELONMARS-99",
+    "taker_side": "yes",
+    "yes_price_dollars": "0.0900",
+    "no_price_dollars": "0.9100",
+    "count_fp": "1.00",
+    "created_time": "2026-05-04T12:36:03Z",
+}
+
+_TRADE_PAYLOAD_2 = {
+    "trade_id": "trade-bbb",
+    "ticker": "KXELONMARS-99",
+    "taker_side": "no",
+    "yes_price_dollars": "0.0800",
+    "no_price_dollars": "0.9200",
+    "count_fp": "2.50",
+    "created_time": "2026-05-04T13:00:00Z",
+}
+
+_ORDERBOOK_PAYLOAD = {
+    "orderbook_fp": {
+        "yes_dollars": [["0.0800", "100.00"], ["0.0700", "200.00"]],
+        "no_dollars": [["0.9000", "50.00"]],
+    }
+}
+
+
+def _sample_market() -> KalshiMarket:
+    return KalshiMarket.model_validate(_MARKET_PAYLOAD)
+
+
+def _sample_trade(payload: dict) -> KalshiTrade:
+    return KalshiTrade.model_validate(payload)
+
+
+def _sample_orderbook() -> KalshiOrderbook:
+    return KalshiOrderbook.model_validate(_ORDERBOOK_PAYLOAD)
+
+
+# ---------------------------------------------------------------------------
+# KalshiMarketsRepo
+# ---------------------------------------------------------------------------
+
+
+def test_markets_repo_upsert_and_get(tmp_db: sqlite3.Connection) -> None:
+    repo = KalshiMarketsRepo(tmp_db)
+    repo.upsert(_sample_market())
+
+    row = repo.get("KXELONMARS-99")
+    assert row is not None
+    assert row.ticker == "KXELONMARS-99"
+    assert row.status == "active"
+    assert row.last_price_cents == 9
+    assert row.yes_bid_cents == 8
+    assert row.yes_ask_cents == 10
+    assert row.no_bid_cents == 90
+    assert row.no_ask_cents == 92
+
+
+def test_markets_repo_get_missing_returns_none(tmp_db: sqlite3.Connection) -> None:
+    repo = KalshiMarketsRepo(tmp_db)
+    assert repo.get("KXNOSUCH-1") is None
+
+
+def test_markets_repo_upsert_replaces_on_duplicate(tmp_db: sqlite3.Connection) -> None:
+    repo = KalshiMarketsRepo(tmp_db)
+    repo.upsert(_sample_market())
+
+    updated_payload = dict(_MARKET_PAYLOAD)
+    updated_payload["status"] = "closed"
+    updated_payload["last_price_dollars"] = "0.9500"
+    repo.upsert(KalshiMarket.model_validate(updated_payload))
+
+    row = repo.get("KXELONMARS-99")
+    assert row is not None
+    assert row.status == "closed"
+    assert row.last_price_cents == 95
+
+
+def test_markets_repo_list_by_status(tmp_db: sqlite3.Connection) -> None:
+    repo = KalshiMarketsRepo(tmp_db)
+    repo.upsert(_sample_market())
+
+    other_payload = dict(_MARKET_PAYLOAD)
+    other_payload["ticker"] = "KXOTHER-1"
+    other_payload["status"] = "closed"
+    repo.upsert(KalshiMarket.model_validate(other_payload))
+
+    active = repo.list_by_status("active")
+    assert len(active) == 1
+    assert active[0].ticker == "KXELONMARS-99"
+
+    closed = repo.list_by_status("closed")
+    assert len(closed) == 1
+    assert closed[0].ticker == "KXOTHER-1"
+
+
+def test_markets_repo_list_by_status_empty(tmp_db: sqlite3.Connection) -> None:
+    repo = KalshiMarketsRepo(tmp_db)
+    assert repo.list_by_status("active") == []
+
+
+def test_markets_repo_list_by_event(tmp_db: sqlite3.Connection) -> None:
+    repo = KalshiMarketsRepo(tmp_db)
+    repo.upsert(_sample_market())
+
+    other_payload = dict(_MARKET_PAYLOAD)
+    other_payload["ticker"] = "KXOTHER-EVENT"
+    other_payload["event_ticker"] = "KXOTHER-EVENT"
+    repo.upsert(KalshiMarket.model_validate(other_payload))
+
+    rows = repo.list_by_event("KXELONMARS-99")
+    assert len(rows) == 1
+    assert rows[0].ticker == "KXELONMARS-99"
+
+
+def test_markets_repo_cached_at_populated(tmp_db: sqlite3.Connection) -> None:
+    repo = KalshiMarketsRepo(tmp_db)
+    repo.upsert(_sample_market())
+    row = repo.get("KXELONMARS-99")
+    assert row is not None
+    assert row.cached_at >= int(time.time()) - 5
+
+
+# ---------------------------------------------------------------------------
+# KalshiTradesRepo
+# ---------------------------------------------------------------------------
+
+
+def test_trades_repo_insert_batch_and_get(tmp_db: sqlite3.Connection) -> None:
+    repo = KalshiTradesRepo(tmp_db)
+    inserted = repo.insert_batch([_sample_trade(_TRADE_PAYLOAD_1)])
+    assert inserted == 1
+
+    row = repo.get("trade-aaa")
+    assert row is not None
+    assert row.trade_id == "trade-aaa"
+    assert row.taker_side == "yes"
+    assert row.yes_price_cents == 9
+    assert row.no_price_cents == 91
+    assert row.count_fp == pytest.approx(1.0)
+
+
+def test_trades_repo_get_missing_returns_none(tmp_db: sqlite3.Connection) -> None:
+    repo = KalshiTradesRepo(tmp_db)
+    assert repo.get("no-such-id") is None
+
+
+def test_trades_repo_insert_batch_deduplicates(tmp_db: sqlite3.Connection) -> None:
+    repo = KalshiTradesRepo(tmp_db)
+    first = repo.insert_batch([_sample_trade(_TRADE_PAYLOAD_1)])
+    assert first == 1
+    # Second insert of same trade_id is a no-op
+    second = repo.insert_batch([_sample_trade(_TRADE_PAYLOAD_1)])
+    assert second == 0
+
+
+def test_trades_repo_insert_multiple(tmp_db: sqlite3.Connection) -> None:
+    repo = KalshiTradesRepo(tmp_db)
+    trades = [_sample_trade(_TRADE_PAYLOAD_1), _sample_trade(_TRADE_PAYLOAD_2)]
+    inserted = repo.insert_batch(trades)
+    assert inserted == 2
+
+
+def test_trades_repo_list_by_ticker(tmp_db: sqlite3.Connection) -> None:
+    repo = KalshiTradesRepo(tmp_db)
+    repo.insert_batch([_sample_trade(_TRADE_PAYLOAD_1), _sample_trade(_TRADE_PAYLOAD_2)])
+
+    rows = repo.list_by_ticker("KXELONMARS-99")
+    assert len(rows) == 2
+    # Newest-first ordering (trade-bbb was created_time 13:00, trade-aaa 12:36)
+    assert rows[0].trade_id == "trade-bbb"
+    assert rows[1].trade_id == "trade-aaa"
+
+
+def test_trades_repo_list_by_ticker_empty(tmp_db: sqlite3.Connection) -> None:
+    repo = KalshiTradesRepo(tmp_db)
+    assert repo.list_by_ticker("KXNOSUCH-99") == []
+
+
+def test_trades_repo_list_by_ticker_limit(tmp_db: sqlite3.Connection) -> None:
+    repo = KalshiTradesRepo(tmp_db)
+    repo.insert_batch([_sample_trade(_TRADE_PAYLOAD_1), _sample_trade(_TRADE_PAYLOAD_2)])
+    rows = repo.list_by_ticker("KXELONMARS-99", limit=1)
+    assert len(rows) == 1
+
+
+# ---------------------------------------------------------------------------
+# KalshiOrderbookSnapshotsRepo
+# ---------------------------------------------------------------------------
+
+
+def test_orderbook_repo_insert_and_latest(tmp_db: sqlite3.Connection) -> None:
+    repo = KalshiOrderbookSnapshotsRepo(tmp_db)
+    repo.insert("KXELONMARS-99", _sample_orderbook())
+
+    snap = repo.latest("KXELONMARS-99")
+    assert snap is not None
+    assert snap.ticker == "KXELONMARS-99"
+    # yes_bids_json round-trips through JSON
+    yes_bids = json.loads(snap.yes_bids_json)
+    assert yes_bids[0] == ["0.0800", "100.00"]
+
+
+def test_orderbook_repo_latest_missing_returns_none(tmp_db: sqlite3.Connection) -> None:
+    repo = KalshiOrderbookSnapshotsRepo(tmp_db)
+    assert repo.latest("KXNOSUCH-1") is None
+
+
+def test_orderbook_repo_latest_returns_newest(tmp_db: sqlite3.Connection) -> None:
+    """latest() returns the row with the highest id when ts values are equal."""
+    repo = KalshiOrderbookSnapshotsRepo(tmp_db)
+    ob1 = KalshiOrderbook.model_validate(
+        {"orderbook_fp": {"yes_dollars": [["0.05", "1.00"]], "no_dollars": []}}
+    )
+    ob2 = KalshiOrderbook.model_validate(
+        {"orderbook_fp": {"yes_dollars": [["0.06", "2.00"]], "no_dollars": []}}
+    )
+    repo.insert("KXELONMARS-99", ob1)
+    repo.insert("KXELONMARS-99", ob2)
+
+    # list_by_ticker uses ORDER BY ts DESC, id DESC so the second insert (higher id)
+    # sorts first even when ts is the same.
+    snaps = repo.list_by_ticker("KXELONMARS-99", limit=10)
+    assert len(snaps) >= 2
+    assert snaps[0].id is not None
+    assert snaps[1].id is not None
+    assert snaps[0].id > snaps[1].id
+    # latest() should return the same as snaps[0]
+    snap = repo.latest("KXELONMARS-99")
+    assert snap is not None
+    assert snap.id == snaps[0].id
+
+
+def test_orderbook_repo_list_by_ticker(tmp_db: sqlite3.Connection) -> None:
+    repo = KalshiOrderbookSnapshotsRepo(tmp_db)
+    repo.insert("KXELONMARS-99", _sample_orderbook())
+    repo.insert("KXELONMARS-99", _sample_orderbook())
+
+    snaps = repo.list_by_ticker("KXELONMARS-99", limit=10)
+    assert len(snaps) == 2
+
+
+def test_orderbook_repo_id_is_set(tmp_db: sqlite3.Connection) -> None:
+    repo = KalshiOrderbookSnapshotsRepo(tmp_db)
+    repo.insert("KXELONMARS-99", _sample_orderbook())
+    snap = repo.latest("KXELONMARS-99")
+    assert snap is not None
+    assert snap.id is not None
+    assert snap.id >= 1


### PR DESCRIPTION
Closes #36 (Stage 1).

## Summary
Adds the `pscanner.kalshi` module mirroring `pscanner.poly`'s shape — REST-only, no auth, cents-priced binary YES/NO event contracts.

- `pscanner.kalshi.ids` — `KalshiMarketTicker`, `KalshiEventTicker`, `KalshiSeriesTicker` `NewType`s (per RFC §2: per-platform modules, no shared `MarketId` supertype).
- `pscanner.kalshi.client.KalshiClient` — async httpx wrapper over the public REST endpoints (markets, market detail, orderbook, market-scoped trades). Tenacity backoff on 429/5xx, token-bucket rate limiting.
- `pscanner.kalshi.models` — pydantic models for the API payloads. Price fields are dollar floats with `_cents` integer properties for downstream comparison with poly/manifold.
- `pscanner.kalshi.db` / `.repos` — `kalshi_markets`, `kalshi_trades`, `kalshi_orderbook_snapshots` tables with `upsert` / `get` / `latest` repos.

`KALSHI_SCHEMA_STATEMENTS` is spliced into the daemon DB's `_SCHEMA_STATEMENTS` bootstrap so `init_db` creates the new tables alongside the existing poly ones.

## API quirks discovered (and documented in CLAUDE.md)
- **Prices are dollar strings** (`"0.0900"`), NOT cents integers. Models expose `_cents` properties via `int(round(dollars * 100))`.
- **Trades endpoint is `GET /markets/trades?ticker=X`**, NOT `/markets/{ticker}/trades` (404s).
- **Volume fields are fixed-point strings** (`"12345.00"`) — pydantic auto-coerces to float.

## What was deferred
- WebSocket streaming (Stage 2 — gated behind Kalshi account + RSA-signed handshake)
- `KalshiTradeCollector` orchestrator (RFC PR D)
- Detector instances per platform
- `platform` column on shared corpus tables (RFC PR A)

## Notes
- `_TokenBucket` is duplicated from `pscanner.poly.http` (and `pscanner.manifold.client`, and `pscanner.poly.onchain_rpc`) — flagged for a future refactor PR to extract into a shared `pscanner.util.rate_limit` module.

## Test plan
- [x] 62 new tests in `tests/kalshi/` (5 ids, ~22 client incl. 2-page pagination + 429-retry, ~12 models, ~23 repos)
- [x] Full suite: 953 passed, ruff/format/ty clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)