### PR TITLE
fix(corpus): derive outcome_side from clob_token_ids (#159)

### DIFF
--- a/src/pscanner/corpus/cli.py
+++ b/src/pscanner/corpus/cli.py
@@ -354,7 +354,9 @@ def _make_data_client() -> _DataCM:
     return _DataCM()
 
 
-async def _drain_pending(*, conn: sqlite3.Connection, data: DataClient) -> int:
+async def _drain_pending(
+    *, conn: sqlite3.Connection, data: DataClient, gamma: GammaClient
+) -> int:
     """Drain `corpus_markets` work queue, walking each pending market once."""
     markets_repo = CorpusMarketsRepo(conn)
     trades_repo = CorpusTradesRepo(conn)
@@ -368,6 +370,7 @@ async def _drain_pending(*, conn: sqlite3.Connection, data: DataClient) -> int:
                 inserted = await walk_market(
                     condition_id=m.condition_id,
                     data=data,
+                    gamma=gamma,
                     markets_repo=markets_repo,
                     trades_repo=trades_repo,
                     now_ts=int(time.time()),
@@ -442,7 +445,7 @@ async def _run_polymarket_backfill(args: argparse.Namespace) -> int:
                 now_ts=int(time.time()),
                 since_ts=None,
             )
-            await _drain_pending(conn=conn, data=data)
+            await _drain_pending(conn=conn, data=data, gamma=gamma)
             await _register_missing_polymarket_resolutions(
                 conn=conn,
                 gamma=gamma,
@@ -523,7 +526,7 @@ async def _run_polymarket_refresh(args: argparse.Namespace) -> int:
                 now_ts=int(time.time()),
                 since_ts=since_ts,
             )
-            await _drain_pending(conn=conn, data=data)
+            await _drain_pending(conn=conn, data=data, gamma=gamma)
             await _register_missing_polymarket_resolutions(
                 conn=conn,
                 gamma=gamma,

--- a/src/pscanner/corpus/market_walker.py
+++ b/src/pscanner/corpus/market_walker.py
@@ -18,16 +18,75 @@ from pscanner.corpus.repos import (
     CorpusTradesRepo,
 )
 from pscanner.poly.data import DataClient
+from pscanner.poly.gamma import GammaClient
 
 _log = structlog.get_logger(__name__)
 _PAGE_SIZE: Final[int] = 500
 _OFFSET_CAP: Final[int] = (
     3000  # Polymarket /trades hard cap (server: "max historical activity offset of 3000 exceeded")  # noqa: E501
 )
+_BINARY_MARKET_OUTCOME_COUNT: Final[int] = 2
 
 
-def _parse_trade(item: dict[str, Any], condition_id: str) -> CorpusTrade | None:
+async def _resolve_outcome_side_index(
+    condition_id: str,
+    *,
+    data: DataClient,
+    gamma: GammaClient,
+) -> dict[str, str]:
+    """Build ``{asset_id: "YES" | "NO"}`` from the market's ``clob_token_ids``.
+
+    Polymarket convention: ``clob_token_ids[0]`` is the YES-equivalent leg,
+    ``clob_token_ids[1]`` is the NO-equivalent leg (parallel to ``outcomes``).
+    The `/trades` row's ``outcome`` field is the human-readable name
+    (e.g. ``"Cavaliers"``), which is unreliable for non-binary-Yes/No markets.
+    Deriving ``outcome_side`` from the token-id position fixes the
+    long-standing sports-collapse bug (#159).
+
+    Returns an empty mapping when the market cannot be resolved or is not
+    binary; the caller falls back to the legacy outcome-name heuristic.
+    """
+    try:
+        slug = await data.get_market_slug_by_condition_id(condition_id)
+    except Exception:
+        _log.warning("corpus.outcome_side_index.slug_lookup_failed", condition_id=condition_id)
+        return {}
+    if slug is None:
+        return {}
+    try:
+        market = await gamma.get_market_by_slug(slug)
+    except Exception:
+        _log.warning(
+            "corpus.outcome_side_index.gamma_lookup_failed",
+            condition_id=condition_id,
+            slug=slug,
+        )
+        return {}
+    if market is None:
+        return {}
+    if len(market.clob_token_ids) != _BINARY_MARKET_OUTCOME_COUNT:
+        return {}
+    return {
+        str(market.clob_token_ids[0]): "YES",
+        str(market.clob_token_ids[1]): "NO",
+    }
+
+
+def _parse_trade(
+    item: dict[str, Any],
+    condition_id: str,
+    *,
+    outcome_side_by_asset_id: dict[str, str],
+) -> CorpusTrade | None:
     """Best-effort parse of a `/trades` JSON item to ``CorpusTrade``.
+
+    ``outcome_side`` is derived from ``outcome_side_by_asset_id`` (built
+    once per ``walk_market`` from the market's ``clob_token_ids``). When
+    the trade's ``asset`` is not present in the map (e.g. resolution
+    failed or this is a non-binary market), falls back to the legacy
+    outcome-name heuristic, which collapses non-``yes`` labels to ``NO``
+    (the #159 bug, kept as the fallback because it preserves earlier
+    behavior for unresolvable markets).
 
     Returns ``None`` if required fields are missing or malformed.
     """
@@ -52,12 +111,15 @@ def _parse_trade(item: dict[str, Any], condition_id: str) -> CorpusTrade | None:
         return None
     if price_f is None or size_f is None:
         return None
+    resolved_side = outcome_side_by_asset_id.get(asset)
+    if resolved_side is None:
+        resolved_side = "YES" if outcome.lower() == "yes" else "NO"
     return CorpusTrade(
         tx_hash=tx,
         asset_id=asset,
         wallet_address=wallet,
         condition_id=condition_id,
-        outcome_side="YES" if outcome.lower() == "yes" else "NO",
+        outcome_side=resolved_side,
         bs="BUY" if side.upper() == "BUY" else "SELL",
         price=price_f,
         size=size_f,
@@ -70,15 +132,23 @@ async def walk_market(
     *,
     condition_id: str,
     data: DataClient,
+    gamma: GammaClient,
     markets_repo: CorpusMarketsRepo,
     trades_repo: CorpusTradesRepo,
     now_ts: int,
 ) -> int:
     """Pull every trade on ``condition_id``; record progress and final state.
 
+    Pre-fetches the parent ``Market`` once via gamma so each trade's
+    ``outcome_side`` can be derived from the position of its ``asset`` in
+    ``clob_token_ids`` (#159). When the gamma lookup fails, every trade
+    falls back to the legacy outcome-name heuristic; the walk still
+    proceeds with the older (known-buggy) labelling rather than aborting.
+
     Args:
         condition_id: Polymarket market identifier.
-        data: Data client used for ``/trades`` pagination.
+        data: Data client used for ``/trades`` pagination + slug resolution.
+        gamma: Gamma client used to fetch ``clob_token_ids`` once.
         markets_repo: Markets repo to update progress/state on.
         trades_repo: Trades repo for inserts.
         now_ts: Unix seconds for state-machine timestamps.
@@ -91,6 +161,10 @@ async def walk_market(
     total_inserted = 0
     truncated = False
 
+    outcome_side_by_asset_id = await _resolve_outcome_side_index(
+        condition_id, data=data, gamma=gamma
+    )
+
     try:
         total_inserted, truncated = await _fetch_all_pages(
             condition_id=condition_id,
@@ -98,6 +172,7 @@ async def walk_market(
             markets_repo=markets_repo,
             trades_repo=trades_repo,
             start_offset=offset,
+            outcome_side_by_asset_id=outcome_side_by_asset_id,
         )
     except Exception as exc:
         markets_repo.mark_failed(condition_id, error_message=str(exc))
@@ -110,6 +185,7 @@ async def walk_market(
         condition_id=condition_id,
         trades_inserted=total_inserted,
         truncated=truncated,
+        outcome_side_resolved=bool(outcome_side_by_asset_id),
     )
     return total_inserted
 
@@ -121,6 +197,7 @@ async def _fetch_all_pages(
     markets_repo: CorpusMarketsRepo,
     trades_repo: CorpusTradesRepo,
     start_offset: int,
+    outcome_side_by_asset_id: dict[str, str],
 ) -> tuple[int, bool]:
     """Fetch and store all pages of trades for one market.
 
@@ -136,7 +213,16 @@ async def _fetch_all_pages(
         if not page:
             truncated = offset >= _OFFSET_CAP
             break
-        parsed = [t for item in page if (t := _parse_trade(item, condition_id)) is not None]
+        parsed = [
+            t
+            for item in page
+            if (
+                t := _parse_trade(
+                    item, condition_id, outcome_side_by_asset_id=outcome_side_by_asset_id
+                )
+            )
+            is not None
+        ]
         inserted = trades_repo.insert_batch(parsed)
         total_inserted += inserted
         offset += len(page)

--- a/src/pscanner/poly/models.py
+++ b/src/pscanner/poly/models.py
@@ -37,7 +37,7 @@ def _parse_json_string_list(value: Any) -> list[Any]:
     Raises:
         ValueError: If ``value`` is a string but not valid JSON-list.
     """
-    if value is None or value in {"", "null"}:
+    if value is None or value in ("", "null"):
         return []
     if isinstance(value, list):
         return value

--- a/tests/corpus/test_market_walker.py
+++ b/tests/corpus/test_market_walker.py
@@ -14,6 +14,7 @@ from pscanner.corpus.repos import (
     CorpusMarketsRepo,
     CorpusTradesRepo,
 )
+from pscanner.poly.models import Market
 
 
 def _trade_dict(**overrides: Any) -> dict[str, Any]:
@@ -30,6 +31,45 @@ def _trade_dict(**overrides: Any) -> dict[str, Any]:
     }
     base.update(overrides)
     return base
+
+
+def _make_market(
+    *,
+    condition_id: str = "cond1",
+    outcomes: tuple[str, str] = ("Yes", "No"),
+    clob_token_ids: tuple[str, str] = ("asset1", "asset2"),
+) -> Market:
+    """Build a minimal Market with two outcomes for outcome_side-index tests."""
+    return Market.model_validate(
+        {
+            "id": "m1",
+            "question": "q",
+            "slug": "slug-" + condition_id,
+            "conditionId": condition_id,
+            "outcomes": list(outcomes),
+            "outcomePrices": ["0.5", "0.5"],
+            "clobTokenIds": list(clob_token_ids),
+            "active": True,
+            "closed": False,
+        }
+    )
+
+
+def _fake_gamma_returning(market: Market | None) -> AsyncMock:
+    """Build an AsyncMock GammaClient that returns ``market`` from get_market_by_slug."""
+    gamma = AsyncMock()
+    gamma.get_market_by_slug = AsyncMock(return_value=market)
+    return gamma
+
+
+def _fake_data_with_slug(
+    *, pages: list[list[dict[str, Any]]], slug: str = "slug-cond1"
+) -> AsyncMock:
+    """Build an AsyncMock DataClient: slug resolves + trade pages drain in order."""
+    data = AsyncMock()
+    data.get_market_slug_by_condition_id = AsyncMock(return_value=slug)
+    data._fetch_market_trades_page = AsyncMock(side_effect=[*pages, []])
+    return data
 
 
 def _seed_market(repo: CorpusMarketsRepo, condition_id: str) -> None:
@@ -54,16 +94,14 @@ async def test_walk_inserts_trades_and_marks_complete(
     trades = CorpusTradesRepo(tmp_corpus_db)
     _seed_market(markets, "cond1")
 
-    fake_data = AsyncMock()
-    fake_data._fetch_market_trades_page = AsyncMock(
-        side_effect=[
-            [_trade_dict(transactionHash="0xa", price=0.5, size=100.0)],
-            [],
-        ]
+    fake_data = _fake_data_with_slug(
+        pages=[[_trade_dict(transactionHash="0xa", price=0.5, size=100.0)]],
     )
+    fake_gamma = _fake_gamma_returning(_make_market())
     await walk_market(
         condition_id="cond1",
         data=fake_data,
+        gamma=fake_gamma,
         markets_repo=markets,
         trades_repo=trades,
         now_ts=1_500,
@@ -86,16 +124,12 @@ async def test_walk_normalizes_wallet_lowercases(
     markets = CorpusMarketsRepo(tmp_corpus_db)
     trades = CorpusTradesRepo(tmp_corpus_db)
     _seed_market(markets, "cond1")
-    fake_data = AsyncMock()
-    fake_data._fetch_market_trades_page = AsyncMock(
-        side_effect=[
-            [_trade_dict(proxyWallet="0xMIXED")],
-            [],
-        ]
-    )
+    fake_data = _fake_data_with_slug(pages=[[_trade_dict(proxyWallet="0xMIXED")]])
+    fake_gamma = _fake_gamma_returning(_make_market())
     await walk_market(
         condition_id="cond1",
         data=fake_data,
+        gamma=fake_gamma,
         markets_repo=markets,
         trades_repo=trades,
         now_ts=1_500,
@@ -111,19 +145,19 @@ async def test_walk_filters_below_notional_floor(
     markets = CorpusMarketsRepo(tmp_corpus_db)
     trades = CorpusTradesRepo(tmp_corpus_db)
     _seed_market(markets, "cond1")
-    fake_data = AsyncMock()
-    fake_data._fetch_market_trades_page = AsyncMock(
-        side_effect=[
+    fake_data = _fake_data_with_slug(
+        pages=[
             [
                 _trade_dict(transactionHash="0xbig", price=0.5, size=100.0),
                 _trade_dict(transactionHash="0xsmall", price=0.05, size=1.0),
             ],
-            [],
-        ]
+        ],
     )
+    fake_gamma = _fake_gamma_returning(_make_market())
     await walk_market(
         condition_id="cond1",
         data=fake_data,
+        gamma=fake_gamma,
         markets_repo=markets,
         trades_repo=trades,
         now_ts=1_500,
@@ -140,6 +174,7 @@ async def test_walk_truncates_at_offset_cap(
     trades = CorpusTradesRepo(tmp_corpus_db)
     _seed_market(markets, "cond1")
     fake_data = AsyncMock()
+    fake_data.get_market_slug_by_condition_id = AsyncMock(return_value="slug-cond1")
     full_page = [_trade_dict(transactionHash=f"0x{i}") for i in range(500)]
 
     async def _fetch(condition_id: str, *, offset: int) -> list[dict[str, Any]]:
@@ -149,9 +184,11 @@ async def test_walk_truncates_at_offset_cap(
         return full_page
 
     fake_data._fetch_market_trades_page = AsyncMock(side_effect=_fetch)
+    fake_gamma = _fake_gamma_returning(_make_market())
     await walk_market(
         condition_id="cond1",
         data=fake_data,
+        gamma=fake_gamma,
         markets_repo=markets,
         trades_repo=trades,
         now_ts=1_500,
@@ -161,3 +198,125 @@ async def test_walk_truncates_at_offset_cap(
     ).fetchone()
     assert row["backfill_state"] == "complete"
     assert row["truncated_at_offset_cap"] == 1
+
+
+@pytest.mark.asyncio
+async def test_walk_resolves_team_name_outcomes_via_clob_token_ids(
+    tmp_corpus_db: sqlite3.Connection,
+) -> None:
+    """#159 regression: sports markets used to collapse both legs to NO.
+
+    Now each trade's ``outcome_side`` is derived from the position of its
+    ``asset`` in ``clob_token_ids`` (parallel to ``outcomes``).
+    """
+    markets = CorpusMarketsRepo(tmp_corpus_db)
+    trades = CorpusTradesRepo(tmp_corpus_db)
+    _seed_market(markets, "cond1")
+    fake_data = _fake_data_with_slug(
+        pages=[
+            [
+                _trade_dict(
+                    transactionHash="0xcavs",
+                    asset="token-cavs",
+                    outcome="Cavaliers",
+                    price=0.5,
+                    size=100.0,
+                ),
+                _trade_dict(
+                    transactionHash="0xknicks",
+                    asset="token-knicks",
+                    outcome="Knicks",
+                    price=0.5,
+                    size=100.0,
+                ),
+            ],
+        ],
+    )
+    fake_gamma = _fake_gamma_returning(
+        _make_market(
+            outcomes=("Cavaliers", "Knicks"),
+            clob_token_ids=("token-cavs", "token-knicks"),
+        )
+    )
+    await walk_market(
+        condition_id="cond1",
+        data=fake_data,
+        gamma=fake_gamma,
+        markets_repo=markets,
+        trades_repo=trades,
+        now_ts=1_500,
+    )
+    rows = tmp_corpus_db.execute(
+        "SELECT tx_hash, asset_id, outcome_side FROM corpus_trades ORDER BY tx_hash"
+    ).fetchall()
+    sides = {r["asset_id"]: r["outcome_side"] for r in rows}
+    assert sides == {"token-cavs": "YES", "token-knicks": "NO"}
+
+
+@pytest.mark.asyncio
+async def test_walk_falls_back_to_outcome_name_on_gamma_failure(
+    tmp_corpus_db: sqlite3.Connection,
+) -> None:
+    """When gamma can't resolve the market, the walk continues with the
+    legacy outcome-name heuristic and still completes successfully."""
+    markets = CorpusMarketsRepo(tmp_corpus_db)
+    trades = CorpusTradesRepo(tmp_corpus_db)
+    _seed_market(markets, "cond1")
+    fake_data = _fake_data_with_slug(
+        pages=[[_trade_dict(transactionHash="0xa", outcome="Yes")]],
+    )
+    fake_gamma = _fake_gamma_returning(None)  # market not found in gamma
+    await walk_market(
+        condition_id="cond1",
+        data=fake_data,
+        gamma=fake_gamma,
+        markets_repo=markets,
+        trades_repo=trades,
+        now_ts=1_500,
+    )
+    row = tmp_corpus_db.execute(
+        "SELECT outcome_side FROM corpus_trades WHERE tx_hash='0xa'"
+    ).fetchone()
+    assert row["outcome_side"] == "YES"  # outcome.lower() == "yes" fallback path
+
+
+@pytest.mark.asyncio
+async def test_walk_skips_resolution_for_non_binary_market(
+    tmp_corpus_db: sqlite3.Connection,
+) -> None:
+    """Markets with non-binary ``clob_token_ids`` skip the resolver and
+    fall back to the legacy heuristic (preserves prior behavior)."""
+    markets = CorpusMarketsRepo(tmp_corpus_db)
+    trades = CorpusTradesRepo(tmp_corpus_db)
+    _seed_market(markets, "cond1")
+    fake_data = _fake_data_with_slug(
+        pages=[[_trade_dict(transactionHash="0xa", outcome="OptionA", asset="token-a")]],
+    )
+    fake_gamma = _fake_gamma_returning(
+        Market.model_validate(
+            {
+                "id": "m1",
+                "question": "q",
+                "slug": "slug-cond1",
+                "conditionId": "cond1",
+                "outcomes": ["OptionA", "OptionB", "OptionC"],
+                "outcomePrices": ["0.33", "0.33", "0.34"],
+                "clobTokenIds": ["token-a", "token-b", "token-c"],
+                "active": True,
+                "closed": False,
+            }
+        )
+    )
+    await walk_market(
+        condition_id="cond1",
+        data=fake_data,
+        gamma=fake_gamma,
+        markets_repo=markets,
+        trades_repo=trades,
+        now_ts=1_500,
+    )
+    row = tmp_corpus_db.execute(
+        "SELECT outcome_side FROM corpus_trades WHERE tx_hash='0xa'"
+    ).fetchone()
+    # 3-outcome market not resolved; falls back to "OptionA".lower() != "yes" → NO.
+    assert row["outcome_side"] == "NO"

--- a/tests/poly/test_models.py
+++ b/tests/poly/test_models.py
@@ -35,3 +35,15 @@ def test_outcomes_literal_null_string_parses_as_empty() -> None:
     """Same defensive contract for the sibling ``outcomes`` field."""
     market = Market.model_validate(_payload(outcomes="null"))
     assert market.outcomes == []
+
+
+def test_list_input_is_pass_through() -> None:
+    """Regression for a sentinel-check bug: lists are unhashable, so the
+    early ``value in {...}`` set check raised ``TypeError`` on every list
+    payload. The check must use a tuple so the equality path is taken.
+    """
+    market = Market.model_validate(
+        _payload(outcomes=["Yes", "No"], outcomePrices=["0.5", "0.5"])
+    )
+    assert market.outcomes == ["Yes", "No"]
+    assert market.outcome_prices == [0.5, 0.5]


### PR DESCRIPTION
## Summary

- `market_walker._parse_trade` used to compute ``outcome_side = \"YES\" if outcome.lower() == \"yes\" else \"NO\"``, collapsing every non-`yes` outcome name (Cavaliers, Knicks, Trump, ...) to `NO`. Sports markets stored both legs as `NO`.
- `walk_market` now pre-fetches the parent `Market` once via the established `data.get_market_slug_by_condition_id` → `gamma.get_market_by_slug` chain (same pattern as `PaperTrader._backfill_market_cache`) and builds `asset_id → \"YES\" | \"NO\"` from the position of each token in `clob_token_ids`.
- When gamma can't resolve the market (network error, missing market, non-binary), falls back to the legacy outcome-name heuristic. The walk continues either way.
- **Also fixes a regression introduced in PR #165**: `value in {\"\", \"null\"}` raised `TypeError` on list payloads (lists are unhashable, can't go through set membership). Switched the sentinel check to a tuple so the equality path is taken regardless of input type. Added a list-input regression test.

## Scope

Forward-fix only — existing wrong `corpus_trades.outcome_side` rows are NOT corrected. The next ML retrain still sees the inverted sports labels (`corpus/examples.py:174` reads `outcome_side` for the supervised label) until a follow-up backfill lands. Tracked as a separate issue per the conversation.

Closes #159.

## Test plan

- [x] 3 new tests in `tests/corpus/test_market_walker.py`:
  - Sports market with team-name outcomes (`Cavaliers`/`Knicks`) → YES/NO derived correctly from `clob_token_ids` positions
  - Gamma returns `None` (market not found) → falls back to legacy outcome-name logic without aborting
  - Non-binary 3-outcome market → resolution skipped, falls back to legacy logic
- [x] 1 new test in `tests/poly/test_models.py` covering the list-input regression on `_parse_json_string_list`
- [x] 4 existing market-walker tests updated to pass `gamma=fake_gamma`
- [x] `uv run pytest tests/corpus/ tests/poly/ -q` — 423 passed
- [x] `uv run ruff check .` — clean
- [x] `uv run ty check` — 15 diagnostics, all pre-existing (no new diagnostics)

🤖 Generated with [Claude Code](https://claude.com/claude-code)