### PR TITLE
perf(corpus): in-memory resolutions cache + skip Trade rebuild for SELLs (#58)

### DIFF
--- a/src/pscanner/corpus/examples.py
+++ b/src/pscanner/corpus/examples.py
@@ -102,22 +102,26 @@ def _example_from_features(
 
 def _maybe_make_example(
     trade: Trade,
-    resolutions_repo: MarketResolutionsRepo,
     provider: StreamingHistoryProvider,
     now_ts: int,
 ) -> TrainingExample | None:
-    """Return a TrainingExample for a resolved BUY, or None to skip."""
-    if trade.bs != "BUY":
-        return None
-    resolution = resolutions_repo.get(trade.condition_id)
+    """Return a TrainingExample for a resolved BUY, or None to skip.
+
+    Caller must guarantee ``trade.bs == "BUY"`` — the loop short-circuits
+    SELL rows before allocating ``Trade``, so this function does not
+    re-check the side.
+
+    Reads resolution status from the provider's in-memory map rather
+    than ``MarketResolutionsRepo`` so the hot path avoids a per-trade
+    SQLite SELECT. The provider is seeded once from
+    ``market_resolutions`` at startup via ``_register_resolutions``.
+    """
+    resolution = provider.get_resolution(trade.condition_id)
     if resolution is None:
         return None
+    _, outcome_yes_won = resolution
     features = compute_features(trade, provider)
-    won = (
-        resolution.outcome_yes_won == 1
-        if trade.outcome_side == "YES"
-        else resolution.outcome_yes_won == 0
-    )
+    won = outcome_yes_won == 1 if trade.outcome_side == "YES" else outcome_yes_won == 0
     return _example_from_features(
         trade=trade,
         features=features,
@@ -155,15 +159,20 @@ def build_features(
 
     Args:
         trades_repo: Source of raw trades (chronological).
-        resolutions_repo: Source of per-market labels.
+        resolutions_repo: Kept for API compat; the per-trade resolution
+            check now reads from the provider's in-memory map (seeded by
+            ``_register_resolutions`` at startup) so the hot loop avoids a
+            per-row SQLite SELECT.
         examples_repo: Sink for materialized rows.
-        markets_conn: Connection used to load corpus_markets metadata.
+        markets_conn: Connection used to load corpus_markets metadata
+            and the one-shot ``market_resolutions`` snapshot.
         now_ts: ``built_at`` for new rows.
         rebuild: If True, drop training_examples before walking.
 
     Returns:
         Number of rows actually written (deduped via INSERT OR IGNORE).
     """
+    del resolutions_repo  # signature kept; reads come from provider/markets_conn
     if rebuild:
         examples_repo.truncate()
 
@@ -178,6 +187,13 @@ def build_features(
         meta = metadata.get(ct.condition_id)
         if meta is None:
             continue
+        # Half the corpus is SELLs; they only need to enter wallet/market
+        # state for recency + volume bookkeeping. Skip the Trade rebuild
+        # (saves the per-row dataclass allocation + the unused
+        # ``category`` lookup) and route through ``observe_sell``.
+        if ct.bs != "BUY":
+            provider.observe_sell(ct)
+            continue
         trade = Trade(
             tx_hash=ct.tx_hash,
             asset_id=ct.asset_id,
@@ -191,7 +207,7 @@ def build_features(
             ts=ct.ts,
             category=meta.category,
         )
-        example = _maybe_make_example(trade, resolutions_repo, provider, now_ts)
+        example = _maybe_make_example(trade, provider, now_ts)
         if example is not None:
             pending_examples.append(example)
         provider.observe(trade)

--- a/src/pscanner/corpus/features.py
+++ b/src/pscanner/corpus/features.py
@@ -40,6 +40,27 @@ class Trade:
     category: str
 
 
+class _TradeFields(Protocol):
+    """Structural shape of the fields ``observe`` reads on the SELL path.
+
+    Both ``Trade`` and ``pscanner.corpus.repos.CorpusTrade`` satisfy this.
+    Used so the ``build-features`` loop can hand ``CorpusTrade`` straight
+    to ``observe`` for SELL rows without rebuilding a ``Trade`` (which
+    would also force allocating the unused ``category`` field).
+    """
+
+    tx_hash: str
+    asset_id: str
+    wallet_address: str
+    condition_id: str
+    outcome_side: str
+    bs: str
+    price: float
+    size: float
+    notional_usd: float
+    ts: int
+
+
 @dataclass(frozen=True)
 class WalletState:
     """Running per-wallet aggregate at some point in time.
@@ -164,11 +185,13 @@ def apply_buy_to_state(state: WalletState, trade: Trade) -> WalletState:
     )
 
 
-def apply_sell_to_state(state: WalletState, trade: Trade) -> WalletState:
+def apply_sell_to_state(state: WalletState, trade: _TradeFields) -> WalletState:
     """Apply a SELL fill to wallet state. Returns a new WalletState.
 
     Sells contribute to total trade count and recency but not to BUY
-    aggregates (avg price paid, bet sizes, win/loss ledger).
+    aggregates (avg price paid, bet sizes, win/loss ledger). Accepts any
+    object with the SELL-relevant fields so callers can pass either
+    ``Trade`` or the bare repo ``CorpusTrade`` without rebuilding.
     """
     return replace(
         state,
@@ -200,7 +223,9 @@ def apply_resolution_to_state(
     )
 
 
-def apply_trade_to_market(state: MarketState, trade: Trade, *, is_new_trader: bool) -> MarketState:
+def apply_trade_to_market(
+    state: MarketState, trade: _TradeFields, *, is_new_trader: bool
+) -> MarketState:
     """Apply a fill to market state (per-market running aggregates).
 
     ``is_new_trader`` is computed by the caller against its own membership
@@ -428,6 +453,15 @@ class StreamingHistoryProvider:
         """Return static metadata for ``condition_id``; raises KeyError if unknown."""
         return self._metadata[condition_id]
 
+    def get_resolution(self, condition_id: str) -> tuple[int, int] | None:
+        """Return ``(resolved_at, outcome_yes_won)`` for a market, or None if unresolved.
+
+        Reads from the in-memory map seeded by ``register_resolution`` so the
+        ``build-features`` hot path can answer "is this market resolved?"
+        without a per-trade SQLite SELECT against ``market_resolutions``.
+        """
+        return self._resolutions.get(condition_id)
+
     def register_resolution(
         self,
         *,
@@ -451,15 +485,14 @@ class StreamingHistoryProvider:
             accum.unscheduled = remaining
 
     def observe(self, trade: Trade) -> None:
-        """Fold a trade into running wallet + market state."""
-        accum = self._wallets.get(trade.wallet_address)
-        if accum is None:
-            accum = _WalletAccumulator(
-                state=empty_wallet_state(first_seen_ts=trade.ts),
-                heap=[],
-                unscheduled=[],
-            )
-            self._wallets[trade.wallet_address] = accum
+        """Fold a trade into running wallet + market state.
+
+        For BUY rows the caller must pass a full ``Trade`` (the
+        ``category`` field feeds ``WalletState.category_counts``). For
+        SELL rows ``observe_sell`` is preferred — it accepts the bare
+        repo dataclass and skips an unnecessary ``Trade`` rebuild.
+        """
+        accum = self._ensure_accumulator(trade)
 
         if trade.bs == "BUY":
             accum.state = apply_buy_to_state(accum.state, trade)
@@ -480,6 +513,34 @@ class StreamingHistoryProvider:
         elif trade.bs == "SELL":
             accum.state = apply_sell_to_state(accum.state, trade)
 
+        self._fold_market_state(trade)
+
+    def observe_sell(self, trade: _TradeFields) -> None:
+        """Fold a SELL fill into wallet + market state.
+
+        Accepts any object with the trade fields used by the SELL path
+        (no ``category`` required). Lets the ``build-features`` loop hand
+        ``CorpusTrade`` directly without rebuilding a ``Trade``.
+
+        Caller must guarantee ``trade.bs == "SELL"`` — BUYs would skip
+        the heap-bookkeeping and silently lose label coverage.
+        """
+        accum = self._ensure_accumulator(trade)
+        accum.state = apply_sell_to_state(accum.state, trade)
+        self._fold_market_state(trade)
+
+    def _ensure_accumulator(self, trade: _TradeFields) -> _WalletAccumulator:
+        accum = self._wallets.get(trade.wallet_address)
+        if accum is None:
+            accum = _WalletAccumulator(
+                state=empty_wallet_state(first_seen_ts=trade.ts),
+                heap=[],
+                unscheduled=[],
+            )
+            self._wallets[trade.wallet_address] = accum
+        return accum
+
+    def _fold_market_state(self, trade: _TradeFields) -> None:
         market = self._markets.get(trade.condition_id)
         if market is None:
             market = empty_market_state(market_age_start_ts=trade.ts)

--- a/tests/corpus/test_examples.py
+++ b/tests/corpus/test_examples.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import sqlite3
+from unittest.mock import patch
 
+from pscanner.corpus import examples as examples_module
 from pscanner.corpus.examples import build_features
 from pscanner.corpus.repos import (
     CorpusTrade,
@@ -160,6 +162,170 @@ def test_build_features_skips_sells(tmp_corpus_db: sqlite3.Connection) -> None:
         now_ts=10_000,
     )
     assert written == 0
+
+
+def test_build_features_does_not_query_resolutions_repo_per_row(
+    tmp_corpus_db: sqlite3.Connection,
+) -> None:
+    """The hot loop must read resolutions from the in-memory provider map.
+
+    Pre-fix, every row in ``corpus_trades`` triggered a SELECT-by-PK on
+    ``market_resolutions``. Post-fix, only ``_register_resolutions`` reads
+    from the repo (once at startup), and the per-row check goes through
+    ``StreamingHistoryProvider.get_resolution`` against an in-memory dict.
+    """
+    _seed_market_metadata(tmp_corpus_db, "cond1")
+    _seed_market_metadata(tmp_corpus_db, "cond2")
+    trades = CorpusTradesRepo(tmp_corpus_db)
+    resolutions = MarketResolutionsRepo(tmp_corpus_db)
+    examples = TrainingExamplesRepo(tmp_corpus_db)
+
+    trades.insert_batch(
+        [
+            _trade(tx_hash="0xa", condition_id="cond1", ts=1_000),
+            _trade(tx_hash="0xb", condition_id="cond1", bs="SELL", ts=1_500),
+            _trade(tx_hash="0xc", condition_id="cond2", ts=2_000),
+            _trade(tx_hash="0xd", condition_id="cond2", ts=2_500),
+        ]
+    )
+    resolutions.upsert(
+        MarketResolution(
+            condition_id="cond1",
+            winning_outcome_index=0,
+            outcome_yes_won=1,
+            resolved_at=5_000,
+            source="gamma",
+        ),
+        recorded_at=5_001,
+    )
+
+    with patch.object(
+        MarketResolutionsRepo, "get", autospec=True, side_effect=MarketResolutionsRepo.get
+    ) as get_spy:
+        build_features(
+            trades_repo=trades,
+            resolutions_repo=resolutions,
+            examples_repo=examples,
+            markets_conn=tmp_corpus_db,
+            now_ts=10_000,
+        )
+    assert get_spy.call_count == 0, (
+        f"MarketResolutionsRepo.get must not be called per-row "
+        f"during build_features (got {get_spy.call_count} calls). "
+        "Resolutions are seeded once via _register_resolutions."
+    )
+
+
+def test_build_features_skips_maybe_make_example_for_sell_rows(
+    tmp_corpus_db: sqlite3.Connection,
+) -> None:
+    """SELL rows must short-circuit before _maybe_make_example.
+
+    The function is a no-op for SELLs, so calling it is wasted work
+    plus a wasted Trade dataclass allocation. The loop now routes SELLs
+    straight to ``provider.observe_sell`` and never invokes the
+    BUY-only example pipeline.
+    """
+    _seed_market_metadata(tmp_corpus_db, "cond1")
+    trades = CorpusTradesRepo(tmp_corpus_db)
+    resolutions = MarketResolutionsRepo(tmp_corpus_db)
+    examples = TrainingExamplesRepo(tmp_corpus_db)
+    trades.insert_batch(
+        [
+            _trade(tx_hash="0xa", bs="BUY", ts=1_000),
+            _trade(tx_hash="0xb", bs="SELL", ts=2_000),
+            _trade(tx_hash="0xc", bs="SELL", ts=3_000),
+            _trade(tx_hash="0xd", bs="SELL", ts=4_000),
+        ]
+    )
+    resolutions.upsert(
+        MarketResolution(
+            condition_id="cond1",
+            winning_outcome_index=0,
+            outcome_yes_won=1,
+            resolved_at=5_000,
+            source="gamma",
+        ),
+        recorded_at=5_001,
+    )
+
+    with patch(
+        "pscanner.corpus.examples._maybe_make_example",
+        wraps=examples_module._maybe_make_example,
+    ) as spy:
+        build_features(
+            trades_repo=trades,
+            resolutions_repo=resolutions,
+            examples_repo=examples,
+            markets_conn=tmp_corpus_db,
+            now_ts=10_000,
+        )
+
+    assert spy.call_count == 1, (
+        f"Expected _maybe_make_example called only once (for the BUY); "
+        f"got {spy.call_count}. SELLs must short-circuit."
+    )
+
+
+def test_build_features_writes_same_examples_with_mixed_buy_sell(
+    tmp_corpus_db: sqlite3.Connection,
+) -> None:
+    """End-to-end no-regression: BUY+SELL mix produces the expected example set.
+
+    Post-fix the SELL rows go through ``observe_sell`` (no Trade rebuild,
+    no resolution lookup), but the materialised ``training_examples``
+    rows must be unchanged: same row count, same labels, same
+    prior_trades_count progression.
+    """
+    _seed_market_metadata(tmp_corpus_db, "cond1")
+    trades = CorpusTradesRepo(tmp_corpus_db)
+    resolutions = MarketResolutionsRepo(tmp_corpus_db)
+    examples = TrainingExamplesRepo(tmp_corpus_db)
+
+    # Wallet 0xw: BUY -> SELL -> BUY -> SELL on the same market.
+    # Each BUY whose market has resolved should yield one training row.
+    trades.insert_batch(
+        [
+            _trade(tx_hash="0xa", wallet_address="0xw", bs="BUY", ts=1_000),
+            _trade(tx_hash="0xb", wallet_address="0xw", bs="SELL", ts=1_500),
+            _trade(tx_hash="0xc", wallet_address="0xw", bs="BUY", ts=2_000),
+            _trade(tx_hash="0xd", wallet_address="0xw", bs="SELL", ts=2_500),
+        ]
+    )
+    resolutions.upsert(
+        MarketResolution(
+            condition_id="cond1",
+            winning_outcome_index=0,
+            outcome_yes_won=1,
+            resolved_at=8_000,
+            source="gamma",
+        ),
+        recorded_at=8_001,
+    )
+
+    written = build_features(
+        trades_repo=trades,
+        resolutions_repo=resolutions,
+        examples_repo=examples,
+        markets_conn=tmp_corpus_db,
+        now_ts=10_000,
+    )
+    assert written == 2
+
+    rows = tmp_corpus_db.execute(
+        """
+        SELECT tx_hash, label_won, prior_trades_count, prior_buys_count
+        FROM training_examples
+        ORDER BY trade_ts
+        """
+    ).fetchall()
+    assert [r["tx_hash"] for r in rows] == ["0xa", "0xc"]
+    # Both YES BUYs on a YES-winning market -> label_won == 1.
+    assert [r["label_won"] for r in rows] == [1, 1]
+    # The first BUY sees an empty wallet history; the second sees one
+    # prior BUY + one prior SELL = 2 prior trades, 1 prior buy.
+    assert [r["prior_trades_count"] for r in rows] == [0, 2]
+    assert [r["prior_buys_count"] for r in rows] == [0, 1]
 
 
 def test_build_features_is_incremental(tmp_corpus_db: sqlite3.Connection) -> None:


### PR DESCRIPTION
Refs #58 (lands fixes 1+2 from the analysis).

## Summary
Two surgical fixes for the `build-features` hot path on the post-Phase-3 24.6 GB corpus (16M+ trades). Together: **3-5× expected speedup**, 5-8h → 1-2h on the laptop.

### Fix 1 — In-memory `market_resolutions` cache
`_maybe_make_example` was calling `MarketResolutionsRepo.get(condition_id)` on **every trade** — 16M SELECT-by-PK SQLite roundtrips. The `StreamingHistoryProvider` already loads every resolution into memory via `_register_resolutions` at startup. Added a `get_resolution()` accessor and replaced the per-trade SQLite call with a dict lookup.

### Fix 2 — Skip `Trade` rebuild for SELL rows
The build loop constructed a `Trade` dataclass for every row before deciding what to emit. SELLs only need state updates (no training-example output), so they go through a new `provider.observe_sell()` that accepts the bare repo dataclass via a `_TradeFields` Protocol — no `Trade` allocation, no `_maybe_make_example` call. Half the corpus is SELLs.

## Verified zero-call invariant
New test `test_build_features_does_not_query_resolutions_repo_per_row` asserts `MarketResolutionsRepo.get` is called **zero** times during `build_features` (only `_register_resolutions` reads from the repo, once at startup).

## Implementation notes
- New `_TradeFields` `Protocol` in `features.py` documents the 10 fields shared between `Trade` (the streaming-side dataclass) and `CorpusTrade` (the repo dataclass) — avoids importing `repos.CorpusTrade` into `features.py` and keeps the module direction one-way.
- `observe_sell()` is a separate method (not a widened `observe()`) to preserve the contract that BUYs go through the full `Trade` path with category — accidental `observe_sell(buy_trade)` would silently lose label coverage; docstring flags this.
- `build_features` keeps the `resolutions_repo` parameter for backward-compat (callers won't notice the optimization). Marked `del resolutions_repo` to suppress unused-arg warnings.

## Test plan
- [x] 3 new tests in `tests/corpus/test_examples.py` — zero-call invariant, SELL-row short-circuit, end-to-end no-regression.
- [x] Full suite: 1072 passed, ruff/format/ty clean.
- [ ] **Live wall-clock verification on the desktop** — re-run on the same 24.6 GB corpus, compare end-to-end runtime. The user is about to do this anyway.

## Out of scope (separate follow-ups under #58)
- Fix #3: deque-backed `recent_30d_trades` to cure heavy-wallet O(window-size) cost.
- Fix #4: separate read/write SQLite connections for `iter_chronological`.
- Fix #5: drop the gratuitous `dict(state.category_counts)` copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)