### PR TITLE
perf(ml): bulk-fetch top_categories in materialize_test (fixes #74)

### DIFF
--- a/src/pscanner/ml/streaming.py
+++ b/src/pscanner/ml/streaming.py
@@ -160,7 +160,9 @@ class StreamingDataset:
 
         # Parallel small SELECT for unencoded top_category strings.
         # Mirrors the deleted _extract_top_category: nulls become "".
-        top_categories = np.empty(self.n_test_rows, dtype=object)
+        # Bulk fetchall + np.array is multiple orders of magnitude faster than
+        # the per-row loop pattern at corpus scale (~2M rows takes seconds vs
+        # ~10+ minutes for the row-at-a-time numpy assignment).
         sql = (
             "SELECT COALESCE(te.top_category, '') "
             "FROM training_examples te "
@@ -170,10 +172,10 @@ class StreamingDataset:
         conn = sqlite3.connect(str(self._db_path))
         try:
             _populate_temp_table(conn, "_split_markets", self._test_markets)
-            for i, (cat,) in enumerate(conn.execute(sql)):
-                top_categories[i] = cat
+            rows = conn.execute(sql).fetchall()
         finally:
             conn.close()
+        top_categories = np.array([r[0] for r in rows], dtype=object)
 
         return TestSplit(x=x, y=y, implied_prob=implied, top_categories=top_categories)
 


### PR DESCRIPTION
Fixes #74.

Replaces the per-row Python loop in \`materialize_test()\`:

\`\`\`python
top_categories = np.empty(self.n_test_rows, dtype=object)
for i, (cat,) in enumerate(conn.execute(sql)):
    top_categories[i] = cat
\`\`\`

with a single fetchall + numpy array construction:

\`\`\`python
rows = conn.execute(sql).fetchall()
top_categories = np.array([r[0] for r in rows], dtype=object)
\`\`\`

Per-iteration overhead at corpus scale is ~100-500 ns × 2M rows = 3-15 minutes. Bulk path is seconds.

Discovered when \`scripts/analyze_model.py\` was still running at 33 minutes against the production test split with no output. Killed the run and shipped a partial report from \`metrics.json\` (#73's PR description has the comparison vs the prior 60/20/20 baseline).

## Test plan

- [x] 52/52 ml tests pass locally (existing \`test_materialize_test_returns_unencoded_top_categories\` continues to pass on the small synthetic fixture; behavior is unchanged, only the loop shape).
- [x] ruff + format clean.
- [ ] Re-run \`pscanner ml train\` ↣ \`analyze_model.py\` on the desktop. Expect \`materialize_test\` to finish in under a minute and the SHAP + per-category report to print to disk within ~2-3 minutes.