### PR TITLE
refactor(store): unify migrations + collapse count helpers

### DIFF
--- a/src/pscanner/corpus/cli.py
+++ b/src/pscanner/corpus/cli.py
@@ -363,9 +363,7 @@ def _make_data_client() -> _DataCM:
     return _DataCM()
 
 
-async def _drain_pending(
-    *, conn: sqlite3.Connection, data: DataClient, gamma: GammaClient
-) -> int:
+async def _drain_pending(*, conn: sqlite3.Connection, data: DataClient, gamma: GammaClient) -> int:
     """Drain `corpus_markets` work queue, walking each pending market once."""
     markets_repo = CorpusMarketsRepo(conn)
     trades_repo = CorpusTradesRepo(conn)

--- a/src/pscanner/corpus/db.py
+++ b/src/pscanner/corpus/db.py
@@ -14,6 +14,8 @@ from pathlib import Path
 
 import structlog
 
+from pscanner.store.migrations import apply_additive_migrations
+
 _log = structlog.get_logger(__name__)
 
 
@@ -661,23 +663,16 @@ def _apply_migrations(conn: sqlite3.Connection) -> None:
     Runs the platform-column migrations first (which copy old tables into
     new ones with composite PKs), then the additive ALTER TABLE migrations
     in ``_MIGRATIONS``. The platform migrations are idempotent via
-    ``_column_exists`` checks; the additive ones swallow ``duplicate column
-    name`` / ``no such column`` errors.
+    ``_column_exists`` checks; the additive ones swallow the standard
+    idempotent-failure error messages via
+    :func:`pscanner.store.migrations.apply_additive_migrations`.
     """
     _migrate_corpus_markets_add_platform(conn)
     _migrate_corpus_trades_add_platform(conn)
     _migrate_market_resolutions_add_platform(conn)
     _migrate_training_examples_add_platform(conn)
     _migrate_asset_index_add_platform(conn)
-    for stmt in _MIGRATIONS:
-        try:
-            conn.execute(stmt)
-        except sqlite3.OperationalError as exc:
-            msg = str(exc).lower()
-            if "duplicate column name" in msg or "no such column" in msg or "no such table" in msg:
-                continue
-            raise
-    conn.commit()
+    apply_additive_migrations(conn, _MIGRATIONS)
 
 
 def init_corpus_db(path: Path) -> sqlite3.Connection:

--- a/src/pscanner/kalshi/db.py
+++ b/src/pscanner/kalshi/db.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 
 import sqlite3
 
+from pscanner.store.migrations import apply_additive_migrations
+
 KALSHI_SCHEMA_STATEMENTS: tuple[str, ...] = (
     """
     CREATE TABLE IF NOT EXISTS kalshi_markets (
@@ -69,24 +71,7 @@ KALSHI_SCHEMA_STATEMENTS: tuple[str, ...] = (
 )
 
 
-_MIGRATIONS: tuple[str, ...] = ("ALTER TABLE kalshi_markets ADD COLUMN result TEXT",)
-
-
-def _apply_migrations(conn: sqlite3.Connection) -> None:
-    """Apply additive ALTER TABLE migrations. Idempotent.
-
-    Each migration is wrapped to swallow ``duplicate column name`` errors
-    so repeated calls on already-migrated DBs are no-ops. Mirrors
-    ``pscanner.manifold.db._apply_migrations``.
-    """
-    for stmt in _MIGRATIONS:
-        try:
-            conn.execute(stmt)
-        except sqlite3.OperationalError as exc:
-            if "duplicate column name" in str(exc).lower():
-                continue
-            raise
-    conn.commit()
+KALSHI_MIGRATIONS: tuple[str, ...] = ("ALTER TABLE kalshi_markets ADD COLUMN result TEXT",)
 
 
 def init_kalshi_tables(conn: sqlite3.Connection) -> None:
@@ -102,5 +87,5 @@ def init_kalshi_tables(conn: sqlite3.Connection) -> None:
     """
     for statement in KALSHI_SCHEMA_STATEMENTS:
         conn.execute(statement)
-    _apply_migrations(conn)
+    apply_additive_migrations(conn, KALSHI_MIGRATIONS)
     conn.commit()

--- a/src/pscanner/manifold/db.py
+++ b/src/pscanner/manifold/db.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 
 import sqlite3
 
+from pscanner.store.migrations import apply_additive_migrations
+
 MANIFOLD_SCHEMA_STATEMENTS: tuple[str, ...] = (
     """
     CREATE TABLE IF NOT EXISTS manifold_markets (
@@ -66,22 +68,6 @@ MANIFOLD_SCHEMA_STATEMENTS: tuple[str, ...] = (
 _MIGRATIONS: tuple[str, ...] = ("ALTER TABLE manifold_markets ADD COLUMN resolution TEXT",)
 
 
-def _apply_migrations(conn: sqlite3.Connection) -> None:
-    """Apply additive ALTER TABLE migrations. Idempotent.
-
-    Each migration is wrapped to swallow ``duplicate column name`` errors
-    so repeated calls on already-migrated DBs are no-ops.
-    """
-    for stmt in _MIGRATIONS:
-        try:
-            conn.execute(stmt)
-        except sqlite3.OperationalError as exc:
-            if "duplicate column name" in str(exc).lower():
-                continue
-            raise
-    conn.commit()
-
-
 def init_manifold_tables(conn: sqlite3.Connection) -> None:
     """Apply all Manifold schema statements to ``conn``.
 
@@ -94,5 +80,5 @@ def init_manifold_tables(conn: sqlite3.Connection) -> None:
     """
     for statement in MANIFOLD_SCHEMA_STATEMENTS:
         conn.execute(statement)
-    _apply_migrations(conn)
+    apply_additive_migrations(conn, _MIGRATIONS)
     conn.commit()

--- a/src/pscanner/store/db.py
+++ b/src/pscanner/store/db.py
@@ -10,9 +10,9 @@ from __future__ import annotations
 import sqlite3
 from pathlib import Path
 
-from pscanner.kalshi.db import KALSHI_SCHEMA_STATEMENTS
-from pscanner.kalshi.db import _apply_migrations as _apply_kalshi_migrations
+from pscanner.kalshi.db import KALSHI_MIGRATIONS, KALSHI_SCHEMA_STATEMENTS
 from pscanner.manifold.db import MANIFOLD_SCHEMA_STATEMENTS
+from pscanner.store.migrations import apply_additive_migrations
 
 _SCHEMA_STATEMENTS: tuple[str, ...] = (
     """
@@ -347,27 +347,6 @@ _PRAGMAS: tuple[str, ...] = (
 )
 
 
-def _apply_migrations(conn: sqlite3.Connection) -> None:
-    """Apply additive ALTER TABLE migrations. Idempotent.
-
-    SQLite has no IF NOT EXISTS for ADD COLUMN, so each ``ADD COLUMN``
-    migration is wrapped to swallow ``duplicate column name`` errors. For
-    ``RENAME COLUMN`` migrations applied a second time (or against a fresh
-    schema where the new column name already exists), SQLite reports
-    ``no such column`` on the source side; we treat that the same way.
-    Other DatabaseErrors propagate.
-    """
-    for stmt in _MIGRATIONS:
-        try:
-            conn.execute(stmt)
-        except sqlite3.OperationalError as exc:
-            msg = str(exc).lower()
-            if "duplicate column name" in msg or "no such column" in msg:
-                continue
-            raise
-    conn.commit()
-
-
 def init_db(path: Path) -> sqlite3.Connection:
     """Open the pscanner SQLite database, creating dirs/schema as needed.
 
@@ -396,8 +375,8 @@ def init_db(path: Path) -> sqlite3.Connection:
         with conn:
             for statement in _SCHEMA_STATEMENTS:
                 conn.execute(statement)
-        _apply_migrations(conn)
-        _apply_kalshi_migrations(conn)
+        apply_additive_migrations(conn, _MIGRATIONS)
+        apply_additive_migrations(conn, KALSHI_MIGRATIONS)
     except sqlite3.DatabaseError:
         conn.close()
         raise

--- a/src/pscanner/store/migrations.py
+++ b/src/pscanner/store/migrations.py
@@ -1,0 +1,43 @@
+"""Shared migration utilities for pscanner SQLite modules.
+
+Replaces four near-identical ``_apply_migrations`` loops (one per platform DB
+module) with a single helper that swallows the standard set of idempotent
+errors raised when a migration has already been applied.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterable
+
+_EXPECTED_IDEMPOTENT_FAILURES: tuple[str, ...] = (
+    "duplicate column name",  # ADD COLUMN re-applied
+    "no such column",  # RENAME COLUMN re-applied (source side gone)
+    "no such table",  # ALTER against a not-yet-created table
+)
+
+
+def apply_additive_migrations(
+    conn: sqlite3.Connection,
+    migrations: Iterable[str],
+) -> None:
+    """Apply additive ALTER TABLE migrations in order. Idempotent.
+
+    Each statement is executed via ``conn.execute``; any
+    :class:`sqlite3.OperationalError` whose lowercased message matches an entry
+    in :data:`_EXPECTED_IDEMPOTENT_FAILURES` is swallowed so re-runs are safe.
+    All other ``OperationalError`` instances propagate.
+
+    Args:
+        conn: Open SQLite connection. Caller owns the lifecycle.
+        migrations: Iterable of SQL statements (usually a module-private
+            ``_MIGRATIONS`` tuple).
+    """
+    for stmt in migrations:
+        try:
+            conn.execute(stmt)
+        except sqlite3.OperationalError as exc:
+            if any(s in str(exc).lower() for s in _EXPECTED_IDEMPOTENT_FAILURES):
+                continue
+            raise
+    conn.commit()

--- a/src/pscanner/store/repo.py
+++ b/src/pscanner/store/repo.py
@@ -89,6 +89,31 @@ def _now_seconds() -> int:
     return int(time.time())
 
 
+def _count_grouped(
+    conn: sqlite3.Connection,
+    table: str,
+    col: str,
+) -> dict[str, int]:
+    """Return ``{value: count}`` for ``SELECT col, COUNT(*) GROUP BY col``.
+
+    ``table`` and ``col`` must be module-internal SQL identifiers — they are
+    interpolated directly into the query, so caller-supplied values would be a
+    SQL injection risk.
+    """
+    rows = conn.execute(
+        f"SELECT {col} AS k, COUNT(*) AS c FROM {table} GROUP BY {col}"  # noqa: S608
+    ).fetchall()
+    return {str(row["k"]): int(row["c"]) for row in rows}
+
+
+def _count_distinct(conn: sqlite3.Connection, table: str, col: str) -> int:
+    """Return ``COUNT(DISTINCT col)`` for the given table."""
+    row = conn.execute(
+        f"SELECT COUNT(DISTINCT {col}) AS c FROM {table}"  # noqa: S608
+    ).fetchone()
+    return 0 if row is None else int(row["c"])
+
+
 class TrackedWalletsRepo:
     """CRUD for the ``tracked_wallets`` table."""
 
@@ -956,10 +981,7 @@ class WalletTradesRepo:
 
     def count_by_wallet(self) -> dict[str, int]:
         """Return ``{wallet: trade_count}`` across the full table."""
-        rows = self._conn.execute(
-            "SELECT wallet, COUNT(*) AS c FROM wallet_trades GROUP BY wallet",
-        ).fetchall()
-        return {row["wallet"]: int(row["c"]) for row in rows}
+        return _count_grouped(self._conn, "wallet_trades", "wallet")
 
     def distinct_wallets_for_condition(
         self,
@@ -1099,10 +1121,7 @@ class WalletPositionsHistoryRepo:
 
     def count_by_wallet(self) -> dict[str, int]:
         """Return ``{wallet: row_count}`` across the full table."""
-        rows = self._conn.execute(
-            "SELECT wallet, COUNT(*) AS c FROM wallet_positions_history GROUP BY wallet",
-        ).fetchall()
-        return {row["wallet"]: int(row["c"]) for row in rows}
+        return _count_grouped(self._conn, "wallet_positions_history", "wallet")
 
 
 def _row_to_positions_history(row: sqlite3.Row) -> WalletPositionsHistoryRow:
@@ -1231,10 +1250,7 @@ class WalletActivityEventsRepo:
 
     def count_by_wallet(self) -> dict[str, int]:
         """Return ``{wallet: event_count}`` across the full table."""
-        rows = self._conn.execute(
-            "SELECT wallet, COUNT(*) AS c FROM wallet_activity_events GROUP BY wallet",
-        ).fetchall()
-        return {row["wallet"]: int(row["c"]) for row in rows}
+        return _count_grouped(self._conn, "wallet_activity_events", "wallet")
 
 
 def _row_to_activity_event(row: sqlite3.Row) -> WalletActivityEvent:
@@ -1338,19 +1354,11 @@ class MarketSnapshotsRepo:
 
     def distinct_snapshot_count(self) -> int:
         """Return ``COUNT(DISTINCT snapshot_at)`` — total sweeps recorded."""
-        row = self._conn.execute(
-            "SELECT COUNT(DISTINCT snapshot_at) AS c FROM market_snapshots",
-        ).fetchone()
-        if row is None:
-            return 0
-        return int(row["c"])
+        return _count_distinct(self._conn, "market_snapshots", "snapshot_at")
 
     def count_by_market(self) -> dict[str, int]:
         """Return ``{market_id: snapshot_count}`` across the full table."""
-        rows = self._conn.execute(
-            "SELECT market_id, COUNT(*) AS c FROM market_snapshots GROUP BY market_id",
-        ).fetchall()
-        return {row["market_id"]: int(row["c"]) for row in rows}
+        return _count_grouped(self._conn, "market_snapshots", "market_id")
 
 
 def _row_to_market_snapshot(row: sqlite3.Row) -> MarketSnapshot:
@@ -1455,19 +1463,11 @@ class EventSnapshotsRepo:
 
     def distinct_snapshot_count(self) -> int:
         """Return ``COUNT(DISTINCT snapshot_at)`` — total sweeps recorded."""
-        row = self._conn.execute(
-            "SELECT COUNT(DISTINCT snapshot_at) AS c FROM event_snapshots",
-        ).fetchone()
-        if row is None:
-            return 0
-        return int(row["c"])
+        return _count_distinct(self._conn, "event_snapshots", "snapshot_at")
 
     def count_by_event(self) -> dict[str, int]:
         """Return ``{event_id: snapshot_count}`` across the full table."""
-        rows = self._conn.execute(
-            "SELECT event_id, COUNT(*) AS c FROM event_snapshots GROUP BY event_id",
-        ).fetchall()
-        return {row["event_id"]: int(row["c"]) for row in rows}
+        return _count_grouped(self._conn, "event_snapshots", "event_id")
 
 
 def _row_to_event_snapshot(row: sqlite3.Row) -> EventSnapshot:
@@ -1999,19 +1999,11 @@ class MarketTicksRepo:
 
     def distinct_snapshot_count(self) -> int:
         """Return ``COUNT(DISTINCT snapshot_at)`` — total tick cycles recorded."""
-        row = self._conn.execute(
-            "SELECT COUNT(DISTINCT snapshot_at) AS c FROM market_ticks",
-        ).fetchone()
-        if row is None:
-            return 0
-        return int(row["c"])
+        return _count_distinct(self._conn, "market_ticks", "snapshot_at")
 
     def count_by_asset(self) -> dict[str, int]:
         """Return ``{asset_id: tick_count}`` across the full table."""
-        rows = self._conn.execute(
-            "SELECT asset_id, COUNT(*) AS c FROM market_ticks GROUP BY asset_id",
-        ).fetchall()
-        return {row["asset_id"]: int(row["c"]) for row in rows}
+        return _count_grouped(self._conn, "market_ticks", "asset_id")
 
 
 def _row_to_market_tick(row: sqlite3.Row) -> MarketTick:

--- a/tests/corpus/test_outcome_side_backfill_cli.py
+++ b/tests/corpus/test_outcome_side_backfill_cli.py
@@ -130,9 +130,7 @@ async def test_cli_backfill_outcome_side_propagates_rpm(
     conn = init_corpus_db(db_path)
     conn.close()
 
-    fake_gamma_class, fake_data_class = _install_fake_clients(
-        monkeypatch, slug=None, market=None
-    )
+    fake_gamma_class, fake_data_class = _install_fake_clients(monkeypatch, slug=None, market=None)
 
     args = argparse.Namespace(
         db=str(db_path),

--- a/tests/poly/test_models.py
+++ b/tests/poly/test_models.py
@@ -42,8 +42,6 @@ def test_list_input_is_pass_through() -> None:
     early ``value in {...}`` set check raised ``TypeError`` on every list
     payload. The check must use a tuple so the equality path is taken.
     """
-    market = Market.model_validate(
-        _payload(outcomes=["Yes", "No"], outcomePrices=["0.5", "0.5"])
-    )
+    market = Market.model_validate(_payload(outcomes=["Yes", "No"], outcomePrices=["0.5", "0.5"]))
     assert market.outcomes == ["Yes", "No"]
     assert market.outcome_prices == [0.5, 0.5]

--- a/tests/store/test_paper_trades_repo.py
+++ b/tests/store/test_paper_trades_repo.py
@@ -8,7 +8,8 @@ from typing import Any
 import pytest
 
 from pscanner.poly.ids import AssetId, ConditionId
-from pscanner.store.db import _apply_migrations
+from pscanner.store.db import _MIGRATIONS
+from pscanner.store.migrations import apply_additive_migrations
 from pscanner.store.repo import (
     OpenPaperPosition,
     PaperSummary,
@@ -285,7 +286,7 @@ def test_existing_rows_backfilled_to_smart_money(tmp_db: sqlite3.Connection) -> 
         """,
     )
     tmp_db.commit()
-    _apply_migrations(tmp_db)
+    apply_additive_migrations(tmp_db, _MIGRATIONS)
 
     detector = tmp_db.execute(
         "SELECT triggering_alert_detector FROM paper_trades "


### PR DESCRIPTION
## Summary
- New `pscanner.store.migrations.apply_additive_migrations` consolidates the same try/swallow/commit loop that previously lived in 4 db.py modules (store/db.py, corpus/db.py, kalshi/db.py, manifold/db.py). Union swallow set covers `duplicate column name`, `no such column`, `no such table` — widens kalshi/manifold's previously narrower set for forward compat.
- `_count_grouped(conn, table, col)` and `_count_distinct(conn, table, col)` module-private helpers in `store/repo.py` replace 9 near-identical `count_by_*` / `distinct_snapshot_count` methods.
- Includes a `chore: ruff format drift from #161 #167` housekeeping prefix commit so verify gate is clean on a fresh checkout.

3 commits. 10 files. +100/-125.

## Test plan
- [ ] `tests/store/test_db.py`, `tests/store/test_paper_trades_repo.py`, `tests/corpus/test_db.py`, `tests/store/test_repo.py` all green
- [ ] `test_apply_migrations_adds_platform_to_existing_corpus` confirms migration round-trip behaviour unchanged
- [ ] `uv run pytest -q` passes (1467 tests)

Suggested merge order: this one first (lowest invasiveness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)