### PR TITLE
fix(poly): outcomePrices='null' string parses as empty list (#161)

### DIFF
--- a/src/pscanner/poly/models.py
+++ b/src/pscanner/poly/models.py
@@ -26,15 +26,18 @@ def _parse_json_string_list(value: Any) -> list[Any]:
     pass through untouched.
 
     Args:
-        value: A list, a JSON-encoded string, or ``None``/empty string.
+        value: A list, a JSON-encoded string, or ``None``/empty/``"null"``.
+            The literal string ``"null"`` is accepted because gamma
+            occasionally returns it in place of a JSON list for stale
+            markets (#161).
 
     Returns:
-        A Python list (empty if input was ``None`` or empty).
+        A Python list (empty if input was ``None``, ``""``, or ``"null"``).
 
     Raises:
         ValueError: If ``value`` is a string but not valid JSON-list.
     """
-    if value is None or value == "":
+    if value is None or value in {"", "null"}:
         return []
     if isinstance(value, list):
         return value

--- a/tests/poly/test_models.py
+++ b/tests/poly/test_models.py
@@ -1,0 +1,37 @@
+"""Defensive parsing tests for `pscanner.poly.models` (#161)."""
+
+from __future__ import annotations
+
+from pscanner.poly.models import Market
+
+
+def _payload(**overrides: object) -> dict[str, object]:
+    """Return a minimum-viable gamma `/markets` payload, optionally overridden."""
+    base: dict[str, object] = {
+        "id": "m1",
+        "question": "ignored",
+        "slug": "seed",
+        "outcomes": '["Yes","No"]',
+        "outcomePrices": '["0.5","0.5"]',
+        "clobTokenIds": '["yes-token","no-token"]',
+        "active": True,
+        "closed": False,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_outcome_prices_literal_null_string_parses_as_empty() -> None:
+    """Gamma occasionally returns ``outcomePrices='null'`` for stale markets.
+
+    Regression: pre-#161, this raised ``ValidationError`` and aborted any
+    refresh that hit the payload mid-page. Now treated as an empty list.
+    """
+    market = Market.model_validate(_payload(outcomePrices="null"))
+    assert market.outcome_prices == []
+
+
+def test_outcomes_literal_null_string_parses_as_empty() -> None:
+    """Same defensive contract for the sibling ``outcomes`` field."""
+    market = Market.model_validate(_payload(outcomes="null"))
+    assert market.outcomes == []


### PR DESCRIPTION
## Summary

- Gamma occasionally returns the literal string ``\"null\"`` in place of a JSON-encoded list for stale markets. Pydantic validation was raising ``ValidationError`` for the outcome_prices field and aborting any refresh or daemon poll that hit the payload (surfaced in the 2026-05-21 V2 catch-up refresh and again in #152's desktop smoke).
- `_parse_json_string_list` now treats ``\"null\"`` like ``None``/``\"\"`` (empty-list sentinel). Covers ``outcomes``, ``outcomePrices``, and ``clob_token_ids`` in one shot.
- Closes #161.

## Test plan

- [x] `uv run pytest tests/poly/test_models.py -q` — 2 new regression tests pin the contract for both ``outcomePrices='null'`` and ``outcomes='null'``
- [x] `uv run pytest tests/poly/ -q` — 128 passed (no regressions)
- [x] `uv run ruff check . && uv run ty check src/pscanner/poly/models.py` — clean
- [ ] Desktop smoke: re-enable `events`, `gate_model`, `gate_model_market_filter` in config and verify the daemon no longer crashes on the malformed event payload (manual follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)