### PR TITLE
fix(collectors): map Polymarket camelCase trade-row keys correctly

### DIFF
--- a/src/pscanner/collectors/market_scoped_trades.py
+++ b/src/pscanner/collectors/market_scoped_trades.py
@@ -104,17 +104,33 @@ class MarketScopedTradeCollector:
         return n
 
     def _row_to_wallet_trade(self, row: dict[str, Any]) -> WalletTrade | None:
+        """Map a Polymarket ``/trades?market=`` row to ``WalletTrade``.
+
+        Field name aliases mirror :func:`pscanner.collectors.trades._event_to_trade`
+        — Polymarket's data-api emits camelCase keys (``transactionHash``,
+        ``proxyWallet``, ``conditionId``, ``asset``, ``usdcSize``). Snake-case
+        fallbacks (``tx_hash``, ``wallet_address``, ``condition_id``,
+        ``asset_id``, ``notional_usd``) cover test fixtures and any future
+        snake-keyed source.
+        """
+        tx_hash = str(row.get("transactionHash") or row.get("tx_hash") or "")
+        if not tx_hash:
+            _LOG.warning("market_scoped.bad_row", row_keys=list(row.keys()))
+            return None
         try:
-            tx_hash = str(row["tx_hash"])
-            asset_id = str(row["asset_id"])
-            bs = str(row["bs"]).upper()
-            wallet = str(row["wallet_address"])
-            condition_id = str(row["condition_id"])
+            asset_id = str(row.get("asset") or row.get("asset_id") or "")
+            bs = str(row.get("side") or row.get("bs") or "").upper()
+            wallet = str(row.get("proxyWallet") or row.get("wallet_address") or "")
+            condition_id = str(row.get("conditionId") or row.get("condition_id") or "")
             price = float(row["price"])
             size = float(row["size"])
-            notional = float(row.get("notional_usd", price * size))
+            usd_raw = row.get("usdcSize", row.get("notional_usd"))
+            usd_value = float(usd_raw) if usd_raw is not None else price * size
             timestamp = int(row["timestamp"])
         except (KeyError, TypeError, ValueError):
+            _LOG.warning("market_scoped.bad_row", row_keys=list(row.keys()))
+            return None
+        if not (asset_id and bs and wallet and condition_id):
             _LOG.warning("market_scoped.bad_row", row_keys=list(row.keys()))
             return None
         return WalletTrade(
@@ -125,7 +141,7 @@ class MarketScopedTradeCollector:
             condition_id=ConditionId(condition_id),
             size=size,
             price=price,
-            usd_value=notional,
+            usd_value=usd_value,
             status="filled",
             source="market_scoped",
             timestamp=timestamp,

--- a/tests/collectors/test_market_scoped_trades.py
+++ b/tests/collectors/test_market_scoped_trades.py
@@ -178,6 +178,77 @@ async def test_poll_once_dispatches_new_trades() -> None:
 
 
 @pytest.mark.asyncio
+async def test_poll_once_handles_polymarket_camelcase_keys() -> None:
+    """Pin the live Polymarket ``/trades?market=`` row shape.
+
+    Surfaced during the 2026-05-08 smoke run on the desktop: the API
+    returns camelCase keys (``transactionHash``, ``proxyWallet``,
+    ``conditionId``, ``asset``, ``usdcSize``) — the original
+    ``_row_to_wallet_trade`` was looking up snake_case (``tx_hash``,
+    ``wallet_address``, ``condition_id``, ``asset_id``, ``notional_usd``)
+    and warning ``market_scoped.bad_row`` on every observed trade. This
+    test pins the canonical keys so that regression can't recur.
+    """
+    cfg = GateModelMarketFilterConfig(
+        enabled=True,
+        accepted_categories=("esports",),
+        min_volume_24h_usd=0,
+    )
+    event = _make_event(
+        slug="ev",
+        tags=["Esports"],
+        markets=[_make_market(condition_id="0xc1", volume=100_000)],
+    )
+    gamma = _FakeGammaClient([event])
+    data = _FakeDataClient(
+        by_market={
+            "0xc1": [
+                {
+                    # Real Polymarket /trades response shape (camelCase).
+                    "transactionHash": "0xabc123",
+                    "asset": "0xasset1",
+                    "side": "BUY",
+                    "proxyWallet": "0xwallet",
+                    "conditionId": "0xc1",
+                    "outcome": "Yes",
+                    "outcomeIndex": 0,
+                    "price": 0.42,
+                    "size": 100.0,
+                    "usdcSize": 42.0,
+                    "timestamp": 1_700_000_100,
+                    "title": "irrelevant",
+                    "slug": "ev-slug",
+                    "name": "Trader",
+                    "pseudonym": "Trader",
+                    "bio": "",
+                    "profileImage": "",
+                    "profileImageOptimized": "",
+                    "icon": "",
+                    "eventSlug": "ev",
+                }
+            ]
+        }
+    )
+    collector = MarketScopedTradeCollector(config=cfg, gamma=gamma, data_client=data)
+    received: list[WalletTrade] = []
+    collector.subscribe_new_trade(received.append)
+    await collector.refresh_market_set()
+    n = await collector.poll_once()
+    assert n == 1
+    assert len(received) == 1
+    trade = received[0]
+    assert trade.transaction_hash == "0xabc123"
+    assert trade.asset_id == "0xasset1"
+    assert trade.side == "BUY"
+    assert trade.wallet == "0xwallet"
+    assert trade.condition_id == "0xc1"
+    assert trade.price == 0.42
+    assert trade.size == 100.0
+    assert trade.usd_value == 42.0
+    assert trade.timestamp == 1_700_000_100
+
+
+@pytest.mark.asyncio
 async def test_poll_once_advances_last_seen_ts() -> None:
     cfg = GateModelMarketFilterConfig(
         enabled=True, accepted_categories=("esports",), min_volume_24h_usd=0


### PR DESCRIPTION
\`MarketScopedTradeCollector._row_to_wallet_trade\` was looking up snake_case keys (\`tx_hash\`, \`wallet_address\`, \`condition_id\`, \`asset_id\`, \`notional_usd\`) but Polymarket's \`/trades?market=\` endpoint returns camelCase (\`transactionHash\`, \`proxyWallet\`, \`conditionId\`, \`asset\`, \`usdcSize\`).

Surfaced during the 2026-05-08 smoke run on the desktop: the collector correctly enumerated 10K+ open events, narrowed to esports, polled each market's trades, and then logged \`market_scoped.bad_row\` for every single returned row — the dict had the right data under the wrong key names. No alerts could fire.

## Summary

Field mapping now mirrors \`pscanner.collectors.trades._event_to_trade\`:

| Field | Primary (API) | Fallback (test fixtures) |
|---|---|---|
| transactionHash | transactionHash | tx_hash |
| asset | asset | asset_id |
| side | side | bs |
| proxyWallet | proxyWallet | wallet_address |
| conditionId | conditionId | condition_id |
| usdcSize | usdcSize | notional_usd → price * size |
| price, size, timestamp | (same as before, no aliases needed) | |

Empty-string guards on the resolved fields surface genuinely malformed rows via the existing \`bad_row\` warning.

## Test plan

- [x] \`test_poll_once_handles_polymarket_camelcase_keys\` — pins the canonical Polymarket \`/trades\` response shape including noise fields (\`profileImage\`, \`pseudonym\`, \`bio\`, \`outcomeIndex\`, \`title\`, \`slug\`); asserts every \`WalletTrade\` field populates correctly.
- [x] Existing snake-case fixture tests pass via the fallback chain.
- [x] \`uv run pytest -q\` — 1207 passing project-wide.
- [x] \`uv run ruff check . && uv run ruff format --check .\` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)