### PR TITLE
feat(scheduler): load market_resolutions into LiveHistoryProvider at boot

### DIFF
--- a/src/pscanner/scheduler.py
+++ b/src/pscanner/scheduler.py
@@ -171,6 +171,10 @@ class Scanner:
                 conn=self._db,
                 metadata=_load_corpus_metadata(platform=self._config.gate_model.platform),
             )
+            _load_corpus_resolutions(
+                self._live_history_provider,
+                platform=self._config.gate_model.platform,
+            )
         self._owns_clients = clients is None
         self._clients = clients or self._build_default_clients()
         self._renderer = TerminalRenderer()
@@ -928,3 +932,63 @@ def _load_corpus_metadata(*, platform: str = "polymarket") -> dict[str, MarketMe
                 opened_at=int(opened_at),
             )
     return out
+
+
+def _load_corpus_resolutions(provider: LiveHistoryProvider, *, platform: str = "polymarket") -> int:
+    """Load market_resolutions from the corpus DB into the provider.
+
+    Mirrors ``_load_corpus_metadata`` but populates the provider's in-memory
+    ``_resolutions`` dict so the lazy drain inside
+    :meth:`LiveHistoryProvider.wallet_state` can apply resolutions
+    accumulated during ``pscanner daemon bootstrap-features``.
+
+    Without this, ``prior_resolved_buys`` / ``prior_wins`` / ``prior_losses``
+    stay at zero forever — the bootstrap walk only stores buys to the
+    per-wallet ``unresolved_buys_json``; the drain triggers in
+    ``wallet_state(...)``, which checks the resolutions dict before
+    folding each buy. An empty resolutions dict means no buy ever drains.
+
+    Args:
+        provider: The :class:`LiveHistoryProvider` to populate.
+        platform: Scope the SELECT to a single platform. Default
+            ``"polymarket"``; non-Polymarket models would pass their own.
+
+    Returns:
+        Count of resolutions registered. Zero if the corpus DB is missing
+        (empty-dict fallback is acceptable for the same reasons documented
+        on ``_load_corpus_metadata``).
+    """
+    corpus_path = Path("data/corpus.sqlite3")
+    if not corpus_path.exists():
+        _LOG.warning("scanner.corpus_db_missing", path=str(corpus_path))
+        return 0
+    n = 0
+    with closing(sqlite3.connect(str(corpus_path))) as conn:
+        try:
+            cursor = conn.execute(
+                """
+                SELECT condition_id, resolved_at, outcome_yes_won
+                FROM market_resolutions
+                WHERE platform = ?
+                """,
+                (platform,),
+            )
+        except sqlite3.OperationalError as exc:
+            # ``market_resolutions`` predates the platform-column migration.
+            # Open the corpus via ``init_corpus_db`` to apply the schema
+            # migration before retry — same fallback path as the bootstrap.
+            _LOG.warning(
+                "scanner.corpus_db_unmigrated_market_resolutions",
+                err=str(exc),
+                path=str(corpus_path),
+            )
+            return 0
+        for cond_id, resolved_at, yes_won in cursor:
+            provider.register_resolution(
+                condition_id=cond_id,
+                resolved_at=int(resolved_at),
+                outcome_yes_won=int(yes_won),
+            )
+            n += 1
+    _LOG.info("scanner.resolutions_loaded", count=n, platform=platform)
+    return n

--- a/tests/scheduler/test_gate_model_wiring.py
+++ b/tests/scheduler/test_gate_model_wiring.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import Any
@@ -15,9 +16,21 @@ import xgboost as xgb
 from pscanner.collectors.market_scoped_trades import MarketScopedTradeCollector
 from pscanner.config import Config, GateModelConfig, GateModelMarketFilterConfig
 from pscanner.corpus.db import init_corpus_db
-from pscanner.corpus.repos import CorpusMarket, CorpusMarketsRepo
+from pscanner.corpus.repos import (
+    CorpusMarket,
+    CorpusMarketsRepo,
+    MarketResolution,
+    MarketResolutionsRepo,
+)
+from pscanner.daemon.live_history import LiveHistoryProvider
 from pscanner.detectors.gate_model import GateModelDetector
-from pscanner.scheduler import Scanner, SchedulerClients, _load_corpus_metadata
+from pscanner.scheduler import (
+    Scanner,
+    SchedulerClients,
+    _load_corpus_metadata,
+    _load_corpus_resolutions,
+)
+from pscanner.store.db import init_db
 
 
 def _make_stub_clients() -> SchedulerClients:
@@ -219,3 +232,169 @@ def test_load_corpus_metadata_filters_by_platform(tmp_path: Path, monkeypatch) -
     assert set(manifold.keys()) == {"manifold-cond"}
     assert poly["0xpoly"].category == "esports"
     assert manifold["manifold-cond"].category == "politics"
+
+
+def test_load_corpus_resolutions_populates_provider(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """Resolutions loaded at scheduler boot enable the lazy drain in wallet_state."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "data").mkdir()
+    real_corpus_path = tmp_path / "data" / "corpus.sqlite3"
+    conn = init_corpus_db(real_corpus_path)
+    try:
+        resolutions = MarketResolutionsRepo(conn)
+        resolutions.upsert(
+            MarketResolution(
+                condition_id="0xpoly-1",
+                winning_outcome_index=0,
+                outcome_yes_won=1,
+                resolved_at=1_700_001_000,
+                source="gamma",
+                platform="polymarket",
+            ),
+            recorded_at=1_700_001_500,
+        )
+        resolutions.upsert(
+            MarketResolution(
+                condition_id="0xpoly-2",
+                winning_outcome_index=0,
+                outcome_yes_won=0,
+                resolved_at=1_700_002_000,
+                source="gamma",
+                platform="polymarket",
+            ),
+            recorded_at=1_700_002_500,
+        )
+        resolutions.upsert(
+            MarketResolution(
+                condition_id="manifold-cond",
+                winning_outcome_index=0,
+                outcome_yes_won=1,
+                resolved_at=1_700_003_000,
+                source="manifold",
+                platform="manifold",
+            ),
+            recorded_at=1_700_003_500,
+        )
+    finally:
+        conn.close()
+
+    daemon_conn = init_db(tmp_path / "daemon.sqlite3")
+    try:
+        provider = LiveHistoryProvider(conn=daemon_conn, metadata={})
+        n = _load_corpus_resolutions(provider, platform="polymarket")
+        assert n == 2  # only Polymarket rows; the manifold row is filtered
+        assert provider.get_resolution("0xpoly-1") == (1_700_001_000, 1)
+        assert provider.get_resolution("0xpoly-2") == (1_700_002_000, 0)
+        assert provider.get_resolution("manifold-cond") is None
+    finally:
+        daemon_conn.close()
+
+
+def test_load_corpus_resolutions_returns_zero_when_corpus_missing(
+    tmp_path: Path,
+    monkeypatch,  # type: ignore[no-untyped-def]
+) -> None:
+    """Empty-dict fallback path mirrors `_load_corpus_metadata`'s contract."""
+    monkeypatch.chdir(tmp_path)
+    # No data/corpus.sqlite3 exists.
+    daemon_conn = init_db(tmp_path / "daemon.sqlite3")
+    try:
+        provider = LiveHistoryProvider(conn=daemon_conn, metadata={})
+        n = _load_corpus_resolutions(provider, platform="polymarket")
+    finally:
+        daemon_conn.close()
+    assert n == 0
+
+
+def test_load_corpus_resolutions_handles_unmigrated_market_resolutions(
+    tmp_path: Path,
+    monkeypatch,  # type: ignore[no-untyped-def]
+) -> None:
+    """Pre-platform corpus DBs (no ``platform`` column on ``market_resolutions``)
+    fall back to zero rather than crashing the daemon at boot.
+
+    The laptop and any pre-2026-05-04 corpus may have ``corpus_markets``
+    migrated but ``market_resolutions`` not yet (partial-migration state).
+    The function should warn and return 0 instead of bubbling
+    ``OperationalError`` up through ``Scanner.__init__``.
+    """
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "data").mkdir()
+    corpus_path = tmp_path / "data" / "corpus.sqlite3"
+    # Build a market_resolutions table WITHOUT the platform column —
+    # mirrors a pre-migration corpus snapshot.
+    conn = sqlite3.connect(str(corpus_path))
+    try:
+        conn.execute(
+            """
+            CREATE TABLE market_resolutions (
+              condition_id TEXT PRIMARY KEY,
+              winning_outcome_index INTEGER NOT NULL,
+              outcome_yes_won INTEGER NOT NULL,
+              resolved_at INTEGER NOT NULL,
+              source TEXT NOT NULL,
+              recorded_at INTEGER NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO market_resolutions VALUES (?, ?, ?, ?, ?, ?)",
+            ("0xtest", 0, 1, 1_700_001_000, "gamma", 1_700_001_500),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    daemon_conn = init_db(tmp_path / "daemon.sqlite3")
+    try:
+        provider = LiveHistoryProvider(conn=daemon_conn, metadata={})
+        n = _load_corpus_resolutions(provider, platform="polymarket")
+    finally:
+        daemon_conn.close()
+    assert n == 0
+    assert provider.get_resolution("0xtest") is None
+
+
+@pytest.mark.asyncio
+async def test_scanner_loads_resolutions_when_gate_model_enabled(tmp_path: Path) -> None:
+    """Scanner.__init__ calls _load_corpus_resolutions on the live provider.
+
+    End-to-end: seed the corpus with resolutions, enable gate_model, build a
+    Scanner, observe that provider.get_resolution returns the loaded entry.
+    """
+    artifact_dir = tmp_path / "model"
+    _train_dummy_model(artifact_dir)
+    (tmp_path / "data").mkdir()
+    real_corpus_path = tmp_path / "data" / "corpus.sqlite3"
+    conn = init_corpus_db(real_corpus_path)
+    try:
+        resolutions = MarketResolutionsRepo(conn)
+        resolutions.upsert(
+            MarketResolution(
+                condition_id="0xseed",
+                winning_outcome_index=0,
+                outcome_yes_won=1,
+                resolved_at=1_700_001_000,
+                source="gamma",
+                platform="polymarket",
+            ),
+            recorded_at=1_700_001_500,
+        )
+    finally:
+        conn.close()
+    cfg = _make_config(artifact_dir=artifact_dir, gate_enabled=True, filter_enabled=True)
+    clients = _make_stub_clients()
+    # Scanner reads ``data/corpus.sqlite3`` relative to cwd; chdir into the
+    # seeded tmp dir so it picks up the test fixture.
+    monkeypatch_setter = pytest.MonkeyPatch()
+    monkeypatch_setter.chdir(tmp_path)
+    try:
+        scanner = Scanner(config=cfg, db_path=tmp_path / "daemon.sqlite3", clients=clients)
+    finally:
+        monkeypatch_setter.undo()
+    try:
+        provider = scanner._live_history_provider
+        assert provider is not None
+        assert provider.get_resolution("0xseed") == (1_700_001_000, 1)
+    finally:
+        await scanner.aclose()


### PR DESCRIPTION
The bootstrap-features path walks `corpus_trades` but never calls `provider.wallet_state(...)` — drains only happen inside that getter, so every buy lands in `unresolved_buys_json` and `prior_resolved_buys` / `prior_wins` / `prior_losses` stay zero in the bulk-write dump. This is fine *if* the daemon registers resolutions at boot so the lazy drain triggers on first `wallet_state` query per wallet, but the scheduler only loaded `market_metadata` from the corpus, not `market_resolutions`.

Surfaced when validating the desktop's bootstrap output: 974,000 wallets, all with `prior_resolved_buys = 0`. At runtime every `gate_buy` alert would score on null wallet-quality features (`win_rate = None`, `is_high_quality_wallet = 0`, `edge_confidence_weighted = 0`, etc.) regardless of the wallet's actual history. The model handles those (encoder `__none__` token + xgboost missing-direction) but the predictions wouldn't reflect the wallet-quality signal that matters most in the v2 model's top-25-by-gain features.

## Summary

- New `_load_corpus_resolutions(provider, *, platform="polymarket") -> int` in `src/pscanner/scheduler.py`, parallel to `_load_corpus_metadata`. Reads `data/corpus.sqlite3` if it exists; calls `provider.register_resolution(...)` for each row scoped by platform.
- `Scanner.__init__` calls the new function right after constructing the `LiveHistoryProvider`.
- Defensive `sqlite3.OperationalError` catch handles partial-migration corpora (where `corpus_markets` has the platform column but `market_resolutions` doesn't yet — surfaced on the laptop's pre-migration corpus while running the scheduler tests).
- Empty-dict fallback when the corpus DB is absent (mirrors `_load_corpus_metadata`).

## Test plan

- [x] `test_load_corpus_resolutions_populates_provider` — happy path with a migrated corpus DB; platform filter excludes Manifold rows.
- [x] `test_load_corpus_resolutions_returns_zero_when_corpus_missing` — empty-dict fallback.
- [x] `test_load_corpus_resolutions_handles_unmigrated_market_resolutions` — pre-platform schema returns 0 instead of raising.
- [x] `test_scanner_loads_resolutions_when_gate_model_enabled` — end-to-end through `Scanner.__init__`.
- [x] `uv run pytest -q` — 1206 passing project-wide (4 new tests on top of the prior 1202).
- [x] `uv run ruff check . && uv run ruff format --check .` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)