### PR TITLE
refactor(scheduler,cli,daemon): collapse scheduler boilerplate + extract corpus_loader

### DIFF
--- a/src/pscanner/cli.py
+++ b/src/pscanner/cli.py
@@ -23,7 +23,8 @@ import json
 import logging
 import sqlite3
 import sys
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Final
 
@@ -262,6 +263,16 @@ def _configure_logging(level: str) -> None:
     )
 
 
+@contextmanager
+def _daemon_db(config: Config) -> Iterator[sqlite3.Connection]:
+    """Open the daemon SQLite DB, closing it on context exit."""
+    conn = init_db(Path(config.scanner.db_path))
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
 def _cmd_run(config: Config, *, once: bool) -> int:
     """Dispatch to the daemon or the single-shot snapshot path."""
     if once:
@@ -323,12 +334,8 @@ def _cmd_status(config: Config) -> int:
     if not Path(db_path).exists():
         sys.stderr.write(f"{_PROG}: no database at {db_path}; run the daemon first\n")
         return 1
-    conn = init_db(Path(db_path))
-    try:
-        repo = AlertsRepo(conn)
-        alerts = repo.recent(limit=_STATUS_LIMIT)
-    finally:
-        conn.close()
+    with _daemon_db(config) as conn:
+        alerts = AlertsRepo(conn).recent(limit=_STATUS_LIMIT)
     _print_status_table(alerts)
     return 0
 
@@ -360,13 +367,8 @@ def _cmd_watch(config: Config, *, address: str, reason: str | None) -> int:
     Idempotent: re-running for the same address simply preserves the existing
     row (``WatchlistRepo.upsert`` keeps first-seen provenance).
     """
-    db_path = Path(config.scanner.db_path)
-    conn = init_db(db_path)
-    try:
-        repo = WatchlistRepo(conn)
-        inserted = repo.upsert(address=address, source="manual", reason=reason)
-    finally:
-        conn.close()
+    with _daemon_db(config) as conn:
+        inserted = WatchlistRepo(conn).upsert(address=address, source="manual", reason=reason)
     console = Console()
     if inserted:
         console.print(f"watching [bold]{address}[/bold]")
@@ -377,30 +379,21 @@ def _cmd_watch(config: Config, *, address: str, reason: str | None) -> int:
 
 def _cmd_unwatch(config: Config, *, address: str) -> int:
     """Deactivate a watchlist entry. No-op when the address is unknown."""
-    db_path = Path(config.scanner.db_path)
-    conn = init_db(db_path)
-    try:
+    with _daemon_db(config) as conn:
         repo = WatchlistRepo(conn)
         existing = repo.get(address)
         if existing is None:
             Console().print(f"[dim]{address} not in watchlist (no-op)[/dim]")
             return 0
         repo.set_active(address, False)
-    finally:
-        conn.close()
     Console().print(f"unwatched [bold]{address}[/bold]")
     return 0
 
 
 def _cmd_watchlist(config: Config) -> int:
     """Print every watchlist entry (active + inactive) as a ``rich`` table."""
-    db_path = Path(config.scanner.db_path)
-    conn = init_db(db_path)
-    try:
-        repo = WatchlistRepo(conn)
-        entries = repo.list_all()
-    finally:
-        conn.close()
+    with _daemon_db(config) as conn:
+        entries = WatchlistRepo(conn).list_all()
     _print_watchlist_table(entries)
     return 0
 
@@ -434,8 +427,7 @@ def _print_watchlist_table(entries: list[WatchlistEntry]) -> None:
 
 def _cmd_paper_status(config: Config) -> int:
     """Print paper-trading status (NAV, open/closed counts, realized PnL, top trades)."""
-    conn = init_db(Path(config.scanner.db_path))
-    try:
+    with _daemon_db(config) as conn:
         paper = PaperTradesRepo(conn)
         summary = paper.summary_stats(
             starting_bankroll=config.paper_trading.starting_bankroll_usd,
@@ -445,8 +437,6 @@ def _cmd_paper_status(config: Config) -> int:
         worst = _paper_extreme_rows(conn, order="ASC")
         sources = paper.summary_by_source()
         pred_buckets = paper.summary_by_pred_bucket()
-    finally:
-        conn.close()
     console = Console(highlight=False)
     _print_paper_summary(console, summary)
     _print_paper_leaderboard(console, leaderboard)

--- a/src/pscanner/corpus/cli.py
+++ b/src/pscanner/corpus/cli.py
@@ -363,9 +363,7 @@ def _make_data_client() -> _DataCM:
     return _DataCM()
 
 
-async def _drain_pending(
-    *, conn: sqlite3.Connection, data: DataClient, gamma: GammaClient
-) -> int:
+async def _drain_pending(*, conn: sqlite3.Connection, data: DataClient, gamma: GammaClient) -> int:
     """Drain `corpus_markets` work queue, walking each pending market once."""
     markets_repo = CorpusMarketsRepo(conn)
     trades_repo = CorpusTradesRepo(conn)

--- a/src/pscanner/daemon/bootstrap.py
+++ b/src/pscanner/daemon/bootstrap.py
@@ -33,11 +33,14 @@ import structlog
 
 from pscanner.corpus.db import init_corpus_db
 from pscanner.corpus.features import (
-    MarketMetadata,
     StreamingHistoryProvider,
     Trade,
     _UnresolvedBuy,
     _WalletAccumulator,
+)
+from pscanner.daemon.corpus_loader import (
+    load_corpus_metadata,
+    load_corpus_resolutions_into,
 )
 from pscanner.store.db import init_db
 
@@ -68,18 +71,9 @@ def run_bootstrap(
     corpus_conn = init_corpus_db(corpus_db)
     daemon_conn = init_db(daemon_db)
     try:
-        metadata = _load_metadata(corpus_conn, platform=platform)
+        metadata = load_corpus_metadata(conn=corpus_conn, platform=platform)
         provider = StreamingHistoryProvider(metadata=metadata)
-        for cond_id, resolved_at, yes_won in corpus_conn.execute(
-            "SELECT condition_id, resolved_at, outcome_yes_won "
-            "FROM market_resolutions WHERE platform = ?",
-            (platform,),
-        ):
-            provider.register_resolution(
-                condition_id=cond_id,
-                resolved_at=int(resolved_at),
-                outcome_yes_won=int(yes_won),
-            )
+        load_corpus_resolutions_into(provider, conn=corpus_conn, platform=platform)
         n = _walk_corpus_trades(corpus_conn, provider, platform=platform, log_every=log_every)
         _LOG.info("daemon.bootstrap.dump_started", wallets=len(provider._wallets))
         _bulk_write_wallets(daemon_conn, provider)
@@ -223,27 +217,3 @@ def _bulk_write_markets(
         rows,
     )
     daemon_conn.commit()
-
-
-def _load_metadata(
-    conn: sqlite3.Connection, *, platform: str = "polymarket"
-) -> dict[str, MarketMetadata]:
-    out: dict[str, MarketMetadata] = {}
-    for cond_id, category, closed_at, opened_at in conn.execute(
-        """
-        SELECT condition_id,
-               COALESCE(category, ''),
-               COALESCE(closed_at, 0),
-               COALESCE(enumerated_at, 0)
-        FROM corpus_markets
-        WHERE platform = ?
-        """,
-        (platform,),
-    ):
-        out[cond_id] = MarketMetadata(
-            condition_id=cond_id,
-            category=category,
-            closed_at=int(closed_at),
-            opened_at=int(opened_at),
-        )
-    return out

--- a/src/pscanner/daemon/corpus_loader.py
+++ b/src/pscanner/daemon/corpus_loader.py
@@ -1,0 +1,151 @@
+"""Shared corpus-DB loaders for the scheduler and the bootstrap CLI.
+
+Both ``Scanner.__init__`` (live daemon cold-start) and ``run_bootstrap``
+(the ``pscanner daemon bootstrap-features`` CLI) need to read
+``corpus_markets`` and ``market_resolutions`` to pre-warm the live
+history tables. Previously the same SELECTs lived in both places
+(``scheduler._load_corpus_metadata`` / ``_load_corpus_resolutions`` was
+textually identical to ``bootstrap._load_metadata`` + the inline
+resolutions walk in ``run_bootstrap``).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from contextlib import closing
+from pathlib import Path
+from typing import Protocol
+
+import structlog
+
+from pscanner.corpus.features import MarketMetadata
+
+_LOG = structlog.get_logger(__name__)
+
+DEFAULT_CORPUS_DB = Path("data/corpus.sqlite3")
+"""Filesystem path of the corpus DB. Hard-coded constant — historically
+hard-coded at three call sites in ``scheduler.py`` and one in
+``bootstrap.py``."""
+
+
+class _ResolutionConsumer(Protocol):
+    """Minimal contract for ``register_resolution``.
+
+    Satisfied by both ``StreamingHistoryProvider`` and
+    ``LiveHistoryProvider``.
+    """
+
+    def register_resolution(
+        self,
+        *,
+        condition_id: str,
+        resolved_at: int,
+        outcome_yes_won: int,
+    ) -> None: ...
+
+
+def load_corpus_metadata(
+    *,
+    conn: sqlite3.Connection | None = None,
+    corpus_path: Path = DEFAULT_CORPUS_DB,
+    platform: str = "polymarket",
+) -> dict[str, MarketMetadata]:
+    """Read ``corpus_markets`` rows for ``platform`` into a metadata dict.
+
+    When ``conn`` is None, opens a short-lived connection to
+    ``corpus_path`` (used by the scheduler's cold-start). Otherwise reads
+    on the caller's connection (used by ``run_bootstrap`` which already
+    holds an open handle). Missing-file fallback returns an empty dict
+    and emits a warning log; the consumer (``LiveHistoryProvider``)
+    treats KeyError on missing metadata by skipping the trade.
+    """
+    if conn is not None:
+        return _read_metadata(conn, platform=platform)
+    if not corpus_path.exists():
+        _LOG.warning("corpus_loader.corpus_db_missing", path=str(corpus_path))
+        return {}
+    with closing(sqlite3.connect(str(corpus_path))) as own_conn:
+        return _read_metadata(own_conn, platform=platform)
+
+
+def load_corpus_resolutions_into(
+    provider: _ResolutionConsumer,
+    *,
+    conn: sqlite3.Connection | None = None,
+    corpus_path: Path = DEFAULT_CORPUS_DB,
+    platform: str = "polymarket",
+) -> int:
+    """Walk ``market_resolutions`` for ``platform`` and register each in ``provider``.
+
+    Returns the count registered. Open-own-conn semantics mirror
+    :func:`load_corpus_metadata`. On an unmigrated corpus DB (predates the
+    ``market_resolutions.platform`` column), logs and returns 0 — the
+    daemon will run with empty live-resolutions until a bootstrap or
+    schema migration repairs the DB.
+    """
+    if conn is not None:
+        return _drain_resolutions(conn, provider, platform=platform)
+    if not corpus_path.exists():
+        _LOG.warning("corpus_loader.corpus_db_missing", path=str(corpus_path))
+        return 0
+    with closing(sqlite3.connect(str(corpus_path))) as own_conn:
+        return _drain_resolutions(own_conn, provider, platform=platform)
+
+
+def _read_metadata(
+    conn: sqlite3.Connection,
+    *,
+    platform: str,
+) -> dict[str, MarketMetadata]:
+    out: dict[str, MarketMetadata] = {}
+    for cond_id, category, closed_at, opened_at in conn.execute(
+        """
+        SELECT condition_id,
+               COALESCE(category, ''),
+               COALESCE(closed_at, 0),
+               COALESCE(enumerated_at, 0)
+        FROM corpus_markets
+        WHERE platform = ?
+        """,
+        (platform,),
+    ):
+        out[cond_id] = MarketMetadata(
+            condition_id=cond_id,
+            category=category,
+            closed_at=int(closed_at),
+            opened_at=int(opened_at),
+        )
+    return out
+
+
+def _drain_resolutions(
+    conn: sqlite3.Connection,
+    provider: _ResolutionConsumer,
+    *,
+    platform: str,
+) -> int:
+    n = 0
+    try:
+        cursor = conn.execute(
+            """
+            SELECT condition_id, resolved_at, outcome_yes_won
+            FROM market_resolutions
+            WHERE platform = ?
+            """,
+            (platform,),
+        )
+    except sqlite3.OperationalError as exc:
+        _LOG.warning(
+            "corpus_loader.corpus_db_unmigrated_market_resolutions",
+            err=str(exc),
+        )
+        return 0
+    for cond_id, resolved_at, yes_won in cursor:
+        provider.register_resolution(
+            condition_id=cond_id,
+            resolved_at=int(resolved_at),
+            outcome_yes_won=int(yes_won),
+        )
+        n += 1
+    _LOG.info("corpus_loader.resolutions_loaded", count=n, platform=platform)
+    return n

--- a/src/pscanner/scheduler.py
+++ b/src/pscanner/scheduler.py
@@ -24,10 +24,9 @@ import os
 import sqlite3
 import time
 from collections.abc import Awaitable, Callable
-from contextlib import closing
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, TypeVar
 
 import structlog
 
@@ -47,8 +46,12 @@ from pscanner.collectors.trades import TradeCollector
 from pscanner.collectors.watchlist import WatchlistRegistry, WatchlistSyncer
 from pscanner.config import Config
 from pscanner.corpus.db import init_corpus_db
-from pscanner.corpus.features import MarketMetadata
 from pscanner.corpus.repos import AssetIndexRepo
+from pscanner.daemon.corpus_loader import (
+    DEFAULT_CORPUS_DB,
+    load_corpus_metadata,
+    load_corpus_resolutions_into,
+)
 from pscanner.daemon.live_history import LiveHistoryProvider
 from pscanner.detectors.cluster import ClusterDetector
 from pscanner.detectors.convergence import ConvergenceDetector
@@ -114,6 +117,8 @@ _RUN_ONCE_EVENTS_PAGE_SIZE = 100
 _RUN_ONCE_MAX_EVENT_PAGES = 5
 _RUN_ONCE_LEADERBOARD_LIMIT = 25
 
+_CollectorT = TypeVar("_CollectorT", bound=Collector)
+
 
 @dataclass(frozen=True, slots=True)
 class SchedulerClients:
@@ -158,8 +163,7 @@ class Scanner:
         self._corpus_conn: sqlite3.Connection | None = None
         self._subgraph_client: SubgraphClient | None = None
         if self._config.subgraph_trades.enabled:
-            corpus_path = Path("data/corpus.sqlite3")
-            self._corpus_conn = init_corpus_db(corpus_path)
+            self._corpus_conn = init_corpus_db(DEFAULT_CORPUS_DB)
         self._tracked_repo = TrackedWalletsRepo(self._db)
         self._snapshots_repo = PositionSnapshotsRepo(self._db)
         self._first_seen_repo = WalletFirstSeenRepo(self._db)
@@ -181,9 +185,9 @@ class Scanner:
         if self._config.gate_model.enabled:
             self._live_history_provider = LiveHistoryProvider(
                 conn=self._db,
-                metadata=_load_corpus_metadata(platform=self._config.gate_model.platform),
+                metadata=load_corpus_metadata(platform=self._config.gate_model.platform),
             )
-            _load_corpus_resolutions(
+            load_corpus_resolutions_into(
                 self._live_history_provider,
                 platform=self._config.gate_model.platform,
             )
@@ -772,11 +776,36 @@ class Scanner:
         await self._run_once_watchlist_sync()
         await self._run_once_trade_collector()
         return {
-            "position_snapshots": await self._run_once_position_collector(),
-            "activity_events": await self._run_once_activity_collector(),
-            "market_snapshots": await self._run_once_market_collector(),
-            "event_snapshots": await self._run_once_event_collector(),
-            "tick_snapshots": await self._run_once_tick_collector(),
+            "position_snapshots": await self._run_once_collector(
+                key="position_collector",
+                type_=PositionCollector,
+                call=PositionCollector.snapshot_all_wallets,
+                log_event="scanner.run_once.positions_failed",
+            ),
+            "activity_events": await self._run_once_collector(
+                key="activity_collector",
+                type_=ActivityCollector,
+                call=ActivityCollector.poll_all_wallets,
+                log_event="scanner.run_once.activity_failed",
+            ),
+            "market_snapshots": await self._run_once_collector(
+                key="market_collector",
+                type_=MarketCollector,
+                call=MarketCollector.snapshot_all_markets,
+                log_event="scanner.run_once.markets_failed",
+            ),
+            "event_snapshots": await self._run_once_collector(
+                key="event_collector",
+                type_=EventCollector,
+                call=EventCollector.snapshot_all_events,
+                log_event="scanner.run_once.events_failed",
+            ),
+            "tick_snapshots": await self._run_once_collector(
+                key="tick_collector",
+                type_=MarketTickCollector,
+                call=MarketTickCollector.snapshot_once,
+                log_event="scanner.run_once.ticks_failed",
+            ),
         }
 
     async def _run_once_watchlist_sync(self) -> None:
@@ -799,59 +828,27 @@ class Scanner:
         except Exception:
             _LOG.exception("scanner.run_once.trade_collector.failed")
 
-    async def _run_once_position_collector(self) -> int:
-        """Single-shot snapshot of every watched wallet's positions."""
-        collector = self._collectors.get("position_collector")
-        if not isinstance(collector, PositionCollector):
-            return 0
-        try:
-            return await collector.snapshot_all_wallets()
-        except Exception:
-            _LOG.exception("scanner.run_once.positions_failed")
-            return 0
+    async def _run_once_collector(
+        self,
+        *,
+        key: str,
+        type_: type[_CollectorT],
+        call: Callable[[_CollectorT], Awaitable[int]],
+        log_event: str,
+    ) -> int:
+        """Run one int-returning collector's single-pass entrypoint.
 
-    async def _run_once_activity_collector(self) -> int:
-        """Single-shot poll of every watched wallet's full activity stream."""
-        collector = self._collectors.get("activity_collector")
-        if not isinstance(collector, ActivityCollector):
+        Returns 0 when the collector is missing, the wrong type, or the
+        call raises — matches the pre-collapse per-method behaviour where
+        single-shot mode reports whatever it can finish.
+        """
+        collector = self._collectors.get(key)
+        if not isinstance(collector, type_):
             return 0
         try:
-            return await collector.poll_all_wallets()
+            return await call(collector)
         except Exception:
-            _LOG.exception("scanner.run_once.activity_failed")
-            return 0
-
-    async def _run_once_market_collector(self) -> int:
-        """Single-shot snapshot of every active market."""
-        collector = self._collectors.get("market_collector")
-        if not isinstance(collector, MarketCollector):
-            return 0
-        try:
-            return await collector.snapshot_all_markets()
-        except Exception:
-            _LOG.exception("scanner.run_once.markets_failed")
-            return 0
-
-    async def _run_once_event_collector(self) -> int:
-        """Single-shot snapshot of every active event."""
-        collector = self._collectors.get("event_collector")
-        if not isinstance(collector, EventCollector):
-            return 0
-        try:
-            return await collector.snapshot_all_events()
-        except Exception:
-            _LOG.exception("scanner.run_once.events_failed")
-            return 0
-
-    async def _run_once_tick_collector(self) -> int:
-        """Single-shot snapshot of the WS-driven tick collector's in-memory state."""
-        collector = self._collectors.get("tick_collector")
-        if not isinstance(collector, MarketTickCollector):
-            return 0
-        try:
-            return await collector.snapshot_once()
-        except Exception:
-            _LOG.exception("scanner.run_once.ticks_failed")
+            _LOG.exception(log_event)
             return 0
 
     async def _run_once_mispricing(self) -> int:
@@ -986,109 +983,3 @@ class Scanner:
         for closer in closers:
             with contextlib.suppress(Exception):
                 await closer()
-
-
-def _load_corpus_metadata(*, platform: str = "polymarket") -> dict[str, MarketMetadata]:
-    """Load corpus_markets metadata for the gate-model detector.
-
-    Reads ``data/corpus.sqlite3`` if it exists; returns an empty dict if
-    not. The dict is consumed by :class:`LiveHistoryProvider` for the
-    ``market_metadata(condition_id)`` lookup that ``compute_features`` uses.
-
-    Args:
-        platform: Scope the SELECT to a single platform. Defaults to
-            ``"polymarket"``. Mixing platforms here would put non-Polymarket
-            markets in the metadata dict; with disjoint condition_id
-            namespaces today nothing breaks at inference time, but it's
-            wasted memory. The filter keeps the dict aligned with the
-            model's training scope.
-
-    Empty-dict fallback is acceptable for v1: the detector handles
-    ``KeyError`` from ``market_metadata`` by skipping the trade. Operators
-    running gate_model in production should also have a corpus DB.
-    """
-    corpus_path = Path("data/corpus.sqlite3")
-    if not corpus_path.exists():
-        _LOG.warning("scanner.corpus_db_missing", path=str(corpus_path))
-        return {}
-    out: dict[str, MarketMetadata] = {}
-    with closing(sqlite3.connect(str(corpus_path))) as conn:
-        for row in conn.execute(
-            """
-            SELECT condition_id,
-                   COALESCE(category, ''),
-                   COALESCE(closed_at, 0),
-                   COALESCE(enumerated_at, 0)
-            FROM corpus_markets
-            WHERE platform = ?
-            """,
-            (platform,),
-        ):
-            cond_id, category, closed_at, opened_at = row
-            out[cond_id] = MarketMetadata(
-                condition_id=cond_id,
-                category=category,
-                closed_at=int(closed_at),
-                opened_at=int(opened_at),
-            )
-    return out
-
-
-def _load_corpus_resolutions(provider: LiveHistoryProvider, *, platform: str = "polymarket") -> int:
-    """Load market_resolutions from the corpus DB into the provider.
-
-    Mirrors ``_load_corpus_metadata`` but populates the provider's in-memory
-    ``_resolutions`` dict so the lazy drain inside
-    :meth:`LiveHistoryProvider.wallet_state` can apply resolutions
-    accumulated during ``pscanner daemon bootstrap-features``.
-
-    Without this, ``prior_resolved_buys`` / ``prior_wins`` / ``prior_losses``
-    stay at zero forever — the bootstrap walk only stores buys to the
-    per-wallet ``unresolved_buys_json``; the drain triggers in
-    ``wallet_state(...)``, which checks the resolutions dict before
-    folding each buy. An empty resolutions dict means no buy ever drains.
-
-    Args:
-        provider: The :class:`LiveHistoryProvider` to populate.
-        platform: Scope the SELECT to a single platform. Default
-            ``"polymarket"``; non-Polymarket models would pass their own.
-
-    Returns:
-        Count of resolutions registered. Zero if the corpus DB is missing
-        (empty-dict fallback is acceptable for the same reasons documented
-        on ``_load_corpus_metadata``).
-    """
-    corpus_path = Path("data/corpus.sqlite3")
-    if not corpus_path.exists():
-        _LOG.warning("scanner.corpus_db_missing", path=str(corpus_path))
-        return 0
-    n = 0
-    with closing(sqlite3.connect(str(corpus_path))) as conn:
-        try:
-            cursor = conn.execute(
-                """
-                SELECT condition_id, resolved_at, outcome_yes_won
-                FROM market_resolutions
-                WHERE platform = ?
-                """,
-                (platform,),
-            )
-        except sqlite3.OperationalError as exc:
-            # ``market_resolutions`` predates the platform-column migration.
-            # Open the corpus via ``init_corpus_db`` to apply the schema
-            # migration before retry — same fallback path as the bootstrap.
-            _LOG.warning(
-                "scanner.corpus_db_unmigrated_market_resolutions",
-                err=str(exc),
-                path=str(corpus_path),
-            )
-            return 0
-        for cond_id, resolved_at, yes_won in cursor:
-            provider.register_resolution(
-                condition_id=cond_id,
-                resolved_at=int(resolved_at),
-                outcome_yes_won=int(yes_won),
-            )
-            n += 1
-    _LOG.info("scanner.resolutions_loaded", count=n, platform=platform)
-    return n

--- a/src/pscanner/scheduler.py
+++ b/src/pscanner/scheduler.py
@@ -976,16 +976,16 @@ class Scanner:
 
     async def _close_owned_clients(self) -> None:
         """Close HTTP clients we own (data_client owns its lb_http internally)."""
-        with contextlib.suppress(Exception):
-            await self._clients.data_client.aclose()
-        with contextlib.suppress(Exception):
-            await self._clients.gamma_client.aclose()
-        with contextlib.suppress(Exception):
-            await self._clients.gamma_http.aclose()
-        with contextlib.suppress(Exception):
-            await self._clients.data_http.aclose()
-        with contextlib.suppress(Exception):
-            await self._clients.ticks_ws.close()
+        closers: tuple[Callable[[], Awaitable[None]], ...] = (
+            self._clients.data_client.aclose,
+            self._clients.gamma_client.aclose,
+            self._clients.gamma_http.aclose,
+            self._clients.data_http.aclose,
+            self._clients.ticks_ws.close,
+        )
+        for closer in closers:
+            with contextlib.suppress(Exception):
+                await closer()
 
 
 def _load_corpus_metadata(*, platform: str = "polymarket") -> dict[str, MarketMetadata]:

--- a/tests/corpus/test_outcome_side_backfill_cli.py
+++ b/tests/corpus/test_outcome_side_backfill_cli.py
@@ -130,9 +130,7 @@ async def test_cli_backfill_outcome_side_propagates_rpm(
     conn = init_corpus_db(db_path)
     conn.close()
 
-    fake_gamma_class, fake_data_class = _install_fake_clients(
-        monkeypatch, slug=None, market=None
-    )
+    fake_gamma_class, fake_data_class = _install_fake_clients(monkeypatch, slug=None, market=None)
 
     args = argparse.Namespace(
         db=str(db_path),

--- a/tests/poly/test_models.py
+++ b/tests/poly/test_models.py
@@ -42,8 +42,6 @@ def test_list_input_is_pass_through() -> None:
     early ``value in {...}`` set check raised ``TypeError`` on every list
     payload. The check must use a tuple so the equality path is taken.
     """
-    market = Market.model_validate(
-        _payload(outcomes=["Yes", "No"], outcomePrices=["0.5", "0.5"])
-    )
+    market = Market.model_validate(_payload(outcomes=["Yes", "No"], outcomePrices=["0.5", "0.5"]))
     assert market.outcomes == ["Yes", "No"]
     assert market.outcome_prices == [0.5, 0.5]

--- a/tests/scheduler/test_gate_model_wiring.py
+++ b/tests/scheduler/test_gate_model_wiring.py
@@ -22,15 +22,16 @@ from pscanner.corpus.repos import (
     MarketResolution,
     MarketResolutionsRepo,
 )
+from pscanner.daemon.corpus_loader import (
+    load_corpus_metadata as _load_corpus_metadata,
+)
+from pscanner.daemon.corpus_loader import (
+    load_corpus_resolutions_into as _load_corpus_resolutions,
+)
 from pscanner.daemon.live_history import LiveHistoryProvider
 from pscanner.detectors.gate_model import GateModelDetector
 from pscanner.poly.models import Event, Market
-from pscanner.scheduler import (
-    Scanner,
-    SchedulerClients,
-    _load_corpus_metadata,
-    _load_corpus_resolutions,
-)
+from pscanner.scheduler import Scanner, SchedulerClients
 from pscanner.store.db import init_db
 
 


### PR DESCRIPTION
## Summary
- `_daemon_db(config)` context manager in `cli.py` replaces the `init_db` / `try` / `finally close()` pattern in 5 CLI subcommands (status, watch, unwatch, watchlist, paper_status).
- `Scanner._close_owned_clients` collapsed from 5 sequential `contextlib.suppress` blocks to one loop.
- `Scanner._run_once_collector(*, key, type_, call, log_event)` helper replaces 5 near-identical `_run_once_*_collector` methods. Dispatch is a 5-row table inside `_run_once_collectors`.
- New `pscanner.daemon.corpus_loader` module hosts `load_corpus_metadata` + `load_corpus_resolutions_into`, previously duplicated between `scheduler._load_corpus_metadata`/`_load_corpus_resolutions` and `daemon/bootstrap.py`. Both call sites switch to the shared loaders.
- `data/corpus.sqlite3` path lifted to a `DEFAULT_CORPUS_DB` module constant.
- Includes a `chore: ruff format drift from #161 #167` housekeeping prefix commit.

4 commits. 8 files. +256/-259.

## Notes
Phase-1 review finding F6 (delete defensive `isinstance(alert.body, dict) else {}` × 6 evaluators) was rejected on execution — the guard is load-bearing per `test_parse_rejects_non_dict_body` in `test_gate_model.py`. Python dataclasses don't enforce annotations at runtime, so the runtime guard remains the implementation of that contract. Documented in the worktree's `refactor-plan-strategies.md`.

## Test plan
- [ ] `tests/test_scheduler.py`, `tests/test_cli.py`, `tests/daemon/test_bootstrap.py`, `tests/scheduler/test_gate_model_wiring.py` all green
- [ ] `uv run pytest -q` passes (1467 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)