### PR TITLE
docs(corpus): replace speculative "5-25 min" claim with measured numbers (#133)

### DIFF
--- a/src/pscanner/corpus/_duckdb_engine.py
+++ b/src/pscanner/corpus/_duckdb_engine.py
@@ -1,8 +1,19 @@
 """DuckDB-based engine for ``pscanner corpus build-features``.
 
 Pure SQL pipeline that produces ``training_examples`` rows bit-equivalent
-(within ``rtol=1e-9``) to the Python ``StreamingHistoryProvider`` fold,
-in 5-25 min vs 6h. See ``docs/superpowers/plans/2026-05-11-issue-116-duckdb-engine.md``.
+(within ``rtol=1e-9``) to the Python ``StreamingHistoryProvider`` fold.
+
+Measured wall time on the production corpus (46 GB SQLite, 22.78M
+polymarket trades, 11 GB WSL2 host, ``memory_limit=6GB``): 1h 5m pre-#138,
+~5.5x faster than the Python engine's ~6h. The fan-out fix in #138 nearly
+halves the ``copy_to_sqlite`` source-row count and should drop total wall
+time substantially on the next rebuild — see ``CLAUDE.md`` for updated
+per-stage numbers as they land.
+
+Issue history: original rewrite #131; INSERT OR IGNORE + DETACH around
+``copy_to_sqlite`` #134; auto-ANALYZE post-swap #137; market_aggs
+``wallet_address`` JOIN fix #138. Open follow-up: drop+recreate
+secondary indexes around the bulk insert #136.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Addresses the first follow-up in #133: replace the plan-time speculative \`5-25 min vs 6h\` claim in \`_duckdb_engine.py\`'s module docstring with measured numbers from the actual production rebuild.

## Change

The original docstring (from #131 plan-time) said:

> Pure SQL pipeline that produces \`\`training_examples\`\` rows bit-equivalent
> (within \`\`rtol=1e-9\`\`) to the Python \`\`StreamingHistoryProvider\`\` fold,
> in 5-25 min vs 6h.

Replaced with measured numbers from the first production rebuild (46 GB SQLite, 22.78M trades, 11 GB WSL2, \`memory_limit=6GB\`): **1h 5m pre-#138**, ~5.5× faster than the python engine's ~6h. Plus a note that #138's fan-out fix should drop the next rebuild's wall time substantially, and a pointer to CLAUDE.md for live per-stage numbers.

Also added an issue-history trail (#131 → #134 → #137 → #138) and the open follow-up (#136) so a reader landing on the module gets oriented without spelunking commit history.

## Why this matters

The "5-25 min" was a goalpost that the plan didn't quite hit. Leaving it in the docstring after a year of evolution looks like a bug or a missed measurement; the actual goal was eliminating the 90 GB spill, which the rewrite did achieve. Reframing as measured-numbers-plus-issue-trail is more honest.

## Test plan

- [x] \`uv run ruff check src/pscanner/corpus/_duckdb_engine.py\` clean
- [x] \`uv run pytest tests/corpus/test_duckdb_engine.py -q\` → 14 passed
- [x] No behavior change.

Closes #133 (first follow-up only — the second, "decide whether to delete the python engine", is still gated on 2-3 successful prod rebuilds at parity).