### PR TITLE
fix(#103): seed MarketCacheRepo from MarketScopedTradeCollector

### DIFF
--- a/src/pscanner/collectors/market_scoped_trades.py
+++ b/src/pscanner/collectors/market_scoped_trades.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
     from pscanner.daemon.live_history import LiveHistoryProvider
     from pscanner.poly.data import DataClient
     from pscanner.poly.gamma import GammaClient
+    from pscanner.store.repo import MarketCacheRepo
 
 _LOG = structlog.get_logger(__name__)
 _FAR_FUTURE_TS = 2_000_000_000  # ~2033; well past any current trade timestamp
@@ -45,6 +46,7 @@ class MarketScopedTradeCollector:
         gamma: GammaClient,
         data_client: DataClient,
         provider: LiveHistoryProvider | None = None,
+        market_cache: MarketCacheRepo | None = None,
     ) -> None:
         """Initialize the collector with configuration and API clients.
 
@@ -52,11 +54,17 @@ class MarketScopedTradeCollector:
         candidate market enumerated by :meth:`refresh_market_set`. This is how
         live open markets (not yet in ``corpus_markets``) become visible to
         :class:`GateModelDetector` (issue #102).
+
+        ``market_cache``, when supplied, receives an upsert of every candidate
+        :class:`Market` so :class:`GateModelDetector._resolve_outcome_side` can
+        map ``trade.asset_id`` to YES/NO. In a gate-model-only daemon config,
+        no other code path populates the cache (issue #103).
         """
         self._config = config
         self._gamma = gamma
         self._data_client = data_client
         self._provider = provider
+        self._market_cache = market_cache
         self._markets: list[str] = []
         self._callbacks: list[Callable[[WalletTrade], None]] = []
         self._last_seen_ts: dict[str, int] = {}
@@ -105,6 +113,8 @@ class MarketScopedTradeCollector:
                             opened_at=0,
                         ),
                     )
+                if self._market_cache is not None:
+                    self._market_cache.upsert(market)
         candidates.sort(reverse=True)
         selected = [cid for _, cid in candidates[: self._config.max_markets]]
         self._markets = selected

--- a/src/pscanner/scheduler.py
+++ b/src/pscanner/scheduler.py
@@ -332,6 +332,7 @@ class Scanner:
                 gamma=self._clients.gamma_client,
                 data_client=self._clients.data_client,
                 provider=self._live_history_provider,
+                market_cache=self._market_cache_repo,
             )
         return collectors
 

--- a/tests/collectors/test_market_scoped_trades.py
+++ b/tests/collectors/test_market_scoped_trades.py
@@ -13,9 +13,10 @@ import pytest
 from pscanner.collectors.market_scoped_trades import MarketScopedTradeCollector
 from pscanner.config import GateModelMarketFilterConfig
 from pscanner.daemon.live_history import LiveHistoryProvider
+from pscanner.poly.ids import ConditionId
 from pscanner.poly.models import Event, Market
 from pscanner.store.db import init_db
-from pscanner.store.repo import WalletTrade
+from pscanner.store.repo import MarketCacheRepo, WalletTrade
 from pscanner.util.clock import FakeClock
 
 
@@ -397,3 +398,63 @@ async def test_refresh_populates_provider_metadata_for_every_candidate(
     # Politics market is filtered out at the category gate.
     with pytest.raises(KeyError):
         provider.market_metadata("0xMP")
+
+
+@pytest.mark.asyncio
+async def test_refresh_upserts_market_cache_for_every_candidate(
+    tmp_path: Path,
+) -> None:
+    """`refresh_market_set` upserts MarketCacheRepo for every category-matching market.
+
+    Issue #103: in a gate-model-only config, no other code path populates
+    market_cache, so `GateModelDetector._resolve_outcome_side` finds no cached
+    market and silently drops every trade. The collector must seed the cache
+    from the same gamma response it already has in hand.
+    """
+    cfg = GateModelMarketFilterConfig(
+        enabled=True,
+        accepted_categories=("esports",),
+        min_volume_24h_usd=10.0,
+        max_markets=2,
+    )
+    esports_a = _make_event(
+        slug="ev-a",
+        tags=["Esports"],
+        markets=[_make_market(condition_id="0xMA", volume=500.0)],
+    )
+    esports_b = _make_event(
+        slug="ev-b",
+        tags=["Esports"],
+        markets=[
+            _make_market(condition_id="0xMB1", volume=400.0),
+            _make_market(condition_id="0xMB2", volume=15.0),  # passes floor; below top-N
+        ],
+    )
+    politics = _make_event(
+        slug="ev-p",
+        tags=["Politics"],
+        markets=[_make_market(condition_id="0xMP", volume=99999.0)],
+    )
+    gamma = _FakeGammaClient([esports_a, esports_b, politics])
+    data_client = _FakeDataClient(by_market={})
+
+    db_path = tmp_path / "daemon.sqlite3"
+    conn = init_db(db_path)
+    try:
+        market_cache = MarketCacheRepo(conn)
+        collector = MarketScopedTradeCollector(
+            config=cfg,
+            gamma=gamma,  # type: ignore[arg-type]  # ty:ignore[invalid-argument-type]
+            data_client=data_client,  # type: ignore[arg-type]  # ty:ignore[invalid-argument-type]
+            market_cache=market_cache,
+        )
+        await collector.refresh_market_set()
+
+        # All three esports markets cached — including the one below top-N.
+        assert market_cache.get_by_condition_id(ConditionId("0xMA")) is not None
+        assert market_cache.get_by_condition_id(ConditionId("0xMB1")) is not None
+        assert market_cache.get_by_condition_id(ConditionId("0xMB2")) is not None
+        # Politics market is filtered out at the category gate.
+        assert market_cache.get_by_condition_id(ConditionId("0xMP")) is None
+    finally:
+        conn.close()

--- a/tests/scheduler/test_gate_model_wiring.py
+++ b/tests/scheduler/test_gate_model_wiring.py
@@ -151,6 +151,9 @@ async def test_scanner_builds_gate_model_when_enabled(tmp_path: Path) -> None:
         # seed metadata for currently-open markets.
         assert scanner._live_history_provider is not None
         assert collector._provider is scanner._live_history_provider
+        # Issue #103: collector must reference the market_cache so it can
+        # upsert candidate markets for `_resolve_outcome_side` lookups.
+        assert collector._market_cache is scanner._market_cache_repo
     finally:
         await scanner.aclose()
 


### PR DESCRIPTION
## Summary

- `MarketScopedTradeCollector.__init__` accepts an optional `market_cache: MarketCacheRepo | None`.
- `refresh_market_set` calls `market_cache.upsert(market)` for every category-and-volume-passing candidate (including markets below the top-N cutoff, mirroring the metadata-seeding pattern from #102).
- `Scanner._build_collectors` wires `market_cache=self._market_cache_repo`.

Without this, in a gate-model-only daemon config no code path populates `market_cache` (the lazy upserts in `WhalesDetector` and `PaperTrader` don't run), so `GateModelDetector._resolve_outcome_side` always returns `""` and every observed trade silently no-ops.

## Test plan

- [x] `uv run pytest -q` — 1218 passed
- [x] `uv run ruff check . && uv run ruff format --check .` — clean
- [x] `uv run ty check` on touched files — clean
- [ ] Smoke run on the desktop produces at least one `alert.emitted detector=gate_buy` row (acceptance criterion 5; manual verification per issue)

Closes #103.