### PR TITLE
fix(ml): explicit Polars schema in _encode_chunk (#39)

### DIFF
--- a/src/pscanner/ml/streaming.py
+++ b/src/pscanner/ml/streaming.py
@@ -355,7 +355,7 @@ class _SplitIter:
         rows: list[tuple[object, ...]],
         col_names: tuple[str, ...],
     ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-        df = pl.DataFrame(rows, schema=list(col_names), orient="row")
+        df = pl.DataFrame(rows, schema=_chunk_schema(col_names), orient="row")
         # Mirror load_dataset's dtype casting (preserved from preprocessing.py).
         cast_exprs = [
             *[pl.col(c).cast(pl.Categorical) for c in _CATEGORICAL_CAST_COLS if c in df.columns],
@@ -366,6 +366,33 @@ class _SplitIter:
         df = drop_leakage_cols(df)  # idempotent; no-op when SELECT already excluded them
         df = self.encoder.transform(df)
         return build_feature_matrix(df)
+
+
+def _chunk_schema(col_names: tuple[str, ...]) -> dict[str, pl.DataType]:
+    """Build an explicit Polars schema for a chunked SELECT result.
+
+    Polars's default ``infer_schema_length=100`` mis-types nullable numeric
+    columns as ``pl.Null`` when the first 100 rows of a chunk are all
+    ``None``, then raises ``ComputeError`` on subsequent real values. An
+    explicit schema removes the dependency on row content. Categories
+    mirror preprocessing.py's dtype-cast tuples; ``_encode_chunk``'s
+    ``cast_exprs`` then narrow Int64 → Int32 and Float64 → Float32.
+    """
+    schema: dict[str, pl.DataType] = {}
+    for c in col_names:
+        if c in _INT32_COLS:
+            schema[c] = pl.Int64()
+        elif c in _FLOAT32_COLS:
+            schema[c] = pl.Float64()
+        elif c in _CATEGORICAL_CAST_COLS:
+            schema[c] = pl.String()
+        elif c in ("trade_ts", "resolved_at"):
+            schema[c] = pl.Int64()  # SQLite INTEGER unix timestamps
+        else:
+            # condition_id and any other carrier strings (LEAKAGE_COLS are
+            # already excluded at SELECT time via _NEVER_LOAD_COLS).
+            schema[c] = pl.String()
+    return schema
 
 
 class SplitDataIter(xgb.DataIter):

--- a/tests/ml/test_streaming.py
+++ b/tests/ml/test_streaming.py
@@ -356,3 +356,46 @@ def test_streaming_pipeline_matches_eager_baseline(
     # quantization changes but are bounded.
     assert abs(metrics["test_accuracy"] - baseline["test_accuracy"]) < 0.05
     assert abs(metrics["test_logloss"] - baseline["test_logloss"]) < 0.10
+
+
+def test_split_iter_handles_null_to_float_transition_within_chunk(
+    make_synthetic_examples_db: Callable[..., Path],
+) -> None:
+    """Regression: nullable column with all-None leading rows + a real float
+    later in the same chunk used to crash ``_encode_chunk``.
+
+    Polars's default ``infer_schema_length=100`` typed an all-null leading
+    section as ``pl.Null``, then raised ``ComputeError`` on the first real
+    float. The fix passes an explicit schema to ``pl.DataFrame``. Synthetic
+    fixtures with ``chunk_size <= 100`` don't trip the boundary; production
+    runs at chunk_size=100_000 hit it the moment a chunk had >100 leading
+    NULLs in a nullable column.
+
+    100 markets x 2 rows places te.id 1-120 in train (markets 0-59).
+    UPDATEs force the mixed-type pattern within a single chunk.
+    """
+    db_path = make_synthetic_examples_db(n_markets=100, rows_per_market=2, seed=0)
+
+    conn = _sqlite3.connect(str(db_path))
+    try:
+        conn.execute("UPDATE training_examples SET win_rate = NULL WHERE id BETWEEN 1 AND 100")
+        conn.execute("UPDATE training_examples SET win_rate = 0.5 WHERE id BETWEEN 101 AND 120")
+        conn.commit()
+    finally:
+        conn.close()
+
+    with open_dataset(db_path, chunk_size=200) as ds:
+        assert ds.encoder is not None
+        it = _SplitIter(
+            db_path=ds._db_path,
+            condition_ids=ds._train_markets,
+            encoder=ds.encoder,
+            kept_cols=ds._kept_cols,
+            chunk_size=200,
+        )
+        chunks = list(iter(it))
+
+    assert len(chunks) == 1
+    x, _y, _implied = chunks[0]
+    assert x.shape[0] == 120
+    assert x.dtype.name == "float32"


### PR DESCRIPTION
Hotfix for the streaming pipeline merged in #39. Production training crashed on the desktop's 32 GB corpus during the first chunked SELECT with:

\`\`\`
polars.exceptions.ComputeError: could not append value: 1.0 of type: f64 to the builder;
make sure that all rows have the same schema or consider increasing \`infer_schema_length\`
\`\`\`

## Root cause

\`_SplitIter._encode_chunk\` called \`pl.DataFrame(rows, schema=list(col_names), orient=\"row\")\` — passing only column NAMES, not types. Polars's default \`infer_schema_length=100\` types each column from the first 100 rows. Nullable REAL columns (\`win_rate\`, \`realized_edge_pp\`, \`avg_implied_prob_paid\`, etc.) frequently have long all-\`NULL\` leading sections in \`te.id\` order, so Polars infers them as \`pl.Null\` and then chokes on the first real float later in the chunk.

Synthetic test fixtures didn't trigger this because (a) chunks were sized 50-100 (under the boundary) and (b) the random NULL distribution didn't cluster at row 0.

## Fix

Pass an explicit schema dict to \`pl.DataFrame()\`, derived from the existing dtype-cast tuples in \`preprocessing.py\`:

- \`_INT32_COLS\` → \`pl.Int64\` (narrowed to Int32 by \`_encode_chunk\`'s cast_exprs)
- \`_FLOAT32_COLS\` → \`pl.Float64\` (narrowed to Float32)
- \`_CATEGORICAL_CAST_COLS\` → \`pl.String\` (cast to Categorical)
- \`trade_ts\`, \`resolved_at\` → \`pl.Int64\` (SQLite INTEGER timestamps)
- \`condition_id\` and any other carrier strings → \`pl.String\`

Removes the dependency on row content entirely.

## Operational signal from the failed run (still preserved by this fix)

The streaming pre-pass is doing its job — RSS at \`post_pre_pass\` was **128 MB** vs the pre-#39 OOM at **11.8 GB** on the same corpus. The crash happened in the chunk-encoding path, not the load path. Once this hotfix lands, training should complete end-to-end on the full corpus.

## Regression test

\`tests/ml/test_streaming.py::test_split_iter_handles_null_to_float_transition_within_chunk\` forces 100 leading \`win_rate=NULL\` rows + 20 \`win_rate=0.5\` rows via UPDATE statements on the synthetic fixture, then iterates with \`chunk_size=200\`. Without the fix it raises the same \`ComputeError\`; with the fix it passes.

Verified locally: stash → test fails (same error as desktop) → restore → test passes. 52/52 ml tests green, ruff/format clean, ty unchanged.

## Test plan

- [ ] Merge this hotfix.
- [ ] Re-run \`pscanner ml train --device cuda --n-jobs 1 --n-trials 5 --db data/corpus.sqlite3\` on the desktop. Expected: completes end-to-end, \`grep ml.mem /tmp/ml-streaming-after.log\` shows the full phase progression (run_study_entry → post_pre_pass → post_dmatrix → post_optuna → post_fit_winning).