### PR TITLE
refactor(detectors): wire_sink, AsyncDispatcher, run_periodic, cluster cache

### DIFF
--- a/src/pscanner/detectors/cluster.py
+++ b/src/pscanner/detectors/cluster.py
@@ -188,25 +188,58 @@ class ClusterDetector:
         recent = self._first_seen.list_recent(within=self._config.discovery_lookback_days)
         if len(recent) < self._config.min_cluster_size:
             return 0
+        # Fetch each candidate wallet's recent trades ONCE per scan; thread the
+        # cache through the three downstream consumers (was 3x queries each).
+        trades_by_wallet = self._load_recent_trades(recent)
         seen_cluster_ids: set[str] = set()
         new_count = 0
         # Path 1: existing creation-window partition.
         for group in self._iter_candidate_groups(recent):
-            if await self._consider_group(group, seen_cluster_ids, sink):
+            if await self._consider_group(group, seen_cluster_ids, sink, trades_by_wallet):
                 new_count += 1
         # Path 2: co-occurrence partition (organic clusters via shared
         # obscure-market overlap). _consider_group's _cluster_id_for SHA256
         # dedupe ensures clusters surfaced by both paths emit exactly once.
-        for group in self._iter_co_trade_groups(recent):
-            if await self._consider_group(group, seen_cluster_ids, sink):
+        for group in self._iter_co_trade_groups(recent, trades_by_wallet=trades_by_wallet):
+            if await self._consider_group(group, seen_cluster_ids, sink, trades_by_wallet):
                 new_count += 1
         return new_count
+
+    def _load_recent_trades(
+        self,
+        recent: list[WalletFirstSeen],
+    ) -> dict[str, list[WalletTrade]]:
+        """Pull each candidate wallet's recent trades into a per-scan cache.
+
+        Per-wallet ``recent_for_wallet`` failures are isolated: the failing
+        wallet maps to ``[]`` (treated as no trades by every downstream
+        consumer) and a ``cluster.recent_trades_failed`` warning is emitted.
+        Other wallets in the same scan are unaffected.
+        """
+        out: dict[str, list[WalletTrade]] = {}
+        for wallet in recent:
+            try:
+                out[wallet.address] = list(
+                    self._trades.recent_for_wallet(
+                        wallet.address,
+                        limit=_RECENT_TRADE_LIMIT,
+                    ),
+                )
+            except Exception:
+                _LOG.warning(
+                    "cluster.recent_trades_failed",
+                    wallet=wallet.address,
+                    exc_info=True,
+                )
+                out[wallet.address] = []
+        return out
 
     async def _consider_group(
         self,
         group: list[WalletFirstSeen],
         seen_cluster_ids: set[str],
         sink: AlertSink,
+        trades_by_wallet: dict[str, list[WalletTrade]],
     ) -> bool:
         """Evaluate one candidate group; return True iff a new alert emitted."""
         cluster_id = _cluster_id_for(group)
@@ -215,7 +248,7 @@ class ClusterDetector:
         seen_cluster_ids.add(cluster_id)
         if self._clusters.get(cluster_id) is not None:
             return False
-        scored = self._score_candidate(group)
+        scored = self._score_candidate(group, trades_by_wallet)
         if scored is None:
             return False
         score, shared_markets, behavior_tag = scored
@@ -266,6 +299,8 @@ class ClusterDetector:
     def _iter_co_trade_groups(
         self,
         recent: list[WalletFirstSeen],
+        *,
+        trades_by_wallet: dict[str, list[WalletTrade]] | None = None,
     ) -> Iterable[list[WalletFirstSeen]]:
         """Yield candidate groups derived from shared-obscure-market overlap.
 
@@ -277,41 +312,39 @@ class ClusterDetector:
         This path is independent of creation timestamps — it discovers
         clusters that grew organically over time. Existing scoring
         (B/C/D + the refactored Signal A) is applied per component.
+
+        Args:
+            recent: Candidate wallets.
+            trades_by_wallet: Optional pre-loaded per-wallet trade cache
+                (built by :meth:`discovery_scan` to avoid re-querying
+                across the three downstream consumers). When omitted —
+                as in unit tests that call this method directly — the
+                cache is built inline via :meth:`_load_recent_trades`.
         """
         if len(recent) < self._config.min_cluster_size:
             return
 
-        obscure_markets = self._build_obscure_markets_index(recent)
+        if trades_by_wallet is None:
+            trades_by_wallet = self._load_recent_trades(recent)
+        obscure_markets = self._build_obscure_markets_index(recent, trades_by_wallet)
         adjacency = self._build_cotrade_adjacency(obscure_markets)
         yield from self._yield_components(recent, adjacency)
 
     def _build_obscure_markets_index(
         self,
         recent: list[WalletFirstSeen],
+        trades_by_wallet: dict[str, list[WalletTrade]],
     ) -> dict[str, set[ConditionId]]:
         """Per-wallet set of obscure-market condition_ids.
 
-        Per-wallet ``recent_for_wallet`` failures are isolated — that
-        wallet's set is treated as empty (no edges incident on it). Other
-        wallets unaffected.
+        Reads from the per-scan trade cache built by
+        :meth:`_load_recent_trades`. Wallets that failed during load have
+        empty entries in the cache (treated here as zero obscure markets).
         """
         index: dict[str, set[ConditionId]] = {}
         for wallet in recent:
-            try:
-                trades = self._trades.recent_for_wallet(
-                    wallet.address,
-                    limit=_RECENT_TRADE_LIMIT,
-                )
-            except Exception:
-                _LOG.warning(
-                    "cluster.cotrade_trades_failed",
-                    wallet=wallet.address,
-                    exc_info=True,
-                )
-                index[wallet.address] = set()
-                continue
             obscure: set[ConditionId] = set()
-            for trade in trades:
+            for trade in trades_by_wallet.get(wallet.address, []):
                 cached = self._market_cache.get_by_condition_id(trade.condition_id)
                 if cached is None:
                     continue
@@ -403,6 +436,7 @@ class ClusterDetector:
     def _score_candidate(
         self,
         group: list[WalletFirstSeen],
+        trades_by_wallet: dict[str, list[WalletTrade]],
     ) -> tuple[int, list[CachedMarket], str | None] | None:
         """Score a candidate group and return ``(score, shared_markets, tag)``.
 
@@ -416,11 +450,13 @@ class ClusterDetector:
         # (co-occurrence — added in a later task) it is a real bonus when
         # the discovered cluster also has tight creation timestamps.
         score += self._compute_creation_cohesion_score(group)
-        shared = self._find_shared_obscure_markets(wallets)
+        shared = self._find_shared_obscure_markets(wallets, trades_by_wallet)
         if len(shared) >= self._config.min_shared_markets:
             score += 2
         # Signals C and D inspect cluster trades on shared markets.
-        cluster_trades_by_market = self._collect_cluster_trades(wallets, shared)
+        cluster_trades_by_market = self._collect_cluster_trades(
+            wallets, shared, trades_by_wallet,
+        )
         if self._has_size_correlation(cluster_trades_by_market):
             score += 1
         if self._has_direction_correlation(cluster_trades_by_market):
@@ -429,16 +465,21 @@ class ClusterDetector:
         behavior_tag = _behavior_tag_for(all_trades)
         return score, shared, behavior_tag
 
-    def _find_shared_obscure_markets(self, wallets: list[str]) -> list[CachedMarket]:
+    def _find_shared_obscure_markets(
+        self,
+        wallets: list[str],
+        trades_by_wallet: dict[str, list[WalletTrade]],
+    ) -> list[CachedMarket]:
         """Return obscure markets traded by ≥3 distinct cluster wallets.
 
         "Obscure" means below ``max_shared_market_liquidity_usd`` AND below
         ``max_shared_market_volume_usd``. Markets missing from the cache or
-        with NULL liquidity / volume are conservatively excluded.
+        with NULL liquidity / volume are conservatively excluded. Reads
+        from the per-scan trade cache built by :meth:`_load_recent_trades`.
         """
         traders_per_market: dict[ConditionId, set[str]] = {}
         for wallet in wallets:
-            for trade in self._trades.recent_for_wallet(wallet, limit=_RECENT_TRADE_LIMIT):
+            for trade in trades_by_wallet.get(wallet, []):
                 traders_per_market.setdefault(trade.condition_id, set()).add(wallet)
         shared: list[CachedMarket] = []
         for condition_id, traders in traders_per_market.items():
@@ -464,12 +505,17 @@ class ClusterDetector:
         self,
         wallets: list[str],
         shared: list[CachedMarket],
+        trades_by_wallet: dict[str, list[WalletTrade]],
     ) -> dict[ConditionId, list[WalletTrade]]:
-        """Group cluster trades by ``condition_id`` for the shared markets."""
+        """Group cluster trades by ``condition_id`` for the shared markets.
+
+        Reads from the per-scan trade cache built by
+        :meth:`_load_recent_trades`.
+        """
         shared_ids = {m.condition_id for m in shared if m.condition_id is not None}
         out: dict[ConditionId, list[WalletTrade]] = {cid: [] for cid in shared_ids}
         for wallet in wallets:
-            for trade in self._trades.recent_for_wallet(wallet, limit=_RECENT_TRADE_LIMIT):
+            for trade in trades_by_wallet.get(wallet, []):
                 if trade.condition_id in shared_ids:
                     out[trade.condition_id].append(trade)
         return out

--- a/src/pscanner/detectors/cluster.py
+++ b/src/pscanner/detectors/cluster.py
@@ -46,6 +46,7 @@ from pscanner.store.repo import (
 )
 from pscanner.util.async_dispatch import AsyncDispatcher
 from pscanner.util.clock import Clock, RealClock
+from pscanner.util.loops import run_periodic
 
 _LOG = structlog.get_logger(__name__)
 _BEHAVIOR_FARMER_LO = 0.5
@@ -123,14 +124,12 @@ class ClusterDetector:
         """
         if self._sink is None:
             self._sink = sink
-        while True:
-            try:
-                await self.discovery_scan(sink)
-            except asyncio.CancelledError:
-                raise
-            except Exception:
-                _LOG.exception("cluster.discovery_failed")
-            await self._clock.sleep(self._config.scan_interval_seconds)
+        await run_periodic(
+            lambda: self.discovery_scan(sink),
+            interval_seconds=self._config.scan_interval_seconds,
+            clock=self._clock,
+            log_event="cluster.discovery_failed",
+        )
 
     def handle_trade_sync(self, trade: WalletTrade) -> None:
         """Sync entry called by the trade collector callback.

--- a/src/pscanner/detectors/cluster.py
+++ b/src/pscanner/detectors/cluster.py
@@ -96,6 +96,15 @@ class ClusterDetector:
         self._sink: AlertSink | None = None
         self._pending_tasks: set[asyncio.Task[None]] = set()
 
+    def wire_sink(self, sink: AlertSink) -> None:
+        """Pre-wire the alert sink before :meth:`run` starts.
+
+        Used by the scheduler (and tests) to seed the sink before the
+        trade-callback path fires for the first time. Mirrors the
+        ``if self._sink is None`` ratchet inside :meth:`run`.
+        """
+        self._sink = sink
+
     async def run(self, sink: AlertSink) -> None:
         """Periodic discovery loop — scans for new clusters on a fixed cadence.
 

--- a/src/pscanner/detectors/cluster.py
+++ b/src/pscanner/detectors/cluster.py
@@ -44,6 +44,7 @@ from pscanner.store.repo import (
     WalletTrade,
     WalletTradesRepo,
 )
+from pscanner.util.async_dispatch import AsyncDispatcher
 from pscanner.util.clock import Clock, RealClock
 
 _LOG = structlog.get_logger(__name__)
@@ -94,7 +95,12 @@ class ClusterDetector:
         self._members = members_repo
         self._clock: Clock = clock if clock is not None else RealClock()
         self._sink: AlertSink | None = None
-        self._pending_tasks: set[asyncio.Task[None]] = set()
+        self._dispatcher = AsyncDispatcher(log_event_no_loop="cluster.no_event_loop")
+
+    @property
+    def pending_tasks(self) -> set[asyncio.Task[None]]:
+        """Live view of in-flight ``evaluate_active`` tasks (test hook)."""
+        return self._dispatcher.pending
 
     def wire_sink(self, sink: AlertSink) -> None:
         """Pre-wire the alert sink before :meth:`run` starts.
@@ -129,21 +135,17 @@ class ClusterDetector:
     def handle_trade_sync(self, trade: WalletTrade) -> None:
         """Sync entry called by the trade collector callback.
 
-        Spawns ``evaluate_active(trade)`` as an async task and tracks it so
-        it isn't garbage collected mid-flight. No-ops if there is no running
-        event loop (e.g. test setup that hasn't started one yet).
+        Spawns ``evaluate_active(trade)`` as a tracked task. No-ops (with
+        a ``cluster.no_event_loop`` debug event) when no event loop is
+        running.
 
         Args:
             trade: Newly-inserted ``WalletTrade`` row.
         """
-        try:
-            loop = asyncio.get_running_loop()
-        except RuntimeError:
-            _LOG.debug("cluster.no_event_loop", tx=trade.transaction_hash)
-            return
-        task = loop.create_task(self.evaluate_active(trade))
-        self._pending_tasks.add(task)
-        task.add_done_callback(self._pending_tasks.discard)
+        self._dispatcher.spawn(
+            self.evaluate_active(trade),
+            tx=trade.transaction_hash,
+        )
 
     async def evaluate_active(self, trade: WalletTrade) -> None:
         """Emit ``cluster.active`` when several cluster members hit one market.

--- a/src/pscanner/detectors/gate_model.py
+++ b/src/pscanner/detectors/gate_model.py
@@ -154,6 +154,14 @@ class GateModelDetector(TradeDrivenDetector):
         """
         return trade.side == "BUY"
 
+    def wire_sink(self, sink: AlertSink) -> None:
+        """Pre-wire the alert sink before :meth:`run` starts.
+
+        Used by the scheduler (and tests) to seed the sink before the
+        queued worker fires for the first time.
+        """
+        self._sink = sink
+
     def handle_trade_sync(self, trade: WalletTrade) -> None:
         """Enqueue for scoring; drop if queue is full or trade fails pre-screen."""
         if not self._should_score(trade):

--- a/src/pscanner/detectors/gate_model.py
+++ b/src/pscanner/detectors/gate_model.py
@@ -38,7 +38,6 @@ from pscanner.corpus.features import (
     Trade,
     compute_features,
 )
-from pscanner.detectors.trade_driven import TradeDrivenDetector
 from pscanner.ml.preprocessing import CARRIER_COLS, LEAKAGE_COLS, OneHotEncoder
 
 if TYPE_CHECKING:
@@ -50,8 +49,15 @@ _LOG = structlog.get_logger(__name__)
 _REQUIRED_PREPROCESSOR_VERSION: Final[int] = 2
 
 
-class GateModelDetector(TradeDrivenDetector):
-    """Score trades against a loaded XGBoost gate model and emit alerts."""
+class GateModelDetector:
+    """Score trades against a loaded XGBoost gate model and emit alerts.
+
+    Standalone detector — does not inherit from :class:`TradeDrivenDetector`
+    because its callback path is queue-deferred (own ``asyncio.Queue`` plus
+    a worker drain loop in :meth:`run`), not the spawn-and-track pattern
+    the base class provides. The scheduler treats it as a sibling via an
+    explicit ``isinstance`` widening.
+    """
 
     name = "gate_model"
 
@@ -75,7 +81,7 @@ class GateModelDetector(TradeDrivenDetector):
                 outcome resolution returns ``""`` and every trade is skipped
                 — production wiring always provides one.
         """
-        super().__init__()
+        self._sink: AlertSink | None = None
         self._config = config
         self._provider = provider
         self._alerts_repo = alerts_repo

--- a/src/pscanner/detectors/move_attribution.py
+++ b/src/pscanner/detectors/move_attribution.py
@@ -22,6 +22,7 @@ from pscanner.alerts.sink import AlertSink
 from pscanner.config import MoveAttributionConfig
 from pscanner.poly.data import DataClient
 from pscanner.store.repo import WatchlistRepo
+from pscanner.util.async_dispatch import AsyncDispatcher
 
 _LOG = structlog.get_logger(__name__)
 
@@ -297,7 +298,14 @@ class MoveAttributionDetector:
         self._data_client = data_client
         self._watchlist_repo = watchlist_repo
         self._sink: AlertSink | None = None
-        self._pending_tasks: set[asyncio.Task[None]] = set()
+        self._dispatcher = AsyncDispatcher(
+            log_event_no_loop="move_attribution.no_event_loop",
+        )
+
+    @property
+    def pending_tasks(self) -> set[asyncio.Task[None]]:
+        """Live view of in-flight ``evaluate`` tasks (aclose() hook)."""
+        return self._dispatcher.pending
 
     def wire_sink(self, sink: AlertSink) -> None:
         """Pre-wire the alert sink before :meth:`run` starts.
@@ -316,19 +324,13 @@ class MoveAttributionDetector:
     def handle_alert_sync(self, alert: Alert) -> None:
         """Subscriber callback fanned out by ``AlertSink.emit``.
 
-        Spawns ``evaluate(alert)`` as a tracked task so it isn't garbage
-        collected mid-flight. No-ops if there is no running event loop.
+        Spawns ``evaluate(alert)`` as a tracked task. No-ops (with a
+        ``move_attribution.no_event_loop`` debug event) when no event
+        loop is running.
         """
         if alert.detector not in self._config.trigger_detectors:
             return
-        try:
-            loop = asyncio.get_running_loop()
-        except RuntimeError:
-            _LOG.debug("move_attribution.no_event_loop", alert_key=alert.alert_key)
-            return
-        task = loop.create_task(self.evaluate(alert))
-        self._pending_tasks.add(task)
-        task.add_done_callback(self._pending_tasks.discard)
+        self._dispatcher.spawn(self.evaluate(alert), alert_key=alert.alert_key)
 
     async def evaluate(self, alert: Alert) -> None:
         """Run the full pipeline for one triggering alert."""
@@ -439,9 +441,9 @@ class MoveAttributionDetector:
 
     async def aclose(self) -> None:
         """Wait for any in-flight evaluation tasks to finish (test helper)."""
-        if not self._pending_tasks:
+        if not self._dispatcher.pending:
             return
-        await asyncio.gather(*self._pending_tasks, return_exceptions=True)
+        await asyncio.gather(*self._dispatcher.pending, return_exceptions=True)
 
 
 __all__ = ["BurstHit", "MoveAttributionDetector", "_backwalk", "_detect_burst"]

--- a/src/pscanner/detectors/move_attribution.py
+++ b/src/pscanner/detectors/move_attribution.py
@@ -299,6 +299,14 @@ class MoveAttributionDetector:
         self._sink: AlertSink | None = None
         self._pending_tasks: set[asyncio.Task[None]] = set()
 
+    def wire_sink(self, sink: AlertSink) -> None:
+        """Pre-wire the alert sink before :meth:`run` starts.
+
+        Used by the scheduler (and tests) to seed the sink before any
+        upstream :meth:`handle_alert_sync` callback fires.
+        """
+        self._sink = sink
+
     async def run(self, sink: AlertSink) -> None:
         """Park forever — this detector is alert-driven, not periodic."""
         if self._sink is None:

--- a/src/pscanner/detectors/polling.py
+++ b/src/pscanner/detectors/polling.py
@@ -9,15 +9,11 @@ detectors don't need a uniform config shape.
 
 from __future__ import annotations
 
-import asyncio
 from abc import ABC, abstractmethod
-
-import structlog
 
 from pscanner.alerts.sink import AlertSink
 from pscanner.util.clock import Clock, RealClock
-
-_LOG = structlog.get_logger(__name__)
+from pscanner.util.loops import run_periodic
 
 
 class PollingDetector(ABC):
@@ -35,7 +31,8 @@ class PollingDetector(ABC):
     The :meth:`run` loop catches and logs every non-cancellation exception so
     a transient API failure inside ``_scan`` doesn't tear down the detector.
     ``asyncio.CancelledError`` is re-raised so the orchestrating
-    ``asyncio.TaskGroup`` shuts down cleanly.
+    ``asyncio.TaskGroup`` shuts down cleanly. The cancel/swallow/sleep
+    machinery itself lives in :func:`pscanner.util.loops.run_periodic`.
     """
 
     name: str = ""
@@ -67,11 +64,10 @@ class PollingDetector(ABC):
         Args:
             sink: Shared alert sink every iteration emits to.
         """
-        while True:
-            try:
-                await self._scan(sink)
-            except asyncio.CancelledError:
-                raise
-            except Exception:
-                _LOG.exception("polling.scan_failed", detector=self.name)
-            await self._clock.sleep(self._interval_seconds())
+        await run_periodic(
+            lambda: self._scan(sink),
+            interval_seconds=self._interval_seconds,
+            clock=self._clock,
+            log_event="polling.scan_failed",
+            log_fields={"detector": self.name},
+        )

--- a/src/pscanner/detectors/smart_money.py
+++ b/src/pscanner/detectors/smart_money.py
@@ -41,6 +41,7 @@ from pscanner.store.repo import (
     TrackedWalletsRepo,
 )
 from pscanner.util.clock import Clock, RealClock
+from pscanner.util.loops import run_periodic
 
 _LOG = structlog.get_logger(__name__)
 
@@ -184,23 +185,21 @@ class SmartMoneyDetector:
 
     async def _refresh_loop(self) -> None:
         """Drive :meth:`_refresh_tracked_wallets` on the configured cadence."""
-        interval = self._config.refresh_interval_seconds
-        while True:
-            try:
-                await self._refresh_tracked_wallets()
-            except Exception:
-                _LOG.exception("smart_money.refresh_failed")
-            await self._clock.sleep(interval)
+        await run_periodic(
+            self._refresh_tracked_wallets,
+            interval_seconds=self._config.refresh_interval_seconds,
+            clock=self._clock,
+            log_event="smart_money.refresh_failed",
+        )
 
     async def _poll_loop(self, sink: AlertSink) -> None:
         """Drive :meth:`poll_positions` on the configured cadence."""
-        interval = self._config.position_poll_interval_seconds
-        while True:
-            try:
-                await self.poll_positions(sink)
-            except Exception:
-                _LOG.exception("smart_money.poll_failed")
-            await self._clock.sleep(interval)
+        await run_periodic(
+            lambda: self.poll_positions(sink),
+            interval_seconds=self._config.position_poll_interval_seconds,
+            clock=self._clock,
+            log_event="smart_money.poll_failed",
+        )
 
     async def _refresh_tracked_wallets(self) -> None:
         """Recompute and persist tracked wallets from the live leaderboard."""

--- a/src/pscanner/detectors/trade_driven.py
+++ b/src/pscanner/detectors/trade_driven.py
@@ -16,12 +16,9 @@ from __future__ import annotations
 import asyncio
 from abc import ABC, abstractmethod
 
-import structlog
-
 from pscanner.alerts.sink import AlertSink
 from pscanner.store.repo import WalletTrade
-
-_LOG = structlog.get_logger(__name__)
+from pscanner.util.async_dispatch import AsyncDispatcher
 
 
 class TradeDrivenDetector(ABC):
@@ -30,9 +27,14 @@ class TradeDrivenDetector(ABC):
     name: str = ""
 
     def __init__(self) -> None:
-        """Initialise the shared sink slot and pending-tasks tracker."""
+        """Initialise the shared sink slot and async dispatcher."""
         self._sink: AlertSink | None = None
-        self._pending_tasks: set[asyncio.Task[None]] = set()
+        self._dispatcher = AsyncDispatcher(log_event_no_loop="trade_driven.no_event_loop")
+
+    @property
+    def pending_tasks(self) -> set[asyncio.Task[None]]:
+        """Live view of in-flight ``evaluate`` tasks (test + aclose hook)."""
+        return self._dispatcher.pending
 
     @abstractmethod
     async def evaluate(self, trade: WalletTrade) -> None:
@@ -56,25 +58,18 @@ class TradeDrivenDetector(ABC):
     def handle_trade_sync(self, trade: WalletTrade) -> None:
         """Sync entry for ``TradeCollector.subscribe_new_trade``.
 
-        Spawns ``evaluate(trade)`` as an async task and tracks it so it
-        isn't garbage collected before completion. No-ops if there's no
-        running event loop (e.g., test setup that hasn't started one).
+        Spawns ``evaluate(trade)`` as a tracked task. No-ops (with a
+        ``trade_driven.no_event_loop`` debug event) when no event loop is
+        running, e.g. test setup that hasn't started one.
 
         Args:
             trade: Newly-inserted ``WalletTrade`` row.
         """
-        try:
-            loop = asyncio.get_running_loop()
-        except RuntimeError:
-            _LOG.debug(
-                "trade_driven.no_event_loop",
-                detector=self.name,
-                tx=trade.transaction_hash,
-            )
-            return
-        task = loop.create_task(self.evaluate(trade))
-        self._pending_tasks.add(task)
-        task.add_done_callback(self._pending_tasks.discard)
+        self._dispatcher.spawn(
+            self.evaluate(trade),
+            detector=self.name,
+            tx=trade.transaction_hash,
+        )
 
     async def run(self, sink: AlertSink) -> None:
         """Park forever — the detector is callback-driven, not loop-driven.

--- a/src/pscanner/detectors/trade_driven.py
+++ b/src/pscanner/detectors/trade_driven.py
@@ -42,6 +42,17 @@ class TradeDrivenDetector(ABC):
             trade: Newly-inserted ``WalletTrade`` row.
         """
 
+    def wire_sink(self, sink: AlertSink) -> None:
+        """Pre-wire the alert sink before :meth:`run` starts.
+
+        Used by the scheduler (and tests) to seed the sink before the
+        callback-driven path fires for the first time. Mirrors the
+        ``if self._sink is None: self._sink = sink`` ratcheting in
+        :meth:`run` — callers that drive ``run()`` directly without
+        pre-wiring still get the fallback assignment.
+        """
+        self._sink = sink
+
     def handle_trade_sync(self, trade: WalletTrade) -> None:
         """Sync entry for ``TradeCollector.subscribe_new_trade``.
 

--- a/src/pscanner/detectors/whales.py
+++ b/src/pscanner/detectors/whales.py
@@ -21,7 +21,6 @@ collector via ``TradeCollector.subscribe_new_trade``.
 
 from __future__ import annotations
 
-import asyncio
 import time
 
 import structlog
@@ -41,6 +40,7 @@ from pscanner.store.repo import (
     WalletTrade,
 )
 from pscanner.util.clock import Clock, RealClock
+from pscanner.util.loops import run_periodic
 
 _LOG = structlog.get_logger(__name__)
 _WALLET_CACHE_TTL_SECONDS = 86400
@@ -98,14 +98,12 @@ class WhalesDetector(TradeDrivenDetector):
         """
         if self._sink is None:
             self._sink = sink
-        while True:
-            try:
-                await self._refresh_market_cache()
-            except asyncio.CancelledError:
-                raise
-            except Exception:
-                _LOG.exception("whales.refresh_failed")
-            await self._clock.sleep(self._config.ws_resubscribe_interval_seconds)
+        await run_periodic(
+            self._refresh_market_cache,
+            interval_seconds=self._config.ws_resubscribe_interval_seconds,
+            clock=self._clock,
+            log_event="whales.refresh_failed",
+        )
 
     async def _refresh_market_cache(self) -> None:
         """Page the active markets, upsert into market_cache, rebuild condition map."""

--- a/src/pscanner/scheduler.py
+++ b/src/pscanner/scheduler.py
@@ -218,7 +218,7 @@ class Scanner:
             return
         for detector in self._detectors.values():
             if isinstance(detector, TradeDrivenDetector | ClusterDetector):
-                detector._sink = self._sink
+                detector.wire_sink(self._sink)
                 trade_collector.subscribe_new_trade(detector.handle_trade_sync)
                 _LOG.info("scanner.trade_driven_detector_wired", detector=detector.name)
 
@@ -230,7 +230,7 @@ class Scanner:
             return
         if not isinstance(gate_detector, GateModelDetector):
             return
-        gate_detector._sink = self._sink
+        gate_detector.wire_sink(self._sink)
         market_scoped.subscribe_new_trade(gate_detector.handle_trade_sync)
         _LOG.info("scanner.gate_model_wired", detector=gate_detector.name)
 
@@ -248,7 +248,7 @@ class Scanner:
         """
         for detector in self._detectors.values():
             if isinstance(detector, MoveAttributionDetector):
-                detector._sink = self._sink
+                detector.wire_sink(self._sink)
                 self._sink.subscribe(detector.handle_alert_sync)
                 _LOG.info("scanner.alert_driven_detector_wired", detector=detector.name)
             elif isinstance(detector, PaperTrader):

--- a/src/pscanner/scheduler.py
+++ b/src/pscanner/scheduler.py
@@ -208,16 +208,21 @@ class Scanner:
 
         Each trade-driven detector evaluates per-trade and needs its
         ``_sink`` populated before the run-loop starts so callbacks fire
-        correctly during the first poll cycle. The cluster detector has a
-        hybrid loop+callback shape and so doesn't inherit from
-        :class:`TradeDrivenDetector`; it is wired explicitly alongside the
-        TradeDrivenDetector subclasses.
+        correctly during the first poll cycle. :class:`ClusterDetector`
+        has a hybrid loop+callback shape and :class:`GateModelDetector`
+        is queue-deferred — neither inherits from
+        :class:`TradeDrivenDetector`, so both are wired explicitly via
+        ``isinstance`` widening alongside the TradeDrivenDetector
+        subclasses.
         """
         trade_collector = self._collectors.get("trade_collector")
         if not isinstance(trade_collector, TradeCollector):
             return
         for detector in self._detectors.values():
-            if isinstance(detector, TradeDrivenDetector | ClusterDetector):
+            if isinstance(
+                detector,
+                TradeDrivenDetector | ClusterDetector | GateModelDetector,
+            ):
                 detector.wire_sink(self._sink)
                 trade_collector.subscribe_new_trade(detector.handle_trade_sync)
                 _LOG.info("scanner.trade_driven_detector_wired", detector=detector.name)

--- a/src/pscanner/util/async_dispatch.py
+++ b/src/pscanner/util/async_dispatch.py
@@ -1,0 +1,79 @@
+"""Shared sync→async dispatch helper for callback-driven detectors.
+
+Detectors with synchronous callback entry points (e.g. trade-collector
+``subscribe_new_trade`` callbacks, alert ``subscribe`` subscribers) need
+to spawn coroutines as fire-and-forget tasks while still holding a
+reference to each task so the GC doesn't collect it mid-flight.
+
+The same three-step idiom (``try get_running_loop``, ``create_task``,
+``add + add_done_callback``) was duplicated across
+:class:`TradeDrivenDetector`, :class:`ClusterDetector`, and
+:class:`MoveAttributionDetector`. This module hosts the one shared
+implementation; detectors compose an :class:`AsyncDispatcher` instead
+of re-implementing the pattern.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Coroutine
+from typing import Any
+
+import structlog
+
+_LOG = structlog.get_logger(__name__)
+
+
+class AsyncDispatcher:
+    """Spawn coroutines as tracked fire-and-forget tasks.
+
+    Each dispatcher owns its own pending-task set. When there's no
+    running event loop (e.g. test setup that hasn't started one yet),
+    :meth:`spawn` logs the configured ``log_event_no_loop`` event at
+    ``DEBUG`` and returns silently — the un-awaited coroutine is closed
+    so the call doesn't leak.
+    """
+
+    def __init__(self, *, log_event_no_loop: str) -> None:
+        """Build a dispatcher with a stable no-loop log event name.
+
+        Args:
+            log_event_no_loop: structlog event name emitted when
+                :meth:`spawn` is called without a running event loop.
+                Preserved per-caller for telemetry continuity.
+        """
+        self._tasks: set[asyncio.Task[None]] = set()
+        self._log_event_no_loop = log_event_no_loop
+
+    def spawn(
+        self,
+        coro: Coroutine[Any, Any, None],
+        /,
+        **log_fields: object,
+    ) -> None:
+        """Schedule ``coro`` on the running event loop.
+
+        Args:
+            coro: The coroutine to spawn. Closed (not awaited) when
+                no event loop is running.
+            **log_fields: Additional fields attached to the
+                ``log_event_no_loop`` debug event when the no-loop
+                branch fires.
+        """
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            _LOG.debug(self._log_event_no_loop, **log_fields)
+            coro.close()
+            return
+        task = loop.create_task(coro)
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+
+    @property
+    def pending(self) -> set[asyncio.Task[None]]:
+        """Live view of the in-flight task set (for tests and aclose())."""
+        return self._tasks
+
+
+__all__ = ["AsyncDispatcher"]

--- a/src/pscanner/util/loops.py
+++ b/src/pscanner/util/loops.py
@@ -1,0 +1,75 @@
+"""Shared periodic-loop helper used by polling-shaped detector loops.
+
+The "while True / try work / except CancelledError raise / except Exception
+log / sleep" pattern was duplicated across five detector loop sites:
+
+* :class:`PollingDetector.run` (canonical version).
+* :class:`ClusterDetector.run`.
+* :class:`WhalesDetector.run`.
+* :meth:`SmartMoneyDetector._refresh_loop` and
+  :meth:`SmartMoneyDetector._poll_loop`.
+
+This module hosts the single shared implementation. Stream-driven
+detectors (e.g. :class:`PriceVelocityDetector`) use a different
+``async for`` shape and stay on their inline implementation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable, Mapping
+
+import structlog
+
+from pscanner.util.clock import Clock
+
+_LOG = structlog.get_logger(__name__)
+
+
+async def run_periodic(
+    work: Callable[[], Awaitable[object]],
+    *,
+    interval_seconds: float | Callable[[], float],
+    clock: Clock,
+    log_event: str,
+    log_fields: Mapping[str, object] | None = None,
+) -> None:
+    """Run ``work`` forever on ``interval_seconds``, surviving exceptions.
+
+    ``asyncio.CancelledError`` is re-raised so the orchestrating
+    :class:`asyncio.TaskGroup` can shut down cleanly. Every other
+    exception is logged via ``_LOG.exception(log_event, **log_fields)``
+    and the loop continues — one bad iteration cannot tear down the
+    detector.
+
+    Args:
+        work: Zero-arg coroutine factory invoked once per iteration.
+            Wrap closure state in a ``lambda`` when ``work`` needs
+            arguments.
+        interval_seconds: Sleep duration between iterations. Pass a
+            ``float`` for a fixed interval, or a ``Callable[[], float]``
+            (re-evaluated per cycle) when the interval may change at
+            runtime — e.g. :meth:`PollingDetector._interval_seconds`.
+        clock: Injected :class:`Clock` used for the sleep.
+        log_event: structlog event name emitted when ``work`` raises
+            a non-cancellation exception. Preserved per-caller for
+            telemetry continuity.
+        log_fields: Optional extra fields attached to the
+            ``log_event`` exception log line.
+    """
+    fields = dict(log_fields) if log_fields is not None else {}
+    while True:
+        try:
+            await work()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            _LOG.exception(log_event, **fields)
+        if isinstance(interval_seconds, int | float):
+            seconds = float(interval_seconds)
+        else:
+            seconds = interval_seconds()
+        await clock.sleep(seconds)
+
+
+__all__ = ["run_periodic"]

--- a/tests/detectors/test_cluster.py
+++ b/tests/detectors/test_cluster.py
@@ -672,7 +672,7 @@ def test_handle_trade_sync_no_running_loop_is_noop() -> None:
     """With no running loop, ``handle_trade_sync`` returns silently."""
     detector = _make_detector()
     detector.handle_trade_sync(_trade(wallet="0xa", condition_id="cond-1"))
-    assert detector._pending_tasks == set()
+    assert detector.pending_tasks == set()
 
 
 @pytest.mark.asyncio

--- a/tests/detectors/test_cluster.py
+++ b/tests/detectors/test_cluster.py
@@ -276,7 +276,7 @@ def _make_detector(
         clock=clock or FakeClock(start=float(_NOW)),
     )
     if sink is not None:
-        detector._sink = sink  # type: ignore[assignment]  # ty:ignore[invalid-assignment]
+        detector.wire_sink(sink)  # type: ignore[arg-type]  # ty:ignore[invalid-argument-type]
     return detector
 
 

--- a/tests/detectors/test_convergence.py
+++ b/tests/detectors/test_convergence.py
@@ -178,7 +178,7 @@ def _make_detector(
         smart_money_config=smart_config or SmartMoneyConfig(),
     )
     if sink is not None:
-        detector._sink = sink  # type: ignore[assignment]  # ty:ignore[invalid-assignment]
+        detector.wire_sink(sink)  # type: ignore[arg-type]  # ty:ignore[invalid-argument-type]
     return detector
 
 

--- a/tests/detectors/test_gate_model.py
+++ b/tests/detectors/test_gate_model.py
@@ -225,7 +225,7 @@ async def test_evaluate_emits_alert_when_gates_pass(tmp_path: Path) -> None:
         detector._predict_one = lambda _: 0.85  # type: ignore[method-assign,assignment]  # ty:ignore[invalid-assignment]
         detector._resolve_outcome_side = lambda _trade: "YES"  # type: ignore[method-assign,assignment]  # ty:ignore[invalid-assignment]
         sink = AlertSink(alerts_repo=alerts_repo)
-        detector._sink = sink
+        detector.wire_sink(sink)
         trade = _make_wallet_trade(condition_id="0xc1", price=0.40)
         await detector.evaluate(trade)
         recent = alerts_repo.recent(detector="gate_buy", limit=10)
@@ -260,7 +260,7 @@ async def test_evaluate_skips_when_pred_below_floor(tmp_path: Path) -> None:
         detector = GateModelDetector(config=cfg, provider=provider, alerts_repo=alerts_repo)
         detector._predict_one = lambda _: 0.30  # type: ignore[method-assign,assignment]  # ty:ignore[invalid-assignment]
         detector._resolve_outcome_side = lambda _trade: "YES"  # type: ignore[method-assign,assignment]  # ty:ignore[invalid-assignment]
-        detector._sink = AlertSink(alerts_repo=alerts_repo)
+        detector.wire_sink(AlertSink(alerts_repo=alerts_repo))
         trade = _make_wallet_trade(condition_id="0xc1", price=0.20)
         await detector.evaluate(trade)
         recent = alerts_repo.recent(detector="gate_buy", limit=10)
@@ -289,7 +289,7 @@ async def test_evaluate_skips_when_category_not_accepted(tmp_path: Path) -> None
         detector = GateModelDetector(config=cfg, provider=provider, alerts_repo=alerts_repo)
         detector._predict_one = lambda _: 0.85  # type: ignore[method-assign,assignment]  # ty:ignore[invalid-assignment]
         detector._resolve_outcome_side = lambda _trade: "YES"  # type: ignore[method-assign,assignment]  # ty:ignore[invalid-assignment]
-        detector._sink = AlertSink(alerts_repo=alerts_repo)
+        detector.wire_sink(AlertSink(alerts_repo=alerts_repo))
         trade = _make_wallet_trade(condition_id="0xc1", price=0.40)
         await detector.evaluate(trade)
         recent = alerts_repo.recent(detector="gate_buy", limit=10)
@@ -323,7 +323,7 @@ async def test_evaluate_accepts_multi_label_market_via_intersection(tmp_path: Pa
         detector = GateModelDetector(config=cfg, provider=provider, alerts_repo=alerts_repo)
         detector._predict_one = lambda _: 0.85  # type: ignore[method-assign,assignment]  # ty:ignore[invalid-assignment]
         detector._resolve_outcome_side = lambda _trade: "YES"  # type: ignore[method-assign,assignment]  # ty:ignore[invalid-assignment]
-        detector._sink = AlertSink(alerts_repo=alerts_repo)
+        detector.wire_sink(AlertSink(alerts_repo=alerts_repo))
         trade = _make_wallet_trade(condition_id="0xc1", price=0.40)
         await detector.evaluate(trade)
         recent = alerts_repo.recent(detector="gate_buy", limit=10)
@@ -361,7 +361,7 @@ async def test_evaluate_falls_back_to_primary_category_when_categories_empty(
         detector = GateModelDetector(config=cfg, provider=provider, alerts_repo=alerts_repo)
         detector._predict_one = lambda _: 0.85  # type: ignore[method-assign,assignment]  # ty:ignore[invalid-assignment]
         detector._resolve_outcome_side = lambda _trade: "YES"  # type: ignore[method-assign,assignment]  # ty:ignore[invalid-assignment]
-        detector._sink = AlertSink(alerts_repo=alerts_repo)
+        detector.wire_sink(AlertSink(alerts_repo=alerts_repo))
         trade = _make_wallet_trade(condition_id="0xc1", price=0.40)
         await detector.evaluate(trade)
         recent = alerts_repo.recent(detector="gate_buy", limit=10)
@@ -397,7 +397,7 @@ async def test_evaluate_rejects_when_no_category_set_member_accepted(
         detector = GateModelDetector(config=cfg, provider=provider, alerts_repo=alerts_repo)
         detector._predict_one = lambda _: 0.85  # type: ignore[method-assign,assignment]  # ty:ignore[invalid-assignment]
         detector._resolve_outcome_side = lambda _trade: "YES"  # type: ignore[method-assign,assignment]  # ty:ignore[invalid-assignment]
-        detector._sink = AlertSink(alerts_repo=alerts_repo)
+        detector.wire_sink(AlertSink(alerts_repo=alerts_repo))
         trade = _make_wallet_trade(condition_id="0xc1", price=0.40)
         await detector.evaluate(trade)
         recent = alerts_repo.recent(detector="gate_buy", limit=10)

--- a/tests/detectors/test_move_attribution.py
+++ b/tests/detectors/test_move_attribution.py
@@ -293,7 +293,7 @@ async def test_detector_emits_candidate_and_watchlists_contributors(tmp_db) -> N
         )
         sink.subscribe(detector.handle_alert_sync)
         # The detector needs sink set so its async path can call sink.emit.
-        detector._sink = sink  # type: ignore[assignment]
+        detector.wire_sink(sink)
         await sink.emit(_build_velocity_alert(created_at=alert_ts))
         for _ in range(10):
             await asyncio.sleep(0)
@@ -320,7 +320,7 @@ async def test_detector_ignores_non_trigger_detectors(tmp_db) -> None:
             watchlist_repo=watchlist,
         )
         sink.subscribe(detector.handle_alert_sync)
-        detector._sink = sink  # type: ignore[assignment]
+        detector.wire_sink(sink)
         a = Alert(
             detector="whales",
             alert_key="whales:1",
@@ -350,7 +350,7 @@ async def test_detector_skips_alert_without_condition_id(tmp_db) -> None:
             watchlist_repo=watchlist,
         )
         sink.subscribe(detector.handle_alert_sync)
-        detector._sink = sink  # type: ignore[assignment]
+        detector.wire_sink(sink)
         a = Alert(
             detector="velocity",
             alert_key="velocity:nocond",
@@ -382,7 +382,7 @@ async def test_detector_swallows_trades_http_error(tmp_db) -> None:
             watchlist_repo=watchlist,
         )
         sink.subscribe(detector.handle_alert_sync)
-        detector._sink = sink  # type: ignore[assignment]
+        detector.wire_sink(sink)
         await sink.emit(_build_velocity_alert())
         for _ in range(10):
             await asyncio.sleep(0)

--- a/tests/detectors/test_trade_driven.py
+++ b/tests/detectors/test_trade_driven.py
@@ -104,7 +104,7 @@ async def test_run_does_not_overwrite_prewired_sink() -> None:
     """When ``_sink`` was pre-wired, ``run`` keeps the original instance."""
     detector = _RecordingDetector()
     prewired = _StubSink()
-    detector._sink = prewired  # type: ignore[assignment]  # ty:ignore[invalid-assignment]
+    detector.wire_sink(prewired)  # type: ignore[arg-type]  # ty:ignore[invalid-argument-type]
     other = _StubSink()
 
     task = asyncio.create_task(detector.run(other))  # type: ignore[arg-type]  # ty:ignore[invalid-argument-type]

--- a/tests/detectors/test_trade_driven.py
+++ b/tests/detectors/test_trade_driven.py
@@ -64,7 +64,7 @@ def test_handle_trade_sync_no_running_loop_is_noop() -> None:
     detector = _RecordingDetector()
     detector.handle_trade_sync(_make_trade())
     assert detector.evaluated == []
-    assert detector._pending_tasks == set()
+    assert detector.pending_tasks == set()
 
 
 @pytest.mark.asyncio
@@ -74,13 +74,13 @@ async def test_handle_trade_sync_spawns_and_tracks_then_clears_task() -> None:
     trade = _make_trade()
 
     detector.handle_trade_sync(trade)
-    assert len(detector._pending_tasks) == 1
+    assert len(detector.pending_tasks) == 1
 
     for _ in range(10):
         await asyncio.sleep(0)
 
     assert detector.evaluated == [trade]
-    assert detector._pending_tasks == set()
+    assert detector.pending_tasks == set()
 
 
 @pytest.mark.asyncio

--- a/tests/detectors/test_whales.py
+++ b/tests/detectors/test_whales.py
@@ -224,7 +224,7 @@ def _make_detector(
         wallet_first_seen=first_seen or StubFirstSeen(),  # type: ignore[arg-type]  # ty:ignore[invalid-argument-type]
     )
     if sink is not None:
-        detector._sink = sink  # type: ignore[assignment]  # ty:ignore[invalid-assignment]
+        detector.wire_sink(sink)  # type: ignore[arg-type]  # ty:ignore[invalid-argument-type]
     if seed_condition_map:
         cached = cache.get(_MARKET_ID)
         if cached is not None:

--- a/tests/util/test_async_dispatch.py
+++ b/tests/util/test_async_dispatch.py
@@ -1,0 +1,59 @@
+"""Tests for :class:`pscanner.util.async_dispatch.AsyncDispatcher`.
+
+The dispatcher's contract is exercised end-to-end via the detector
+test modules (``test_trade_driven.py``, ``test_cluster.py``,
+``test_move_attribution.py``). These focused unit tests pin the
+contract directly so future callers find the spec.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from pscanner.util.async_dispatch import AsyncDispatcher
+
+
+async def _make_coro(out: list[int], value: int) -> None:
+    out.append(value)
+
+
+def test_spawn_without_running_loop_drops_silently() -> None:
+    """No event loop → coro closed (not awaited), no pending tasks, no raise."""
+    dispatcher = AsyncDispatcher(log_event_no_loop="test.no_event_loop")
+    out: list[int] = []
+    coro = _make_coro(out, 42)
+    dispatcher.spawn(coro, source="t1")
+    assert dispatcher.pending == set()
+    assert out == []
+    # The coroutine must be closed so the test process doesn't leak a warning.
+    with pytest.raises(RuntimeError, match="cannot reuse already awaited|closed"):
+        coro.send(None)
+
+
+@pytest.mark.asyncio
+async def test_spawn_runs_and_clears_on_done() -> None:
+    """spawn(coro) schedules + tracks; tasks self-discard on completion."""
+    dispatcher = AsyncDispatcher(log_event_no_loop="test.no_event_loop")
+    out: list[int] = []
+    dispatcher.spawn(_make_coro(out, 1))
+    dispatcher.spawn(_make_coro(out, 2))
+    assert len(dispatcher.pending) == 2
+    for _ in range(10):
+        await asyncio.sleep(0)
+    assert sorted(out) == [1, 2]
+    assert dispatcher.pending == set()
+
+
+@pytest.mark.asyncio
+async def test_pending_is_live_view() -> None:
+    """The .pending property mutates as tasks come and go."""
+    dispatcher = AsyncDispatcher(log_event_no_loop="test.no_event_loop")
+    snapshot_before = dispatcher.pending
+    dispatcher.spawn(_make_coro([], 1))
+    assert snapshot_before is dispatcher.pending
+    assert len(dispatcher.pending) == 1
+    for _ in range(5):
+        await asyncio.sleep(0)
+    assert dispatcher.pending == set()

--- a/tests/util/test_async_dispatch.py
+++ b/tests/util/test_async_dispatch.py
@@ -28,7 +28,7 @@ def test_spawn_without_running_loop_drops_silently() -> None:
     assert dispatcher.pending == set()
     assert out == []
     # The coroutine must be closed so the test process doesn't leak a warning.
-    with pytest.raises(RuntimeError, match="cannot reuse already awaited|closed"):
+    with pytest.raises(RuntimeError, match=r"cannot reuse already awaited|closed"):
         coro.send(None)
 
 

--- a/tests/util/test_loops.py
+++ b/tests/util/test_loops.py
@@ -1,0 +1,101 @@
+"""Tests for :func:`pscanner.util.loops.run_periodic`.
+
+The contract is exercised end-to-end by every periodic detector's test
+module (PollingDetector subclasses, cluster, whales, smart_money). These
+focused unit tests pin the contract directly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from pscanner.util.clock import FakeClock
+from pscanner.util.loops import run_periodic
+
+
+@pytest.mark.asyncio
+async def test_run_periodic_cancellation_propagates() -> None:
+    """CancelledError from the surrounding task tears the loop down cleanly."""
+    clock = FakeClock(start=0.0)
+    iterations = 0
+
+    async def work() -> None:
+        nonlocal iterations
+        iterations += 1
+
+    task = asyncio.create_task(
+        run_periodic(
+            work,
+            interval_seconds=1.0,
+            clock=clock,
+            log_event="test.failed",
+        ),
+    )
+    # let one iteration land before cancelling
+    await asyncio.sleep(0)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert iterations >= 1
+
+
+@pytest.mark.asyncio
+async def test_run_periodic_swallows_exception_and_continues() -> None:
+    """work() raising Exception is logged + loop continues to next iteration."""
+    clock = FakeClock(start=0.0)
+    calls: list[str] = []
+
+    async def work() -> None:
+        calls.append("call")
+        if len(calls) == 1:
+            raise RuntimeError("boom")
+
+    task = asyncio.create_task(
+        run_periodic(
+            work,
+            interval_seconds=1.0,
+            clock=clock,
+            log_event="test.failed",
+            log_fields={"detector": "test"},
+        ),
+    )
+    await asyncio.sleep(0)
+    assert calls == ["call"]
+    await clock.advance(1.0)
+    await asyncio.sleep(0)
+    assert calls == ["call", "call"]
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+@pytest.mark.asyncio
+async def test_run_periodic_sleeps_for_interval() -> None:
+    """clock.sleep(interval) is awaited between iterations."""
+    clock = FakeClock(start=0.0)
+    calls: list[float] = []
+
+    async def work() -> None:
+        calls.append(clock.now())
+
+    task = asyncio.create_task(
+        run_periodic(
+            work,
+            interval_seconds=5.0,
+            clock=clock,
+            log_event="test.failed",
+        ),
+    )
+    await asyncio.sleep(0)
+    assert calls == [0.0]
+    await clock.advance(5.0)
+    await asyncio.sleep(0)
+    assert calls == [0.0, 5.0]
+    await clock.advance(5.0)
+    await asyncio.sleep(0)
+    assert calls == [0.0, 5.0, 10.0]
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task


### PR DESCRIPTION
## Summary
- `wire_sink(sink)` method on 4 detectors (trade_driven, cluster, gate_model, move_attribution) replaces 4 sites of `detector._sink = ...` private writes from scheduler + test files. The scheduler `isinstance` check now includes `GateModelDetector` explicitly.
- New `pscanner.util.async_dispatch.AsyncDispatcher` consolidates the spawn-and-track callback dispatch idiom previously copy-pasted in trade_driven.py + cluster.py + move_attribution.py. All 3 \"no event loop\" log events preserved verbatim.
- New `pscanner.util.loops.run_periodic` consolidates 5 detector run-loop bodies (polling, cluster, whales, smart_money × 2). All 5 `_LOG.exception` event strings preserved.
- `GateModelDetector` no longer inherits from `TradeDrivenDetector` — the inheritance was decorative (parent's `_pending_tasks` set never read; parent's run-loop body never executed). Sibling class instead.
- `ClusterDetector.discovery_scan` fetches each candidate wallet's recent trades once per scan into a `dict[str, list[WalletTrade]]`, threading it through `_iter_co_trade_groups`, `_build_obscure_markets_index`, `_find_shared_obscure_markets`, `_collect_cluster_trades`. ~2/3 DB query reduction on the discovery hot path. No signal logic changes.

6 commits. 18 files. +548/-150 (the net positive is helpers + new tests).

## Test plan
- [ ] All `tests/detectors/test_*.py` files green (9 files)
- [ ] New `tests/util/test_async_dispatch.py` (3 tests) + `tests/util/test_loops.py` (3 tests)
- [ ] `uv run pytest -q` passes (1473 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)