### PR TITLE
fix(gate-model): unblock live paper-trading smoke

### DIFF
--- a/scripts/analyze_paper_trading.py
+++ b/scripts/analyze_paper_trading.py
@@ -1,0 +1,244 @@
+r"""Diagnostics for a paper-trading smoke run.
+
+Answers three questions about the gate-model paper-trading loop:
+
+1. **Latency** — how long between a trade happening on-chain and it being
+   scored by the gate model? Computed as
+   ``alert.created_at - body.trade_ts`` (seconds).
+2. **Activity** — what trades are being taken and how concentrated are
+   they on the same ``(condition_id, outcome)``?
+3. **Price drift** — does the orderbook price at paper-trade time match
+   the source-wallet fill price? Computed as
+   ``paper_trade.fill_price - body.implied_prob_at_buy``. Positive means
+   the market moved against the buyer between the source trade and the
+   paper fill (we'd buy higher).
+
+Usage:
+    uv run python scripts/analyze_paper_trading.py --db data/pscanner.sqlite3
+"""
+
+# ruff: noqa: T201  # script prints diagnostics to stdout by design
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import statistics
+from collections import Counter
+from pathlib import Path
+from typing import Final
+
+_FILL_PRICE_FALLBACK: Final[float] = 0.5
+
+
+def _quantile(sorted_vals: list[float], q: float) -> float:
+    if not sorted_vals:
+        return float("nan")
+    pos = q * (len(sorted_vals) - 1)
+    lo = int(pos)
+    hi = min(lo + 1, len(sorted_vals) - 1)
+    frac = pos - lo
+    return sorted_vals[lo] * (1 - frac) + sorted_vals[hi] * frac
+
+
+def _summary(label: str, values: list[float], unit: str) -> None:
+    if not values:
+        print(f"  {label}: (no data)")
+        return
+    s = sorted(values)
+    print(
+        f"  {label} (n={len(s):,}): "
+        f"min={s[0]:.3f}{unit}  "
+        f"p50={_quantile(s, 0.5):.3f}{unit}  "
+        f"p90={_quantile(s, 0.9):.3f}{unit}  "
+        f"p99={_quantile(s, 0.99):.3f}{unit}  "
+        f"max={s[-1]:.3f}{unit}  "
+        f"mean={statistics.fmean(s):.3f}{unit}"
+    )
+
+
+def _bucket_histogram(values: list[float], bins: list[tuple[float, float, str]]) -> None:
+    for lo, hi, label in bins:
+        n = sum(1 for v in values if lo <= v < hi)
+        pct = 100.0 * n / len(values) if values else 0.0
+        bar = "█" * int(pct / 2)
+        print(f"    {label:>20}  n={n:>6,}  {pct:5.1f}%  {bar}")
+
+
+def analyze_latency(conn: sqlite3.Connection) -> None:
+    """Q1: alert.created_at - body.trade_ts for gate_buy alerts."""
+    print("\n=== Q1: Latency (source trade → model alert) ===")
+    rows = conn.execute(
+        "SELECT created_at, body_json FROM alerts WHERE detector='gate_buy'"
+    ).fetchall()
+    latencies = []
+    for created_at, body_json in rows:
+        try:
+            body = json.loads(body_json)
+        except json.JSONDecodeError:
+            continue
+        trade_ts = body.get("trade_ts")
+        if isinstance(trade_ts, int | float):
+            latencies.append(float(created_at) - float(trade_ts))
+    _summary("delay", latencies, "s")
+    if latencies:
+        print("\n  distribution:")
+        _bucket_histogram(
+            latencies,
+            [
+                (-1e9, 0, "negative (clock skew)"),
+                (0, 5, "0-5s"),
+                (5, 15, "5-15s"),
+                (15, 30, "15-30s"),
+                (30, 60, "30-60s"),
+                (60, 120, "60-120s"),
+                (120, 300, "2-5 min"),
+                (300, 900, "5-15 min"),
+                (900, 1e9, "15 min+"),
+            ],
+        )
+
+
+def analyze_activity(conn: sqlite3.Connection) -> None:
+    """Q2: per-market+side concentration."""
+    print("\n=== Q2: Activity (per-market same-side concentration) ===")
+    rows = conn.execute(
+        """
+        SELECT condition_id, outcome, COUNT(*) AS n
+        FROM paper_trades
+        WHERE triggering_alert_detector='gate_buy'
+        GROUP BY condition_id, outcome
+        ORDER BY n DESC
+        """
+    ).fetchall()
+    total = sum(r[2] for r in rows)
+    print(f"  total gate_buy paper trades: {total:,}")
+    print(f"  distinct (condition_id, outcome) keys: {len(rows):,}")
+    if not rows:
+        return
+    print("\n  trades-per-key distribution:")
+    counts = [r[2] for r in rows]
+    _summary("trades/key", [float(c) for c in counts], "")
+    print(f"\n  top 20 most-repeated (condition_id, outcome) of {len(rows):,}:")
+    print(f"    {'condition_id':<68} {'side':<5} {'n':>5}")
+    for cid, side, n in rows[:20]:
+        print(f"    {cid:<68} {side:<5} {n:>5}")
+    # category breakdown via alert body
+    print("\n  by market_category (from alert body):")
+    cat_counts: Counter[str] = Counter()
+    rows2 = conn.execute(
+        """
+        SELECT a.body_json
+        FROM paper_trades p
+        JOIN alerts a ON a.alert_key = p.triggering_alert_key
+        WHERE p.triggering_alert_detector='gate_buy'
+        """
+    ).fetchall()
+    for (body_json,) in rows2:
+        try:
+            body = json.loads(body_json)
+            cat = body.get("market_category", "(missing)")
+            cat_counts[str(cat)] += 1
+        except json.JSONDecodeError:
+            pass
+    for cat, n in sorted(cat_counts.items(), key=lambda kv: -kv[1]):
+        pct = 100.0 * n / total
+        print(f"    {cat:<20} n={n:>5,}  {pct:5.1f}%")
+
+
+def analyze_price_drift(conn: sqlite3.Connection) -> None:
+    """Q3: paper fill_price vs source wallet's implied_prob_at_buy."""
+    print("\n=== Q3: Price drift (paper fill_price vs source implied) ===")
+    rows = conn.execute(
+        """
+        SELECT p.fill_price, p.outcome, a.body_json
+        FROM paper_trades p
+        JOIN alerts a ON a.alert_key = p.triggering_alert_key
+        WHERE p.triggering_alert_detector='gate_buy'
+        """
+    ).fetchall()
+    drifts: list[float] = []
+    abs_drifts: list[float] = []
+    n_fallback_05 = 0
+    for fill_price, _outcome, body_json in rows:
+        try:
+            body = json.loads(body_json)
+        except json.JSONDecodeError:
+            continue
+        implied = body.get("implied_prob_at_buy")
+        if not isinstance(implied, int | float):
+            continue
+        # fill_price == 0.5 is the documented fallback when orderbook tick
+        # is unavailable. Bucket separately so the real signal is clean.
+        if float(fill_price) == _FILL_PRICE_FALLBACK:
+            n_fallback_05 += 1
+            continue
+        # Source trade was a BUY at body.implied. Paper-trader BUYs the same
+        # side at paper_trades.fill_price. Drift = fill - implied (positive =
+        # we paid more than the source did = market moved against us).
+        drift = float(fill_price) - float(implied)
+        drifts.append(drift)
+        abs_drifts.append(abs(drift))
+    total = len(rows)
+    print(f"  total gate_buy paper trades: {total:,}")
+    print(f"  rows skipped (fill_price=0.5 fallback): {n_fallback_05:,}")
+    print(f"  rows analyzed: {len(drifts):,}")
+    if not drifts:
+        return
+    print()
+    _summary("signed drift  ", drifts, "")
+    _summary("absolute drift", abs_drifts, "")
+    print("\n  signed drift distribution:")
+    _bucket_histogram(
+        drifts,
+        [
+            (-1.0, -0.05, "<-5pp (favorable)"),
+            (-0.05, -0.01, "-5pp..-1pp"),
+            (-0.01, -0.001, "-1pp..-0.1pp"),
+            (-0.001, 0.001, "~0 (no drift)"),
+            (0.001, 0.01, "+0.1pp..+1pp"),
+            (0.01, 0.05, "+1pp..+5pp"),
+            (0.05, 1.0, "+5pp+ (adverse)"),
+        ],
+    )
+    favorable = sum(1 for d in drifts if d < 0)
+    adverse = sum(1 for d in drifts if d > 0)
+    flat = len(drifts) - favorable - adverse
+    print(
+        f"\n  signs: favorable={favorable:,} ({100 * favorable / len(drifts):.1f}%)  "
+        f"flat={flat:,}  "
+        f"adverse={adverse:,} ({100 * adverse / len(drifts):.1f}%)"
+    )
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--db",
+        type=str,
+        default="data/pscanner.sqlite3",
+        help="Path to the daemon SQLite database",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Entry point: parse args, open DB, run three analyses."""
+    args = _parse_args()
+    db_path = Path(args.db)
+    if not db_path.exists():
+        print(f"DB not found: {db_path}")
+        return 1
+    conn = sqlite3.connect(str(db_path))
+    try:
+        analyze_latency(conn)
+        analyze_activity(conn)
+        analyze_price_drift(conn)
+    finally:
+        conn.close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/pscanner/collectors/market_scoped_trades.py
+++ b/src/pscanner/collectors/market_scoped_trades.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
     from pscanner.daemon.live_history import LiveHistoryProvider
     from pscanner.poly.data import DataClient
     from pscanner.poly.gamma import GammaClient
+    from pscanner.poly.models import Market
     from pscanner.store.repo import MarketCacheRepo
 
 _LOG = structlog.get_logger(__name__)
@@ -47,6 +48,7 @@ class MarketScopedTradeCollector:
         data_client: DataClient,
         provider: LiveHistoryProvider | None = None,
         market_cache: MarketCacheRepo | None = None,
+        clock: Clock | None = None,
     ) -> None:
         """Initialize the collector with configuration and API clients.
 
@@ -59,12 +61,17 @@ class MarketScopedTradeCollector:
         :class:`Market` so :class:`GateModelDetector._resolve_outcome_side` can
         map ``trade.asset_id`` to YES/NO. In a gate-model-only daemon config,
         no other code path populates the cache (issue #103).
+
+        ``clock`` seeds the cold-start ``_last_seen_ts`` for newly-discovered
+        markets so the first poll fetches only live trades, not the entire
+        historical backlog. Defaults to :class:`RealClock`.
         """
         self._config = config
         self._gamma = gamma
         self._data_client = data_client
         self._provider = provider
         self._market_cache = market_cache
+        self._clock = clock or RealClock()
         self._markets: list[str] = []
         self._callbacks: list[Callable[[WalletTrade], None]] = []
         self._last_seen_ts: dict[str, int] = {}
@@ -72,6 +79,22 @@ class MarketScopedTradeCollector:
     def subscribe_new_trade(self, callback: Callable[[WalletTrade], None]) -> None:
         """Register a callback fired on every newly observed trade."""
         self._callbacks.append(callback)
+
+    def _market_passes_gate(self, market: Market, *, floor: float) -> bool:
+        """True iff the market clears the volume floor AND the price-range gate.
+
+        Post-decision markets (every outcome at a price extreme) get dropped
+        because ``pred - implied`` can't clear ``min_edge_pct`` when
+        ``implied`` is already near 0 or 1.
+        """
+        if float(market.volume or 0.0) < floor:
+            return False
+        prices = market.outcome_prices
+        if not prices:
+            return True
+        return all(
+            self._config.min_outcome_price <= p <= self._config.max_outcome_price for p in prices
+        )
 
     async def refresh_market_set(self) -> list[str]:
         """Enumerate events, filter by category + volume, return top-N condition_ids.
@@ -97,11 +120,15 @@ class MarketScopedTradeCollector:
                 cond_id = market.condition_id
                 if cond_id is None:
                     continue
-                volume = float(market.volume or 0.0)
-                if volume < floor:
+                if not self._market_passes_gate(market, floor=floor):
                     continue
                 cond_id_str = str(cond_id)
-                candidates.append((volume, cond_id_str))
+                candidates.append((float(market.volume or 0.0), cond_id_str))
+                # Cold-start sentinel: skip the historical backlog and only
+                # pick up trades observed after this refresh. Without this,
+                # the first poll fetches every trade ever recorded on the
+                # market because the per-market dict default is 0 (epoch).
+                self._last_seen_ts.setdefault(cond_id_str, int(self._clock.now()))
                 if self._provider is not None:
                     # Live market: no resolution timestamp yet. closed_at/opened_at
                     # default to 0 — only the category fields are load-bearing at
@@ -213,7 +240,7 @@ class MarketScopedTradeCollector:
         clock: Clock | None = None,
     ) -> None:
         """Long-running loop: refresh market set + poll on cadence."""
-        clk = clock or RealClock()
+        clk = clock or self._clock
         while not stop_event.is_set():
             await self.refresh_market_set()
             await self.poll_once()

--- a/src/pscanner/config.py
+++ b/src/pscanner/config.py
@@ -351,6 +351,15 @@ class GateModelMarketFilterConfig(_Section):
     min_volume_24h_usd: float = 100_000
     max_markets: int = 50
     poll_interval_seconds: int = 60
+    min_outcome_price: float = 0.1
+    """Lower bound on every outcome's last-known price. Markets where any
+    outcome trades below this are skipped — they are typically post-decision
+    coin-flip-tail markets where ``implied_prob_at_buy`` is already at the
+    ceiling and ``pred - implied`` can never clear ``min_edge_pct``.
+    """
+    max_outcome_price: float = 0.9
+    """Upper bound on every outcome's last-known price (symmetric to
+    ``min_outcome_price``)."""
 
 
 class SmartMoneyEvaluatorConfig(_Section):

--- a/src/pscanner/detectors/gate_model.py
+++ b/src/pscanner/detectors/gate_model.py
@@ -128,7 +128,17 @@ class GateModelDetector(TradeDrivenDetector):
         mis-aligns every prediction.
         """
         levels = self._encoder.levels
-        excluded = {*CARRIER_COLS, *LEAKAGE_COLS, "label_won"}
+        # market_category and market_categories are FeatureRow fields used by
+        # the gate-intersection check upstream but are not columns in
+        # training_examples (#122 — the 9 cat_* indicators carry the signal).
+        # market_categories is also a tuple, which numpy can't cast to float32.
+        excluded = {
+            *CARRIER_COLS,
+            *LEAKAGE_COLS,
+            "label_won",
+            "market_category",
+            "market_categories",
+        }
         non_cat = [f.name for f in dataclasses.fields(FeatureRow) if f.name not in levels]
         indicators = [f"{col}__{lvl}" for col, lvls in levels.items() for lvl in lvls]
         return tuple(c for c in [*non_cat, *indicators] if c not in excluded)

--- a/tests/collectors/test_market_scoped_trades.py
+++ b/tests/collectors/test_market_scoped_trades.py
@@ -20,7 +20,14 @@ from pscanner.store.repo import MarketCacheRepo, WalletTrade
 from pscanner.util.clock import FakeClock
 
 
-def _make_market(*, condition_id: str, volume: float, mid: str | None = None) -> Market:
+def _make_market(
+    *,
+    condition_id: str,
+    volume: float,
+    mid: str | None = None,
+    outcome_prices: tuple[float, float] = (0.5, 0.5),
+) -> Market:
+    yes_p, no_p = outcome_prices
     return Market.model_validate(
         {
             "id": mid or condition_id,
@@ -28,7 +35,7 @@ def _make_market(*, condition_id: str, volume: float, mid: str | None = None) ->
             "question": f"q-{condition_id}",
             "slug": f"slug-{condition_id}",
             "outcomes": '["Yes","No"]',
-            "outcomePrices": '["0.5","0.5"]',
+            "outcomePrices": f'["{yes_p}","{no_p}"]',
             "liquidity": "100",
             "volume": str(volume),
             "active": True,
@@ -173,6 +180,7 @@ async def test_poll_once_dispatches_new_trades() -> None:
         config=cfg,
         gamma=gamma,  # type: ignore[arg-type]  # ty:ignore[invalid-argument-type]
         data_client=data,  # type: ignore[arg-type]  # ty:ignore[invalid-argument-type]
+        clock=FakeClock(start=1_700_000_050.0),
     )
     received: list[WalletTrade] = []
     collector.subscribe_new_trade(received.append)
@@ -241,6 +249,7 @@ async def test_poll_once_handles_polymarket_camelcase_keys() -> None:
         config=cfg,
         gamma=gamma,  # type: ignore[arg-type]  # ty:ignore[invalid-argument-type]
         data_client=data,  # type: ignore[arg-type]  # ty:ignore[invalid-argument-type]
+        clock=FakeClock(start=1_700_000_050.0),
     )
     received: list[WalletTrade] = []
     collector.subscribe_new_trade(received.append)
@@ -289,17 +298,132 @@ async def test_poll_once_advances_last_seen_ts() -> None:
             ]
         }
     )
+    cold_start_ts = 1_700_000_050
     collector = MarketScopedTradeCollector(
         config=cfg,
         gamma=gamma,  # type: ignore[arg-type]  # ty:ignore[invalid-argument-type]
         data_client=data,  # type: ignore[arg-type]  # ty:ignore[invalid-argument-type]
+        clock=FakeClock(start=float(cold_start_ts)),
     )
     await collector.refresh_market_set()
     await collector.poll_once()
     await collector.poll_once()  # second poll: nothing new since last_seen_ts advanced
-    # First call had since_ts=0, second should have since_ts >= 1_700_000_100.
-    assert data.calls[0][1] == 0
+    # First call is seeded from the clock (cold-start skips historical), second
+    # advances to the trade timestamp it just observed.
+    assert data.calls[0][1] == cold_start_ts
     assert data.calls[1][1] >= 1_700_000_100
+
+
+@pytest.mark.asyncio
+async def test_cold_start_skips_historical_trades() -> None:
+    """Pin the live-only cold-start behavior: trades older than the clock get dropped.
+
+    The first paper-trading smoke (#79) accidentally replayed multi-day
+    backlogs because ``_last_seen_ts`` defaulted to 0. Setting the
+    sentinel from ``clock.now()`` at refresh time makes the first poll
+    fetch only trades that arrived after the daemon started.
+    """
+    cfg = GateModelMarketFilterConfig(
+        enabled=True, accepted_categories=("esports",), min_volume_24h_usd=0
+    )
+    event = _make_event(
+        slug="ev",
+        tags=["Esports"],
+        markets=[_make_market(condition_id="0xc1", volume=100_000)],
+    )
+    gamma = _FakeGammaClient([event])
+    cold_start_ts = 1_779_000_000
+    data = _FakeDataClient(
+        by_market={
+            "0xc1": [
+                {  # historical: older than the cold-start clock — must be skipped
+                    "transactionHash": "tx_old",
+                    "asset": "0xa1",
+                    "side": "BUY",
+                    "proxyWallet": "0xabc",
+                    "conditionId": "0xc1",
+                    "price": 0.42,
+                    "size": 100.0,
+                    "usdcSize": 42.0,
+                    "timestamp": cold_start_ts - 86_400,  # 1 day before start
+                },
+                {  # live: newer than the cold-start clock — must be dispatched
+                    "transactionHash": "tx_new",
+                    "asset": "0xa1",
+                    "side": "BUY",
+                    "proxyWallet": "0xabc",
+                    "conditionId": "0xc1",
+                    "price": 0.42,
+                    "size": 100.0,
+                    "usdcSize": 42.0,
+                    "timestamp": cold_start_ts + 30,
+                },
+            ]
+        }
+    )
+    collector = MarketScopedTradeCollector(
+        config=cfg,
+        gamma=gamma,  # type: ignore[arg-type]  # ty:ignore[invalid-argument-type]
+        data_client=data,  # type: ignore[arg-type]  # ty:ignore[invalid-argument-type]
+        clock=FakeClock(start=float(cold_start_ts)),
+    )
+    received: list[WalletTrade] = []
+    collector.subscribe_new_trade(received.append)
+    await collector.refresh_market_set()
+    n = await collector.poll_once()
+    assert n == 1
+    assert len(received) == 1
+    assert received[0].transaction_hash == "tx_new"
+    assert data.calls[0][1] == cold_start_ts
+
+
+@pytest.mark.asyncio
+async def test_refresh_excludes_extreme_priced_markets() -> None:
+    """Markets whose every outcome trades outside [min, max] outcome price get dropped.
+
+    The 2026-05-19 live smoke surfaced that the top markets by 24h volume
+    are usually post-decision (one outcome at ~0.99). The gate's
+    ``pred - implied >= 0.05`` floor is unreachable when ``implied >= 0.95``,
+    so subscribing to those markets just wastes the polling budget.
+    """
+    cfg = GateModelMarketFilterConfig(
+        enabled=True,
+        accepted_categories=("esports",),
+        min_volume_24h_usd=0,
+        min_outcome_price=0.1,
+        max_outcome_price=0.9,
+    )
+    event = _make_event(
+        slug="ev",
+        tags=["Esports"],
+        markets=[
+            _make_market(
+                condition_id="0x_mid",
+                volume=100_000,
+                outcome_prices=(0.55, 0.45),
+            ),
+            _make_market(
+                condition_id="0x_post_decision",
+                volume=200_000,
+                outcome_prices=(0.99, 0.01),
+            ),
+            _make_market(
+                condition_id="0x_inverse_post_decision",
+                volume=150_000,
+                outcome_prices=(0.05, 0.95),
+            ),
+        ],
+    )
+    gamma = _FakeGammaClient([event])
+    data = _FakeDataClient(by_market={})
+    collector = MarketScopedTradeCollector(
+        config=cfg,
+        gamma=gamma,  # type: ignore[arg-type]  # ty:ignore[invalid-argument-type]
+        data_client=data,  # type: ignore[arg-type]  # ty:ignore[invalid-argument-type]
+        clock=FakeClock(start=1_700_000_000.0),
+    )
+    selected = await collector.refresh_market_set()
+    assert selected == ["0x_mid"]
 
 
 @pytest.mark.asyncio

--- a/tests/detectors/test_gate_model.py
+++ b/tests/detectors/test_gate_model.py
@@ -17,7 +17,7 @@ from pscanner.config import GateModelConfig
 from pscanner.corpus.features import FeatureRow, MarketMetadata
 from pscanner.daemon.live_history import LiveHistoryProvider
 from pscanner.detectors.gate_model import GateModelDetector
-from pscanner.ml.preprocessing import LEAKAGE_COLS, OneHotEncoder
+from pscanner.ml.preprocessing import _NEVER_LOAD_COLS, OneHotEncoder
 from pscanner.ml.streaming import _derive_feature_names
 from pscanner.poly.ids import AssetId, ConditionId, EventId, MarketId
 from pscanner.store.db import init_db
@@ -635,18 +635,27 @@ def test_feature_cols_parity_against_training_derive_feature_names(tmp_path: Pat
     # Build a kept_cols list mirroring what training_examples PRAGMA would
     # produce after _NEVER_LOAD_COLS is applied: every FeatureRow field +
     # the carrier columns the build_features pipeline writes alongside
-    # them, MINUS the leakage cols stripped at SELECT time.
+    # them, minus the columns the streaming loader drops at SELECT time.
+    # market_categories is a tuple-valued FeatureRow field used by the live
+    # gate-intersection check; it is not a column in training_examples (the
+    # 9 cat_ indicators carry the signal in SQL form), so PRAGMA never
+    # returns it.
     feature_row_fields = tuple(f.name for f in dataclasses.fields(FeatureRow))
     extra_cols = ("condition_id", "trade_ts", "resolved_at", "label_won")
     full_pragma_cols = feature_row_fields + extra_cols
-    kept_cols = tuple(c for c in full_pragma_cols if c not in LEAKAGE_COLS)
+    not_in_sql = {"market_categories"}
+    kept_cols = tuple(
+        c for c in full_pragma_cols if c not in _NEVER_LOAD_COLS and c not in not_in_sql
+    )
     # Use a richer encoder than the dummy one (to mimic production) so the
     # parity check covers the indicator-expansion path too.
+    # Production v2 encoder one-hots side + top_category only — market_category
+    # is dropped via _NEVER_LOAD_COLS at training time (#122) and the cat_*
+    # indicator columns carry the signal instead.
     encoder = OneHotEncoder(
         levels={
             "side": ("NO", "YES"),
             "top_category": ("__none__", "esports", "sports", "thesis"),
-            "market_category": ("esports", "sports", "thesis"),
         }
     )
     detector._encoder = encoder


### PR DESCRIPTION
## Summary

The 2026-05-19 paper-trading smoke surfaced three independent issues in the gate-model loop. This PR fixes all three so the loop measures the live signal end-to-end.

- **`gate_model.py` crash on non-esports markets.** `_derive_feature_cols` was enumerating every `FeatureRow` field, picking up `market_category` (TEXT) and `market_categories` (tuple) — neither is a column in `training_examples` under the v2 preprocessor (#122). NumPy crashed on the first non-esports market with `could not convert string to float: 'geopolitics'`. Fix extends `excluded` to cover both fields; the parity test now uses `_NEVER_LOAD_COLS` (matching production) instead of just `LEAKAGE_COLS`.
- **Historical-replay on cold start.** `MarketScopedTradeCollector._last_seen_ts` defaulted to `0`, so the first poll on every newly-discovered market fetched its full trade history. The smoke scored source trades up to 19.7 days old as if they had just landed. `refresh_market_set` now seeds each new market's sentinel from `clock.now()` (clock kwarg added for testability; defaults to `RealClock`). A new test pins the live-only behavior.
- **Post-decision markets dominate the working set.** Top-volume-by-24h markets are usually pinned near 0.99 — `pred − implied >= min_edge_pct` is unreachable there. Added `min_outcome_price` / `max_outcome_price` to `GateModelMarketFilterConfig` (defaults 0.1 / 0.9) so the collector skips markets where every outcome trades outside the window. New test pins the filter.

Adds `scripts/analyze_paper_trading.py` (latency / activity / price-drift breakdowns over `data/pscanner.sqlite3`) — used to validate the fixes.

## Test plan
- [x] `uv run pytest tests/detectors/test_gate_model.py tests/collectors/test_market_scoped_trades.py -q` — 33 passed
- [x] `uv run ruff check src/pscanner/detectors/gate_model.py src/pscanner/collectors/market_scoped_trades.py src/pscanner/config.py tests/...` — All checks passed
- [x] `uv run ty check src/pscanner/collectors/market_scoped_trades.py src/pscanner/detectors/gate_model.py src/pscanner/config.py` — All checks passed
- [x] 2-hour live smoke on desktop (n=54 alerts): latency p50 4.8 min / max 13 min (bounded by 100-market round-robin under data-API rate limit); 50% of fills within 0.1pp of source `implied_prob_at_buy`, 80% favorable, max adverse drift 2.5pp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)