### PR TITLE
feat(daemon): platform filter on bootstrap-features + scheduler corpus metadata

### DIFF
--- a/src/pscanner/cli.py
+++ b/src/pscanner/cli.py
@@ -125,15 +125,15 @@ def _dispatch_daemon(
     """Route ``pscanner daemon <subcmd>`` to the matching handler."""
     del config  # daemon ops use --corpus-db/--daemon-db flags directly
     if args.daemon_cmd == "bootstrap-features":
-        return _cmd_daemon_bootstrap(args.corpus_db, args.daemon_db)
+        return _cmd_daemon_bootstrap(args.corpus_db, args.daemon_db, args.platform)
     parser.error(f"unknown daemon subcommand: {args.daemon_cmd}")
     return 2  # unreachable; argparse exits
 
 
-def _cmd_daemon_bootstrap(corpus_db: Path, daemon_db: Path) -> int:
+def _cmd_daemon_bootstrap(corpus_db: Path, daemon_db: Path, platform: str) -> int:
     """Cold-start the live history tables from corpus_trades."""
-    n = run_bootstrap(corpus_db=corpus_db, daemon_db=daemon_db)
-    print(f"bootstrap-features: folded {n} trades")  # noqa: T201
+    n = run_bootstrap(corpus_db=corpus_db, daemon_db=daemon_db, platform=platform)
+    print(f"bootstrap-features: folded {n} trades (platform={platform})")  # noqa: T201
     return 0
 
 
@@ -186,6 +186,16 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     bootstrap_parser.add_argument("--corpus-db", type=Path, default=Path("data/corpus.sqlite3"))
     bootstrap_parser.add_argument("--daemon-db", type=Path, default=Path("data/pscanner.sqlite3"))
+    bootstrap_parser.add_argument(
+        "--platform",
+        type=str,
+        default="polymarket",
+        choices=("polymarket", "kalshi", "manifold"),
+        help=(
+            "scope the corpus walk to one platform; default polymarket "
+            "(every shipped gate-model artifact is Polymarket-trained)"
+        ),
+    )
 
     corpus = sub.add_parser(
         "corpus",

--- a/src/pscanner/config.py
+++ b/src/pscanner/config.py
@@ -319,6 +319,14 @@ class GateModelConfig(_Section):
     min_edge_pct: float = 0.01
     accepted_categories: tuple[str, ...] | None = None
     queue_max_size: int = 1024
+    platform: str = "polymarket"
+    """Platform whose corpus rows feed the live history tables.
+
+    Scopes ``LiveHistoryProvider`` metadata loading + ``bootstrap-features``
+    so the model is only fed rows from the platform it was trained on.
+    Default ``"polymarket"`` matches every shipped artifact today; bump
+    to ``"manifold"`` / ``"kalshi"`` once a per-platform model trains.
+    """
 
 
 class GateModelMarketFilterConfig(_Section):

--- a/src/pscanner/daemon/bootstrap.py
+++ b/src/pscanner/daemon/bootstrap.py
@@ -6,6 +6,12 @@ Resolutions are registered up-front from ``market_resolutions`` so the
 buy-then-resolve drain fires correctly during the walk.
 
 After this completes, the daemon can start with O(1) state load.
+
+Reads are scoped to a single ``platform`` so the gate model is only fed
+rows from the platform it was trained on. Manifold trades are
+mana-denominated (CLAUDE.md: "Never aggregate Manifold bet amounts into
+real-money totals"); mixing them into a Polymarket-trained model would
+poison ``cumulative_buy_price_sum`` / ``bet_size_sum`` / ``realized_pnl_usd``.
 """
 
 from __future__ import annotations
@@ -28,6 +34,7 @@ def run_bootstrap(
     corpus_db: Path,
     daemon_db: Path,
     log_every: int = 100_000,
+    platform: str = "polymarket",
 ) -> int:
     """Cold-start ``wallet_state_live`` + ``market_state_live`` from corpus.
 
@@ -35,6 +42,10 @@ def run_bootstrap(
         corpus_db: Path to the corpus SQLite (``data/corpus.sqlite3``).
         daemon_db: Path to the daemon SQLite (``data/pscanner.sqlite3``).
         log_every: Emit a progress log every N trades.
+        platform: Scope all corpus reads to this platform. Defaults to
+            ``"polymarket"`` because every shipped gate-model artifact
+            today was trained on Polymarket data; mixing in non-Polymarket
+            rows poisons the wallet/market accumulators.
 
     Returns:
         Total trade count folded.
@@ -42,10 +53,12 @@ def run_bootstrap(
     corpus_conn = init_corpus_db(corpus_db)
     daemon_conn = init_db(daemon_db)
     try:
-        metadata = _load_metadata(corpus_conn)
+        metadata = _load_metadata(corpus_conn, platform=platform)
         provider = LiveHistoryProvider(conn=daemon_conn, metadata=metadata)
         for cond_id, resolved_at, yes_won in corpus_conn.execute(
-            "SELECT condition_id, resolved_at, outcome_yes_won FROM market_resolutions"
+            "SELECT condition_id, resolved_at, outcome_yes_won "
+            "FROM market_resolutions WHERE platform = ?",
+            (platform,),
         ):
             provider.register_resolution(
                 condition_id=cond_id,
@@ -57,8 +70,10 @@ def run_bootstrap(
             SELECT ct.tx_hash, ct.asset_id, ct.wallet_address, ct.condition_id,
                    ct.outcome_side, ct.bs, ct.price, ct.size, ct.notional_usd, ct.ts
             FROM corpus_trades ct
+            WHERE ct.platform = ?
             ORDER BY ct.ts ASC, ct.tx_hash ASC
-            """
+            """,
+            (platform,),
         )
         n = 0
         for row in rows:
@@ -81,15 +96,17 @@ def run_bootstrap(
                 provider.observe_sell(trade)
             n += 1
             if n % log_every == 0:
-                _LOG.info("daemon.bootstrap.progress", trades_folded=n)
-        _LOG.info("daemon.bootstrap.done", trades_folded=n)
+                _LOG.info("daemon.bootstrap.progress", trades_folded=n, platform=platform)
+        _LOG.info("daemon.bootstrap.done", trades_folded=n, platform=platform)
         return n
     finally:
         daemon_conn.close()
         corpus_conn.close()
 
 
-def _load_metadata(conn: sqlite3.Connection) -> dict[str, MarketMetadata]:
+def _load_metadata(
+    conn: sqlite3.Connection, *, platform: str = "polymarket"
+) -> dict[str, MarketMetadata]:
     out: dict[str, MarketMetadata] = {}
     for cond_id, category, closed_at, opened_at in conn.execute(
         """
@@ -98,7 +115,9 @@ def _load_metadata(conn: sqlite3.Connection) -> dict[str, MarketMetadata]:
                COALESCE(closed_at, 0),
                COALESCE(enumerated_at, 0)
         FROM corpus_markets
-        """
+        WHERE platform = ?
+        """,
+        (platform,),
     ):
         out[cond_id] = MarketMetadata(
             condition_id=cond_id,

--- a/src/pscanner/scheduler.py
+++ b/src/pscanner/scheduler.py
@@ -169,7 +169,7 @@ class Scanner:
         if self._config.gate_model.enabled:
             self._live_history_provider = LiveHistoryProvider(
                 conn=self._db,
-                metadata=_load_corpus_metadata(),
+                metadata=_load_corpus_metadata(platform=self._config.gate_model.platform),
             )
         self._owns_clients = clients is None
         self._clients = clients or self._build_default_clients()
@@ -884,12 +884,20 @@ class Scanner:
             await self._clients.ticks_ws.close()
 
 
-def _load_corpus_metadata() -> dict[str, MarketMetadata]:
+def _load_corpus_metadata(*, platform: str = "polymarket") -> dict[str, MarketMetadata]:
     """Load corpus_markets metadata for the gate-model detector.
 
     Reads ``data/corpus.sqlite3`` if it exists; returns an empty dict if
     not. The dict is consumed by :class:`LiveHistoryProvider` for the
     ``market_metadata(condition_id)`` lookup that ``compute_features`` uses.
+
+    Args:
+        platform: Scope the SELECT to a single platform. Defaults to
+            ``"polymarket"``. Mixing platforms here would put non-Polymarket
+            markets in the metadata dict; with disjoint condition_id
+            namespaces today nothing breaks at inference time, but it's
+            wasted memory. The filter keeps the dict aligned with the
+            model's training scope.
 
     Empty-dict fallback is acceptable for v1: the detector handles
     ``KeyError`` from ``market_metadata`` by skipping the trade. Operators
@@ -908,7 +916,9 @@ def _load_corpus_metadata() -> dict[str, MarketMetadata]:
                    COALESCE(closed_at, 0),
                    COALESCE(enumerated_at, 0)
             FROM corpus_markets
-            """
+            WHERE platform = ?
+            """,
+            (platform,),
         ):
             cond_id, category, closed_at, opened_at = row
             out[cond_id] = MarketMetadata(

--- a/tests/daemon/test_bootstrap.py
+++ b/tests/daemon/test_bootstrap.py
@@ -82,3 +82,144 @@ def test_run_bootstrap_populates_live_tables(tmp_path: Path) -> None:
         daemon_conn.close()
     assert wallet.prior_trades_count == 1
     assert wallet.prior_buys_count == 1
+
+
+def _seed_mixed_platform_corpus(conn: sqlite3.Connection) -> None:
+    """Insert one Polymarket trade + one Manifold trade against the same
+    wallet-address-style key (different namespaces in practice, but the test
+    proves the platform filter even if a string happened to collide).
+    """
+    markets = CorpusMarketsRepo(conn)
+    markets.insert_pending(
+        CorpusMarket(
+            condition_id="0xpoly",
+            event_slug="poly-evt",
+            category="esports",
+            closed_at=1_700_001_000,
+            total_volume_usd=1000.0,
+            enumerated_at=1_699_900_000,
+            market_slug="poly-m",
+            platform="polymarket",
+        )
+    )
+    markets.insert_pending(
+        CorpusMarket(
+            condition_id="manifold-cond",
+            event_slug="m-evt",
+            category="politics",
+            closed_at=1_700_001_500,
+            total_volume_usd=2000.0,
+            enumerated_at=1_699_950_000,
+            market_slug="m-m",
+            platform="manifold",
+        )
+    )
+    trades = CorpusTradesRepo(conn)
+    trades.insert_batch(
+        [
+            CorpusTrade(
+                tx_hash="tx-poly",
+                asset_id="0xpoly-yes",
+                wallet_address="0xabc",
+                condition_id="0xpoly",
+                outcome_side="YES",
+                bs="BUY",
+                price=0.40,
+                size=100.0,
+                notional_usd=40.0,
+                ts=1_700_000_000,
+                platform="polymarket",
+            ),
+            CorpusTrade(
+                tx_hash="tx-manifold",
+                asset_id="manifold-yes",
+                wallet_address="manifold-user",
+                condition_id="manifold-cond",
+                outcome_side="YES",
+                bs="BUY",
+                price=0.55,
+                # 200 mana — above the 100-mana Manifold floor so the row lands.
+                size=200.0,
+                notional_usd=200.0,
+                ts=1_700_000_500,
+                platform="manifold",
+            ),
+        ]
+    )
+    resolutions = MarketResolutionsRepo(conn)
+    resolutions.upsert(
+        MarketResolution(
+            condition_id="0xpoly",
+            winning_outcome_index=0,
+            outcome_yes_won=1,
+            resolved_at=1_700_001_000,
+            source="gamma",
+            platform="polymarket",
+        ),
+        recorded_at=1_700_001_500,
+    )
+    resolutions.upsert(
+        MarketResolution(
+            condition_id="manifold-cond",
+            winning_outcome_index=0,
+            outcome_yes_won=0,
+            resolved_at=1_700_001_500,
+            source="manifold",
+            platform="manifold",
+        ),
+        recorded_at=1_700_001_700,
+    )
+
+
+def test_run_bootstrap_filters_by_platform_default_polymarket(tmp_path: Path) -> None:
+    corpus_path = tmp_path / "corpus.sqlite3"
+    daemon_path = tmp_path / "daemon.sqlite3"
+    corpus_conn = init_corpus_db(corpus_path)
+    try:
+        _seed_mixed_platform_corpus(corpus_conn)
+    finally:
+        corpus_conn.close()
+    daemon_conn = init_db(daemon_path)
+    daemon_conn.close()
+    n = run_bootstrap(corpus_db=corpus_path, daemon_db=daemon_path)
+    # Only the Polymarket trade should land; the Manifold one is filtered.
+    assert n == 1
+    daemon_conn = init_db(daemon_path)
+    try:
+        rows = daemon_conn.execute(
+            "SELECT wallet_address FROM wallet_state_live ORDER BY wallet_address"
+        ).fetchall()
+        market_rows = daemon_conn.execute(
+            "SELECT condition_id FROM market_state_live ORDER BY condition_id"
+        ).fetchall()
+    finally:
+        daemon_conn.close()
+    addresses = [r[0] for r in rows]
+    cond_ids = [r[0] for r in market_rows]
+    assert addresses == ["0xabc"]
+    assert "manifold-user" not in addresses
+    assert cond_ids == ["0xpoly"]
+    assert "manifold-cond" not in cond_ids
+
+
+def test_run_bootstrap_explicit_manifold_platform(tmp_path: Path) -> None:
+    corpus_path = tmp_path / "corpus.sqlite3"
+    daemon_path = tmp_path / "daemon.sqlite3"
+    corpus_conn = init_corpus_db(corpus_path)
+    try:
+        _seed_mixed_platform_corpus(corpus_conn)
+    finally:
+        corpus_conn.close()
+    daemon_conn = init_db(daemon_path)
+    daemon_conn.close()
+    n = run_bootstrap(corpus_db=corpus_path, daemon_db=daemon_path, platform="manifold")
+    assert n == 1
+    daemon_conn = init_db(daemon_path)
+    try:
+        addresses = [
+            r[0]
+            for r in daemon_conn.execute("SELECT wallet_address FROM wallet_state_live").fetchall()
+        ]
+    finally:
+        daemon_conn.close()
+    assert addresses == ["manifold-user"]

--- a/tests/scheduler/test_gate_model_wiring.py
+++ b/tests/scheduler/test_gate_model_wiring.py
@@ -14,8 +14,10 @@ import xgboost as xgb
 
 from pscanner.collectors.market_scoped_trades import MarketScopedTradeCollector
 from pscanner.config import Config, GateModelConfig, GateModelMarketFilterConfig
+from pscanner.corpus.db import init_corpus_db
+from pscanner.corpus.repos import CorpusMarket, CorpusMarketsRepo
 from pscanner.detectors.gate_model import GateModelDetector
-from pscanner.scheduler import Scanner, SchedulerClients
+from pscanner.scheduler import Scanner, SchedulerClients, _load_corpus_metadata
 
 
 def _make_stub_clients() -> SchedulerClients:
@@ -171,3 +173,49 @@ async def test_preflight_noops_when_gate_model_disabled(tmp_path: Path) -> None:
         scanner.preflight()  # no exception
     finally:
         await scanner.aclose()
+
+
+def test_load_corpus_metadata_filters_by_platform(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """``_load_corpus_metadata(platform=...)`` returns only that platform's markets."""
+    corpus_path = tmp_path / "corpus.sqlite3"
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "data").mkdir()
+    real_corpus_path = tmp_path / "data" / "corpus.sqlite3"
+    conn = init_corpus_db(real_corpus_path)
+    try:
+        markets = CorpusMarketsRepo(conn)
+        markets.insert_pending(
+            CorpusMarket(
+                condition_id="0xpoly",
+                event_slug="p",
+                category="esports",
+                closed_at=1_700_001_000,
+                total_volume_usd=1.0,
+                enumerated_at=1_699_900_000,
+                market_slug="p-m",
+                platform="polymarket",
+            )
+        )
+        markets.insert_pending(
+            CorpusMarket(
+                condition_id="manifold-cond",
+                event_slug="m",
+                category="politics",
+                closed_at=1_700_001_500,
+                total_volume_usd=2.0,
+                enumerated_at=1_699_950_000,
+                market_slug="m-m",
+                platform="manifold",
+            )
+        )
+    finally:
+        conn.close()
+    del corpus_path
+
+    poly = _load_corpus_metadata(platform="polymarket")
+    manifold = _load_corpus_metadata(platform="manifold")
+
+    assert set(poly.keys()) == {"0xpoly"}
+    assert set(manifold.keys()) == {"manifold-cond"}
+    assert poly["0xpoly"].category == "esports"
+    assert manifold["manifold-cond"].category == "politics"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -134,6 +134,7 @@ def test_gate_model_config_defaults() -> None:
     assert cfg.min_edge_pct == 0.01
     assert cfg.accepted_categories is None
     assert cfg.queue_max_size == 1024
+    assert cfg.platform == "polymarket"
 
 
 def test_gate_model_market_filter_defaults() -> None:


### PR DESCRIPTION
The daemon-side bootstrap (#78) and the scheduler's `_load_corpus_metadata` were reading every row in `corpus_trades` / `corpus_markets` / `market_resolutions` regardless of platform. After PR #84 (Manifold ingestion), corpora can hold Manifold rows whose `notional_usd` column is **mana-denominated, not USD**. Mixing those into `wallet_state_live` would poison `cumulative_buy_price_sum`, `bet_size_sum`, and `realized_pnl_usd` for any wallet the gate model sees — feeding the Polymarket-trained model rows from a different distribution.

Wallet-address namespaces don't overlap between platforms today (Polymarket 0x-hex, Manifold hash strings, Kalshi tickers), so existing daemon DBs aren't corrupt. But the bug wastes bootstrap time + disk on dead non-Polymarket rows and is a correctness time bomb for any future schema where platforms might share a key namespace.

## Summary

Adds `platform: str = "polymarket"` to:

- `run_bootstrap` + `_load_metadata` in `pscanner.daemon.bootstrap`
- `_load_corpus_metadata` in `pscanner.scheduler`
- `GateModelConfig` (operator-tunable; passes through to the scheduler's metadata loader)
- `pscanner daemon bootstrap-features --platform` CLI flag (choices: `polymarket` / `kalshi` / `manifold`; default `polymarket`)

All three SQL paths gain a `WHERE platform = ?` predicate. Default `"polymarket"` matches every shipped gate-model artifact and preserves existing behavior on Polymarket-only corpora.

Mirrors the platform-threading already in `pscanner.corpus.examples.build_features` and `pscanner.ml.streaming.open_dataset`.

## Test plan

- [x] `test_run_bootstrap_filters_by_platform_default_polymarket` — mixed-platform corpus + default `run_bootstrap` folds only Polymarket rows; Manifold wallet/market rows absent from `wallet_state_live` / `market_state_live`.
- [x] `test_run_bootstrap_explicit_manifold_platform` — `--platform manifold` folds only Manifold rows.
- [x] `test_load_corpus_metadata_filters_by_platform` — scheduler-side metadata loader returns disjoint key sets per platform.
- [x] `test_gate_model_config_defaults` — config default round-trips `platform == "polymarket"`.
- [x] `uv run pytest -q` — 1200 passing project-wide.
- [x] `uv run ruff check . && uv run ruff format --check .` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)