### PR TITLE
fix(corpus): dedupe duckdb final-join to match python INSERT OR IGNORE

### DIFF
--- a/src/pscanner/corpus/_duckdb_engine.py
+++ b/src/pscanner/corpus/_duckdb_engine.py
@@ -670,6 +670,26 @@ def _final_join_to_v2(scratch: duckdb.DuckDBPyConnection, *, platform: str, now_
     f-string interpolation, preserving Task 3's parameterization defense.
     The only f-string interpolation in this SQL is _V2_TABLE (table name)
     and col_list (derived from canonical TRAINING_EXAMPLES_COLUMNS).
+
+    Dedup contract: ``training_examples_v2`` has a UNIQUE constraint on
+    ``(platform, tx_hash, asset_id, wallet_address)``. ``corpus_trades``
+    nominally enforces the same key via its PRIMARY KEY, but legacy
+    on-disk corpora (rows that predate the constraint) may contain
+    duplicates. The python engine swallows these via ``INSERT OR IGNORE``
+    on ``training_examples``; DuckDB's sqlite_scanner extension rejects
+    both ``INSERT OR IGNORE`` and ``ON CONFLICT DO NOTHING`` ("Database
+    type 'sqlite' does not support MERGE INTO or ON CONFLICT"), so we
+    dedup at the SELECT source via ``QUALIFY ROW_NUMBER() = 1``.
+
+    Subtle parity caveat: with both engines deduping, they agree on row
+    count and primary key but may disagree on row CONTENTS for duplicate
+    keys. Python iterates ``corpus_trades`` ordered by ``(ts, tx_hash,
+    asset_id)`` and ``INSERT OR IGNORE`` keeps the FIRST-iterated row
+    (earliest ts). We mirror that here by partitioning on the v2 unique
+    key and ordering by ``(wa.event_ts, wa.kind_priority, wa.tx_hash,
+    wa.asset_id)``. The real fix is at the ingest layer (don't re-insert
+    overlapping trades); this guarantees the build doesn't crash on
+    legacy corpora that already have the dups.
     """
     col_list = ", ".join(TRAINING_EXAMPLES_COLUMNS)
     scratch.execute(
@@ -824,6 +844,15 @@ def _final_join_to_v2(scratch: duckdb.DuckDBPyConnection, *, platform: str, now_
         LEFT JOIN market_aggs ma
             USING (condition_id, event_ts, kind_priority, tx_hash, asset_id)
         WHERE wa.is_buy_only = 1
+        -- Match python engine's INSERT OR IGNORE semantics on duplicate
+        -- (tx_hash, asset_id, wallet_address) tuples in legacy corpora.
+        -- ORDER BY (event_ts, kind_priority, tx_hash, asset_id) mirrors
+        -- python's iter_chronological order so the kept row is the
+        -- earliest-ts dup (see docstring).
+        QUALIFY ROW_NUMBER() OVER (
+            PARTITION BY wa.tx_hash, wa.asset_id, wa.wallet_address
+            ORDER BY wa.event_ts, wa.kind_priority, wa.tx_hash, wa.asset_id
+        ) = 1
         """,  # noqa: S608 — _V2_TABLE is a module-level literal; platform/now_ts bound below
         [platform, now_ts],
     )

--- a/src/pscanner/corpus/_duckdb_engine.py
+++ b/src/pscanner/corpus/_duckdb_engine.py
@@ -27,6 +27,7 @@ _PLATFORMS: Final[frozenset[str]] = frozenset({"polymarket", "kalshi", "manifold
 _SCRATCH_FILENAME: Final[str] = "build_scratch.duckdb"
 _TE_LOCAL_TABLE: Final[str] = "training_examples_v2_local"
 _COPY_BATCH_SIZE: Final[int] = 10000
+_COPY_COMMIT_EVERY_ROWS: Final[int] = 100_000
 
 # Categories that may appear in events.category. Drawn from
 # pscanner.categories.Category enum plus the "unknown" sentinel used
@@ -151,14 +152,19 @@ def build_features_duckdb(
             name="final_join",
             fn=lambda: _final_join_to_v2(scratch, platform=platform, now_ts=now_ts),
         )
+        # Detach corpus from DuckDB BEFORE stdlib sqlite3 opens the same file.
+        # DuckDB's sqlite_scanner uses mmap reads on the attached SQLite;
+        # concurrent stdlib-write through WAL triggers SIGBUS around 480 MB
+        # of accumulated WAL when the kernel tries to extend the mmap region.
+        # See issue #131.
+        corpus_path = _detach_corpus(scratch)
         _run_stage(
             scratch,
             name="copy_to_sqlite",
             fn=lambda: _copy_to_sqlite(scratch, db_path=db_path),
         )
 
-        n_rows = _count_v2(scratch)
-        corpus_path = _detach_corpus(scratch)
+        n_rows = _count_v2_sqlite(db_path)
     finally:
         scratch.close()
 
@@ -193,7 +199,11 @@ def _run_stage(
         "stage3_market_aggs": "market_aggs",
         "stage4_wallet_cat": "wallet_cat_summary",
         "final_join": _TE_LOCAL_TABLE,
-        "copy_to_sqlite": f"corpus.{_V2_TABLE}",
+        # copy_to_sqlite runs after corpus is detached from DuckDB, so the
+        # heartbeat can't poll corpus.training_examples_v2 anymore. The
+        # stage's dups_dropped + stage_done elapsed_seconds logs cover what
+        # we need for observability.
+        "copy_to_sqlite": None,
     }.get(name)
     heartbeat = threading.Thread(
         target=_heartbeat_loop,
@@ -890,13 +900,22 @@ def _copy_to_sqlite(scratch: duckdb.DuckDBPyConnection, *, db_path: Path) -> int
         landed_before = conn.execute(
             f"SELECT COUNT(*) FROM {_V2_TABLE}"  # noqa: S608 — _V2_TABLE is a module-level literal
         ).fetchone()[0]
+        rows_since_commit = 0
         while True:
             batch = cursor.fetchmany(_COPY_BATCH_SIZE)
             if not batch:
                 break
             source_rows += len(batch)
             conn.executemany(insert_sql, batch)
-        conn.commit()
+            rows_since_commit += len(batch)
+            # Cap WAL growth — a single end-of-stream commit lets the WAL
+            # balloon to multi-hundred MB on the production corpus, which
+            # collides with DuckDB's mmap on the same file (see issue #131).
+            if rows_since_commit >= _COPY_COMMIT_EVERY_ROWS:
+                conn.commit()
+                rows_since_commit = 0
+        if rows_since_commit > 0:
+            conn.commit()
         landed_after = conn.execute(
             f"SELECT COUNT(*) FROM {_V2_TABLE}"  # noqa: S608 — _V2_TABLE is a module-level literal
         ).fetchone()[0]
@@ -915,9 +934,20 @@ def _copy_to_sqlite(scratch: duckdb.DuckDBPyConnection, *, db_path: Path) -> int
     return landed
 
 
-def _count_v2(duck: duckdb.DuckDBPyConnection) -> int:
-    row = duck.execute(f"SELECT COUNT(*) FROM corpus.{_V2_TABLE}").fetchone()  # noqa: S608 — _V2_TABLE is a module-level literal
-    return int(row[0]) if row else 0
+def _count_v2_sqlite(db_path: Path) -> int:
+    """Row count of training_examples_v2 via stdlib sqlite3.
+
+    Reads via a fresh sqlite3 connection rather than via DuckDB's attach
+    because the orchestrator detaches corpus before copy_to_sqlite runs
+    (concurrent mmap-read + stdlib-write triggers SIGBUS around 480 MB
+    of WAL — see issue #131).
+    """
+    conn = sqlite3.connect(db_path)
+    try:
+        row = conn.execute(f"SELECT COUNT(*) FROM {_V2_TABLE}").fetchone()  # noqa: S608 — _V2_TABLE is a module-level literal
+        return int(row[0]) if row else 0
+    finally:
+        conn.close()
 
 
 def _detach_corpus(duck: duckdb.DuckDBPyConnection) -> str:

--- a/src/pscanner/corpus/_duckdb_engine.py
+++ b/src/pscanner/corpus/_duckdb_engine.py
@@ -25,6 +25,8 @@ _V2_TABLE: Final[str] = "training_examples_v2"
 _V2_INDEX_PREFIX: Final[str] = "idx_te_v2_"
 _PLATFORMS: Final[frozenset[str]] = frozenset({"polymarket", "kalshi", "manifold"})
 _SCRATCH_FILENAME: Final[str] = "build_scratch.duckdb"
+_TE_LOCAL_TABLE: Final[str] = "training_examples_v2_local"
+_COPY_BATCH_SIZE: Final[int] = 10000
 
 # Categories that may appear in events.category. Drawn from
 # pscanner.categories.Category enum plus the "unknown" sentinel used
@@ -149,6 +151,11 @@ def build_features_duckdb(
             name="final_join",
             fn=lambda: _final_join_to_v2(scratch, platform=platform, now_ts=now_ts),
         )
+        _run_stage(
+            scratch,
+            name="copy_to_sqlite",
+            fn=lambda: _copy_to_sqlite(scratch, db_path=db_path),
+        )
 
         n_rows = _count_v2(scratch)
         corpus_path = _detach_corpus(scratch)
@@ -170,7 +177,7 @@ def _run_stage(
     scratch: duckdb.DuckDBPyConnection,
     *,
     name: str,
-    fn: Callable[[], None],
+    fn: Callable[[], object],
 ) -> None:
     """Run a single stage with logging + heartbeat thread.
 
@@ -185,7 +192,8 @@ def _run_stage(
         "stage2_wallet_aggs": "wallet_aggs",
         "stage3_market_aggs": "market_aggs",
         "stage4_wallet_cat": "wallet_cat_summary",
-        "final_join": f"corpus.{_V2_TABLE}",
+        "final_join": _TE_LOCAL_TABLE,
+        "copy_to_sqlite": f"corpus.{_V2_TABLE}",
     }.get(name)
     heartbeat = threading.Thread(
         target=_heartbeat_loop,
@@ -660,41 +668,46 @@ def _stage4_wallet_cat(scratch: duckdb.DuckDBPyConnection) -> None:
 
 
 def _final_join_to_v2(scratch: duckdb.DuckDBPyConnection, *, platform: str, now_ts: int) -> None:
-    """Join the four stage outputs and INSERT into corpus.training_examples_v2.
+    """Build training_examples_v2_local as a DuckDB-native table in scratch.
 
     All staged inputs live in the scratch DuckDB. ``resolutions`` is the
-    TEMP table from _materialize_trades; ``corpus`` is the attached
-    SQLite database the v2 table lives in.
+    TEMP table from _materialize_trades; ``wallet_aggs`` / ``market_aggs``
+    / ``wallet_cat_summary`` are the prior stages' outputs.
 
     ``platform`` and ``now_ts`` are passed via DuckDB ? bindings, NOT
     f-string interpolation, preserving Task 3's parameterization defense.
-    The only f-string interpolation in this SQL is _V2_TABLE (table name)
+    The only f-string interpolation in this SQL is the local table name
     and col_list (derived from canonical TRAINING_EXAMPLES_COLUMNS).
 
-    Dedup contract: ``training_examples_v2`` has a UNIQUE constraint on
-    ``(platform, tx_hash, asset_id, wallet_address)``. ``corpus_trades``
-    nominally enforces the same key via its PRIMARY KEY, but legacy
-    on-disk corpora (rows that predate the constraint) may contain
-    duplicates. The python engine swallows these via ``INSERT OR IGNORE``
-    on ``training_examples``; DuckDB's sqlite_scanner extension rejects
-    both ``INSERT OR IGNORE`` and ``ON CONFLICT DO NOTHING`` ("Database
-    type 'sqlite' does not support MERGE INTO or ON CONFLICT"), so we
-    dedup at the SELECT source via ``QUALIFY ROW_NUMBER() = 1``.
+    Why DuckDB-native instead of cross-database INSERT into the attached
+    SQLite ``training_examples_v2``:
 
-    Subtle parity caveat: with both engines deduping, they agree on row
-    count and primary key but may disagree on row CONTENTS for duplicate
-    keys. Python iterates ``corpus_trades`` ordered by ``(ts, tx_hash,
-    asset_id)`` and ``INSERT OR IGNORE`` keeps the FIRST-iterated row
-    (earliest ts). We mirror that here by partitioning on the v2 unique
-    key and ordering by ``(wa.event_ts, wa.kind_priority, wa.tx_hash,
-    wa.asset_id)``. The real fix is at the ingest layer (don't re-insert
-    overlapping trades); this guarantees the build doesn't crash on
-    legacy corpora that already have the dups.
+      * The cross-database INSERT through DuckDB's sqlite_scanner extension
+        crashed at production scale with a UNIQUE constraint violation we
+        could not explain via the SELECT semantics (corpus_trades was
+        verified dup-free at the source PRIMARY KEY level, and the
+        pipeline SQL was verified fanout-free on a 50K-trade slice).
+      * The previous workaround was a ``QUALIFY ROW_NUMBER() OVER
+        (PARTITION BY tx_hash, asset_id, wallet_address ORDER BY ...) = 1``
+        clause on the SELECT, which dedup'd correctly but cost ~35 GB
+        of spill and ~14 min of runtime at production scale.
+      * Writing to a DuckDB-native intermediate sidesteps the
+        sqlite_scanner extension's INSERT path entirely, eliminates the
+        QUALIFY window, and pushes dedup responsibility to the next
+        stage (_copy_to_sqlite) which uses Python's stdlib sqlite3 with
+        ``INSERT OR IGNORE`` (matching the python engine's
+        ``repos._INSERT_SQL`` semantics on duplicate keys).
+
+    Tradeoff: removing QUALIFY drops the explicit chronological tiebreak
+    (earliest-ts dup wins). The python engine's tiebreak is dict-insertion
+    order in CPython, which is iter_chronological-driven and thus de-facto
+    earliest, but it isn't a hard guarantee either. In practice
+    ``corpus_trades`` is dup-free at the source, so this tradeoff only
+    matters for legacy on-disk corpora that predate the PRIMARY KEY.
     """
-    col_list = ", ".join(TRAINING_EXAMPLES_COLUMNS)
     scratch.execute(
         f"""
-        INSERT INTO corpus.{_V2_TABLE} ({col_list})
+        CREATE OR REPLACE TABLE {_TE_LOCAL_TABLE} AS
         SELECT
             ? AS platform,
             wa.tx_hash,
@@ -844,18 +857,62 @@ def _final_join_to_v2(scratch: duckdb.DuckDBPyConnection, *, platform: str, now_
         LEFT JOIN market_aggs ma
             USING (condition_id, event_ts, kind_priority, tx_hash, asset_id)
         WHERE wa.is_buy_only = 1
-        -- Match python engine's INSERT OR IGNORE semantics on duplicate
-        -- (tx_hash, asset_id, wallet_address) tuples in legacy corpora.
-        -- ORDER BY (event_ts, kind_priority, tx_hash, asset_id) mirrors
-        -- python's iter_chronological order so the kept row is the
-        -- earliest-ts dup (see docstring).
-        QUALIFY ROW_NUMBER() OVER (
-            PARTITION BY wa.tx_hash, wa.asset_id, wa.wallet_address
-            ORDER BY wa.event_ts, wa.kind_priority, wa.tx_hash, wa.asset_id
-        ) = 1
-        """,  # noqa: S608 — _V2_TABLE is a module-level literal; platform/now_ts bound below
+        """,  # noqa: S608 — _TE_LOCAL_TABLE is a module-level literal; platform/now_ts bound below
         [platform, now_ts],
     )
+
+
+def _copy_to_sqlite(scratch: duckdb.DuckDBPyConnection, *, db_path: Path) -> int:
+    """Stream training_examples_v2_local from scratch DuckDB to SQLite.
+
+    Uses Python's stdlib sqlite3 with ``INSERT OR IGNORE`` to match the
+    python engine's ``repos._INSERT_SQL`` semantics on duplicate keys.
+    Bypasses DuckDB's sqlite_scanner extension's INSERT path (which
+    doesn't support INSERT OR IGNORE or ON CONFLICT DO NOTHING and
+    crashed at production scale with an unexplained UNIQUE conflict).
+
+    Returns the number of rows that landed in SQLite (after dedup). If
+    that's less than the source row count, emits a
+    ``corpus.copy_to_sqlite.dups_dropped`` WARN log as a diagnostic
+    signal — duplicate keys in the SELECT output indicate either a
+    legacy on-disk corpus shape (corpus_trades predates the PRIMARY KEY)
+    or a real fanout bug in the pipeline.
+    """
+    col_list = ", ".join(TRAINING_EXAMPLES_COLUMNS)
+    placeholders = ", ".join(["?"] * len(TRAINING_EXAMPLES_COLUMNS))
+    insert_sql = f"INSERT OR IGNORE INTO {_V2_TABLE} ({col_list}) VALUES ({placeholders})"  # noqa: S608 — _V2_TABLE is a module-level literal
+    select_sql = f"SELECT {col_list} FROM {_TE_LOCAL_TABLE}"  # noqa: S608 — _TE_LOCAL_TABLE is a module-level literal
+
+    source_rows = 0
+    cursor = scratch.execute(select_sql)
+    conn = sqlite3.connect(db_path)
+    try:
+        landed_before = conn.execute(
+            f"SELECT COUNT(*) FROM {_V2_TABLE}"  # noqa: S608 — _V2_TABLE is a module-level literal
+        ).fetchone()[0]
+        while True:
+            batch = cursor.fetchmany(_COPY_BATCH_SIZE)
+            if not batch:
+                break
+            source_rows += len(batch)
+            conn.executemany(insert_sql, batch)
+        conn.commit()
+        landed_after = conn.execute(
+            f"SELECT COUNT(*) FROM {_V2_TABLE}"  # noqa: S608 — _V2_TABLE is a module-level literal
+        ).fetchone()[0]
+    finally:
+        conn.close()
+
+    landed = landed_after - landed_before
+    dups = source_rows - landed
+    if dups > 0:
+        _log.warning(
+            "corpus.copy_to_sqlite.dups_dropped",
+            source_rows=source_rows,
+            landed=landed,
+            dups_dropped=dups,
+        )
+    return landed
 
 
 def _count_v2(duck: duckdb.DuckDBPyConnection) -> int:

--- a/tests/corpus/test_duckdb_engine.py
+++ b/tests/corpus/test_duckdb_engine.py
@@ -673,6 +673,146 @@ def test_materialize_trades_coerces_null_category_to_unknown(tmp_path: Path) -> 
     assert result_rows[1]["market_category"] == "unknown"
 
 
+def test_final_join_handles_duplicate_corpus_trades(tmp_path: Path) -> None:
+    """corpus_trades may contain duplicate (tx_hash, asset_id, wallet_address)
+    tuples from re-ingesting overlapping on-chain ranges (legacy rows that
+    pre-date the PRIMARY KEY constraint, or rows landed via paths that
+    bypass the constraint). The python engine silently dedupes via
+    INSERT OR IGNORE on training_examples; the DuckDB engine must match.
+
+    Without an equivalent OR IGNORE semantic in the cross-database final
+    join, the INSERT into training_examples_v2 crashes with the same
+    UNIQUE constraint violation surfaced on the production corpus.
+
+    The current canonical corpus_trades schema enforces uniqueness via
+    PRIMARY KEY, so seeding two duplicate rows requires rebuilding the
+    table without that constraint — this mirrors the legacy on-disk
+    corpus shape we need to tolerate.
+    """
+    import sqlite3  # noqa: PLC0415
+
+    from pscanner.corpus._duckdb_engine import build_features_duckdb  # noqa: PLC0415
+    from pscanner.corpus.db import init_corpus_db  # noqa: PLC0415
+
+    db_path = tmp_path / "corpus.sqlite3"
+    init_corpus_db(db_path).close()
+    conn = sqlite3.connect(db_path)
+    try:
+        # Drop and recreate corpus_trades WITHOUT the PRIMARY KEY so we can
+        # seed two rows that share (platform, tx_hash, asset_id,
+        # wallet_address). This emulates legacy on-disk corpora whose
+        # trades table predates the unique constraint.
+        conn.execute("DROP TABLE corpus_trades")
+        conn.execute(
+            """
+            CREATE TABLE corpus_trades (
+              platform TEXT NOT NULL DEFAULT 'polymarket'
+                CHECK (platform IN ('polymarket', 'kalshi', 'manifold')),
+              tx_hash TEXT NOT NULL,
+              asset_id TEXT NOT NULL,
+              wallet_address TEXT NOT NULL,
+              condition_id TEXT NOT NULL,
+              outcome_side TEXT NOT NULL,
+              bs TEXT NOT NULL,
+              price REAL NOT NULL,
+              size REAL NOT NULL,
+              notional_usd REAL NOT NULL,
+              ts INTEGER NOT NULL
+            )
+            """
+        )
+        cid = "0x" + "a" * 64
+        wallet = "0x" + "b" * 40
+        tx = "0x" + "c" * 64
+        asset = "asset_yes"
+        conn.execute(
+            """
+            INSERT INTO corpus_markets
+                (platform, condition_id, event_slug, category, categories_json,
+                 enumerated_at, closed_at, total_volume_usd, backfill_state)
+            VALUES ('polymarket', ?, 'slug', 'sports', '["sports"]',
+                    50, 300, 1000.0, 'complete')
+            """,
+            (cid,),
+        )
+        conn.execute(
+            """
+            INSERT INTO market_resolutions
+                (platform, condition_id, resolved_at, winning_outcome_index,
+                 outcome_yes_won, source, recorded_at)
+            VALUES ('polymarket', ?, 300, 0, 1, 'gamma', 300)
+            """,
+            (cid,),
+        )
+        # Two rows with the SAME (tx_hash, asset_id, wallet_address) — only
+        # the ts differs, simulating re-ingest at a slightly different time.
+        # Both are BUYs on a resolved market; either would normally produce
+        # a training_examples row.
+        conn.executemany(
+            """
+            INSERT INTO corpus_trades
+                (platform, tx_hash, asset_id, wallet_address, condition_id,
+                 outcome_side, bs, price, size, notional_usd, ts)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    "polymarket",
+                    tx,
+                    asset,
+                    wallet,
+                    cid,
+                    "YES",
+                    "BUY",
+                    0.5,
+                    100.0,
+                    50.0,
+                    100,
+                ),
+                (
+                    "polymarket",
+                    tx,
+                    asset,
+                    wallet,
+                    cid,
+                    "YES",
+                    "BUY",
+                    0.5,
+                    100.0,
+                    50.0,
+                    101,
+                ),
+            ],
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    # Without dedup, this raises duckdb.Error: UNIQUE constraint failed
+    build_features_duckdb(
+        db_path=db_path,
+        platform="polymarket",
+        now_ts=1000,
+        memory_limit="256MB",
+        temp_dir=tmp_path,
+        threads=1,
+    )
+
+    # Exactly ONE row landed (the dedup result) — matches python engine semantics
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute(
+            "SELECT tx_hash, asset_id, wallet_address FROM training_examples"
+        ).fetchall()
+    finally:
+        conn.close()
+    assert len(rows) == 1
+    assert rows[0]["tx_hash"] == tx
+    assert rows[0]["asset_id"] == asset
+    assert rows[0]["wallet_address"] == wallet
+
+
 def test_heartbeat_emits_during_long_operation() -> None:
     """Heartbeat thread fires at least once and stops cleanly on signal."""
     import threading  # noqa: PLC0415


### PR DESCRIPTION
## Summary

Hotfix for the merged DuckDB rewrite (#132). The first production rebuild on the desktop training box surfaced a `UNIQUE constraint failed` crash at the final-join INSERT — turned out to be a real ~2× row fan-out somewhere in stages 1-4 of the pipeline (only triggers on the desktop's 46 GB production corpus, not on smaller fixtures). Also surfaced a subsequent SIGBUS at copy_to_sqlite start once we'd added a workaround.

This PR has 3 commits showing the evolution:

1. **`c049faf` — QUALIFY ROW_NUMBER dedup workaround** (initial attempt). Worked correctness-wise but cost 35+ GB of DuckDB temp spill and 14+ min of runtime — way too expensive.
2. **`c22d7db` — replace cross-DB INSERT with Python executemany.** DuckDB's sqlite_scanner extension rejects `INSERT OR IGNORE` / `ON CONFLICT DO NOTHING` for attached SQLite, so the final-join now writes to a DuckDB-native intermediate (`training_examples_v2_local`), and a new `_copy_to_sqlite` function streams batches via stdlib sqlite3 with `INSERT OR IGNORE`. Drops the QUALIFY entirely. Also adds a `corpus.copy_to_sqlite.dups_dropped` warn log that finally tells us empirically whether dups exist in the SELECT output.
3. **`577b187` — DETACH corpus + periodic commit.** Second production run crashed with SIGBUS at ~480 MB WAL. Root cause: DuckDB had `corpus.sqlite3` ATTACHed (with mmap reads via sqlite_scanner) while stdlib sqlite3 wrote to the same file. The mmap-vs-WAL conflict triggered the bus error. Fix: detach DuckDB from corpus BEFORE `copy_to_sqlite` runs, and commit every 100K rows so WAL doesn't grow unbounded.

## Validation

Full production rebuild on desktop training box completed successfully (HEAD `577b187`):

| Metric | Value |
|---|---|
| Total wall time | **1h 5m 10s** |
| Peak RSS | 9.4 GB |
| Final training_examples rows | 15,589,656 |
| `dups_dropped` (diagnostic) | 15,454,142 (~50% of SELECT output) |

Compute stages (1 through final_join) ran in **17m 22s** — within the original plan's 5-25 min target. The post-compute SQLite write phase added 48 min on top (copy_to_sqlite + atomic swap).

## Test plan

- [x] `uv run pytest -q` → 1363 passed, 1 deselected (slow test)
- [x] `uv run pytest -m slow -v` → 1 passed in 7m 42s on 2M synthetic trades
- [x] **Production rebuild on desktop corpus** — completed in 65 min, exit 0
- [x] All 12 engine tests including the `test_final_join_handles_duplicate_corpus_trades` regression guard

## Two follow-ups now documented in #133

- The pipeline produces ~2× source rows at production scale. The INSERT OR IGNORE masks the symptom but the bug is real (deferred — needs scale-specific investigation).
- copy_to_sqlite is the new dominant cost (34 of 65 min). The python engine's drop-and-recreate-indexes-around-bulk-insert pattern should be applied here (easy 15-25 min win).

Refs #131, follows up #132.