### PR TITLE
refactor(corpus,tests): asdict examples + rehome synthetic-trades + alt-platform handler collapse

### DIFF
--- a/scripts/profile_live_history.py
+++ b/scripts/profile_live_history.py
@@ -11,18 +11,12 @@ from __future__ import annotations
 
 import argparse
 import statistics
-import sys
 import time
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).parent.parent))
-from tests.daemon.test_live_history_parity import (
-    _build_metadata,
-    _build_synthetic_trades,
-)  # type: ignore[import-not-found]
-
 from pscanner.daemon.live_history import LiveHistoryProvider
 from pscanner.store.db import init_db
+from pscanner.testing.synthetic_trades import build_metadata, build_synthetic_trades
 
 
 def main() -> int:
@@ -32,8 +26,8 @@ def main() -> int:
     parser.add_argument("--seed", type=int, default=0)
     args = parser.parse_args()
 
-    trades = _build_synthetic_trades(seed=args.seed, n=args.n)
-    metadata = _build_metadata(trades)
+    trades = build_synthetic_trades(seed=args.seed, n=args.n, n_wallets=8, n_markets=5)
+    metadata = build_metadata(trades, with_categories=False)
     conn = init_db(Path(":memory:"))
     try:
         provider = LiveHistoryProvider(conn=conn, metadata=metadata)

--- a/src/pscanner/corpus/cli.py
+++ b/src/pscanner/corpus/cli.py
@@ -13,10 +13,11 @@ import os
 import re
 import sqlite3
 import time
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
 from contextlib import AsyncExitStack, asynccontextmanager
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Final
+from typing import Any, Final
 
 import psutil
 import structlog
@@ -327,10 +328,8 @@ async def _register_missing_polymarket_resolutions(
 
 async def _cmd_backfill(args: argparse.Namespace) -> int:
     """Run the corpus backfill for the requested platform."""
-    if args.platform == "manifold":
-        return await _run_manifold_backfill(args)
-    if args.platform == "kalshi":
-        return await _run_kalshi_backfill(args)
+    if args.platform in _ALT_PLATFORM_BINDINGS:
+        return await _run_alt_platform_backfill(args, _ALT_PLATFORM_BINDINGS[args.platform])
     return await _run_polymarket_backfill(args)
 
 
@@ -364,58 +363,10 @@ async def _run_polymarket_backfill(args: argparse.Namespace) -> int:
         conn.close()
 
 
-async def _run_manifold_backfill(args: argparse.Namespace) -> int:
-    """Manifold path: enumerate resolved binary markets, then walk each one."""
-    conn = init_corpus_db(Path(args.db))
-    markets_repo = CorpusMarketsRepo(conn)
-    trades_repo = CorpusTradesRepo(conn)
-    now_ts = int(time.time())
-    try:
-        async with ManifoldClient() as client:
-            await enumerate_resolved_manifold_markets(client, markets_repo, now_ts=now_ts)
-            while pending := markets_repo.next_pending(limit=10, platform="manifold"):
-                for market in pending:
-                    await walk_manifold_market(
-                        client,
-                        markets_repo,
-                        trades_repo,
-                        market_id=ManifoldMarketId(market.condition_id),
-                        now_ts=now_ts,
-                    )
-        return 0
-    finally:
-        conn.close()
-
-
-async def _run_kalshi_backfill(args: argparse.Namespace) -> int:
-    """Kalshi path: enumerate settled binary markets, then walk each one's trades."""
-    conn = init_corpus_db(Path(args.db))
-    markets_repo = CorpusMarketsRepo(conn)
-    trades_repo = CorpusTradesRepo(conn)
-    now_ts = int(time.time())
-    try:
-        async with KalshiClient() as client:
-            await enumerate_resolved_kalshi_markets(client, markets_repo, now_ts=now_ts)
-            while pending := markets_repo.next_pending(limit=10, platform="kalshi"):
-                for market in pending:
-                    await walk_kalshi_market(
-                        client,
-                        markets_repo,
-                        trades_repo,
-                        market_ticker=KalshiMarketTicker(market.condition_id),
-                        now_ts=now_ts,
-                    )
-        return 0
-    finally:
-        conn.close()
-
-
 async def _cmd_refresh(args: argparse.Namespace) -> int:
     """Run the corpus refresh for the requested platform."""
-    if args.platform == "manifold":
-        return await _run_manifold_refresh(args)
-    if args.platform == "kalshi":
-        return await _run_kalshi_refresh(args)
+    if args.platform in _ALT_PLATFORM_BINDINGS:
+        return await _run_alt_platform_refresh(args, _ALT_PLATFORM_BINDINGS[args.platform])
     return await _run_polymarket_refresh(args)
 
 
@@ -446,62 +397,127 @@ async def _run_polymarket_refresh(args: argparse.Namespace) -> int:
         conn.close()
 
 
-async def _run_manifold_refresh(args: argparse.Namespace) -> int:
-    """Manifold refresh: re-enumerate, then record resolutions for missing markets."""
-    db_path = Path(args.db)
-    conn = init_corpus_db(db_path)
+# ---------------------------------------------------------------------------
+# Manifold / Kalshi shared backfill+refresh shell.
+#
+# Both platforms follow the same shape: enumerate resolved markets, then
+# either walk every pending market's trades (backfill) or record resolutions
+# for completed markets missing them (refresh). Only the client class, the
+# identifier-wrapper type, the enumerator, the walker, and the resolution
+# recorder differ. ``_AltPlatformBinding`` carries those per-platform
+# differences; ``_run_alt_platform_*`` are the shared loops.
+# ---------------------------------------------------------------------------
+
+
+async def _walk_manifold(
+    client: ManifoldClient,
+    markets_repo: CorpusMarketsRepo,
+    trades_repo: CorpusTradesRepo,
+    *,
+    condition_id: str,
+    now_ts: int,
+) -> int:
+    return await walk_manifold_market(
+        client,
+        markets_repo,
+        trades_repo,
+        market_id=ManifoldMarketId(condition_id),
+        now_ts=now_ts,
+    )
+
+
+async def _walk_kalshi(
+    client: KalshiClient,
+    markets_repo: CorpusMarketsRepo,
+    trades_repo: CorpusTradesRepo,
+    *,
+    condition_id: str,
+    now_ts: int,
+) -> int:
+    return await walk_kalshi_market(
+        client,
+        markets_repo,
+        trades_repo,
+        market_ticker=KalshiMarketTicker(condition_id),
+        now_ts=now_ts,
+    )
+
+
+@dataclass(frozen=True)
+class _AltPlatformBinding:
+    """Per-platform glue for the Manifold/Kalshi shared backfill+refresh loops."""
+
+    platform: str
+    client_factory: Callable[[], Any]
+    enumerate_fn: Callable[..., Awaitable[int]]
+    walk_fn: Callable[..., Awaitable[int]]
+    record_fn: Callable[..., Awaitable[int]]
+
+
+_ALT_PLATFORM_BINDINGS: Mapping[str, _AltPlatformBinding] = {
+    "manifold": _AltPlatformBinding(
+        platform="manifold",
+        client_factory=ManifoldClient,
+        enumerate_fn=enumerate_resolved_manifold_markets,
+        walk_fn=_walk_manifold,
+        record_fn=record_manifold_resolutions,
+    ),
+    "kalshi": _AltPlatformBinding(
+        platform="kalshi",
+        client_factory=KalshiClient,
+        enumerate_fn=enumerate_resolved_kalshi_markets,
+        walk_fn=_walk_kalshi,
+        record_fn=record_kalshi_resolutions,
+    ),
+}
+
+
+async def _run_alt_platform_backfill(args: argparse.Namespace, binding: _AltPlatformBinding) -> int:
+    """Manifold/Kalshi backfill: enumerate resolved markets, walk each one."""
+    conn = init_corpus_db(Path(args.db))
     markets_repo = CorpusMarketsRepo(conn)
-    resolutions_repo = MarketResolutionsRepo(conn)
+    trades_repo = CorpusTradesRepo(conn)
     now_ts = int(time.time())
     try:
-        async with ManifoldClient() as client:
-            await enumerate_resolved_manifold_markets(client, markets_repo, now_ts=now_ts)
-            rows = conn.execute(
-                "SELECT condition_id, closed_at FROM corpus_markets "
-                "WHERE platform = 'manifold' AND backfill_state = 'complete'"
-            ).fetchall()
-            condition_ids = [row["condition_id"] for row in rows]
-            missing = resolutions_repo.missing_for(condition_ids, platform="manifold")
-            missing_set = set(missing)
-            targets = [
-                (row["condition_id"], int(row["closed_at"]))
-                for row in rows
-                if row["condition_id"] in missing_set
-            ]
-            await record_manifold_resolutions(
-                client=client,
-                repo=resolutions_repo,
-                targets=targets,
-                now_ts=now_ts,
-            )
+        async with binding.client_factory() as client:
+            await binding.enumerate_fn(client, markets_repo, now_ts=now_ts)
+            while pending := markets_repo.next_pending(limit=10, platform=binding.platform):
+                for market in pending:
+                    await binding.walk_fn(
+                        client,
+                        markets_repo,
+                        trades_repo,
+                        condition_id=market.condition_id,
+                        now_ts=now_ts,
+                    )
+        return 0
     finally:
         conn.close()
-    return 0
 
 
-async def _run_kalshi_refresh(args: argparse.Namespace) -> int:
-    """Kalshi refresh: re-enumerate, then record resolutions for missing markets."""
-    db_path = Path(args.db)
-    conn = init_corpus_db(db_path)
+async def _run_alt_platform_refresh(args: argparse.Namespace, binding: _AltPlatformBinding) -> int:
+    """Manifold/Kalshi refresh: re-enumerate, record resolutions for missing markets."""
+    conn = init_corpus_db(Path(args.db))
     markets_repo = CorpusMarketsRepo(conn)
     resolutions_repo = MarketResolutionsRepo(conn)
     now_ts = int(time.time())
     try:
-        async with KalshiClient() as client:
-            await enumerate_resolved_kalshi_markets(client, markets_repo, now_ts=now_ts)
+        async with binding.client_factory() as client:
+            await binding.enumerate_fn(client, markets_repo, now_ts=now_ts)
             rows = conn.execute(
                 "SELECT condition_id, closed_at FROM corpus_markets "
-                "WHERE platform = 'kalshi' AND backfill_state = 'complete'"
+                "WHERE platform = ? AND backfill_state = 'complete'",
+                (binding.platform,),
             ).fetchall()
             condition_ids = [row["condition_id"] for row in rows]
-            missing = resolutions_repo.missing_for(condition_ids, platform="kalshi")
+            missing = resolutions_repo.missing_for(condition_ids, platform=binding.platform)
             missing_set = set(missing)
             targets = [
                 (row["condition_id"], int(row["closed_at"]))
                 for row in rows
                 if row["condition_id"] in missing_set
             ]
-            await record_kalshi_resolutions(
+            await binding.record_fn(
                 client=client,
                 repo=resolutions_repo,
                 targets=targets,

--- a/src/pscanner/corpus/examples.py
+++ b/src/pscanner/corpus/examples.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import json
 import sqlite3
 import time
+from dataclasses import asdict, fields
 from typing import Final
 
 import structlog
@@ -89,6 +90,17 @@ def _load_market_metadata(
     return out
 
 
+# Fields shared by both dataclasses; everything else is either identity
+# state (set per-row from ``trade``) or compute-only on FeatureRow
+# (``market_categories``). The parity test in
+# ``tests/corpus/test_examples_field_parity.py`` is load-bearing: it fails
+# if a future FeatureRow field doesn't get a matching TrainingExample
+# column, which would otherwise silently default-NULL on insert.
+_FEATURE_ONLY_FIELDS: Final[frozenset[str]] = frozenset(
+    f.name for f in fields(TrainingExample)
+) & frozenset(f.name for f in fields(FeatureRow))
+
+
 def _example_from_features(
     *,
     trade: Trade,
@@ -97,7 +109,9 @@ def _example_from_features(
     now_ts: int,
     platform: str = "polymarket",
 ) -> TrainingExample:
+    feature_values = {k: v for k, v in asdict(features).items() if k in _FEATURE_ONLY_FIELDS}
     return TrainingExample(
+        **feature_values,  # type: ignore[arg-type]  # ty:ignore[invalid-argument-type]
         tx_hash=trade.tx_hash,
         asset_id=trade.asset_id,
         wallet_address=trade.wallet_address,
@@ -105,46 +119,6 @@ def _example_from_features(
         trade_ts=trade.ts,
         built_at=now_ts,
         platform=platform,
-        prior_trades_count=features.prior_trades_count,
-        prior_buys_count=features.prior_buys_count,
-        prior_resolved_buys=features.prior_resolved_buys,
-        prior_wins=features.prior_wins,
-        prior_losses=features.prior_losses,
-        win_rate=features.win_rate,
-        avg_implied_prob_paid=features.avg_implied_prob_paid,
-        realized_edge_pp=features.realized_edge_pp,
-        prior_realized_pnl_usd=features.prior_realized_pnl_usd,
-        avg_bet_size_usd=features.avg_bet_size_usd,
-        median_bet_size_usd=features.median_bet_size_usd,
-        wallet_age_days=features.wallet_age_days,
-        seconds_since_last_trade=features.seconds_since_last_trade,
-        prior_trades_30d=features.prior_trades_30d,
-        top_category=features.top_category,
-        category_diversity=features.category_diversity,
-        bet_size_usd=features.bet_size_usd,
-        bet_size_rel_to_avg=features.bet_size_rel_to_avg,
-        edge_confidence_weighted=features.edge_confidence_weighted,
-        win_rate_confidence_weighted=features.win_rate_confidence_weighted,
-        is_high_quality_wallet=features.is_high_quality_wallet,
-        bet_size_relative_to_history=features.bet_size_relative_to_history,
-        side=features.side,
-        implied_prob_at_buy=features.implied_prob_at_buy,
-        market_category=features.market_category,
-        market_volume_so_far_usd=features.market_volume_so_far_usd,
-        market_unique_traders_so_far=features.market_unique_traders_so_far,
-        market_age_seconds=features.market_age_seconds,
-        time_to_resolution_seconds=features.time_to_resolution_seconds,
-        last_trade_price=features.last_trade_price,
-        price_volatility_recent=features.price_volatility_recent,
-        cat_sports=features.cat_sports,
-        cat_esports=features.cat_esports,
-        cat_thesis=features.cat_thesis,
-        cat_macro=features.cat_macro,
-        cat_elections=features.cat_elections,
-        cat_crypto=features.cat_crypto,
-        cat_geopolitics=features.cat_geopolitics,
-        cat_tech=features.cat_tech,
-        cat_culture=features.cat_culture,
         label_won=label_won,
     )
 

--- a/src/pscanner/detectors/cluster.py
+++ b/src/pscanner/detectors/cluster.py
@@ -455,7 +455,9 @@ class ClusterDetector:
             score += 2
         # Signals C and D inspect cluster trades on shared markets.
         cluster_trades_by_market = self._collect_cluster_trades(
-            wallets, shared, trades_by_wallet,
+            wallets,
+            shared,
+            trades_by_wallet,
         )
         if self._has_size_correlation(cluster_trades_by_market):
             score += 1

--- a/src/pscanner/testing/__init__.py
+++ b/src/pscanner/testing/__init__.py
@@ -1,0 +1,6 @@
+"""Helpers for tests and standalone benchmarking scripts.
+
+Shipped with the package (under ``src/pscanner/``, not ``tests/``) so
+non-test consumers — notably ``scripts/profile_live_history.py`` — can
+import them without reaching into ``tests/`` via ``sys.path`` hacks.
+"""

--- a/src/pscanner/testing/synthetic_trades.py
+++ b/src/pscanner/testing/synthetic_trades.py
@@ -1,0 +1,97 @@
+"""Deterministic synthetic ``Trade`` + ``MarketMetadata`` streams for tests.
+
+These helpers used to be open-coded under module-private ``_`` names in
+``tests/corpus/conftest.py``, ``tests/daemon/test_live_history_parity.py``,
+and (via a ``sys.path`` hack) ``scripts/profile_live_history.py``. Lifted
+here so all three consumers share a single source of truth and the
+profile script doesn't need to reach into ``tests/``.
+
+The defaults match the shape ``tests/corpus/conftest.py`` used originally
+(6 wallets x4 markets, ``MarketMetadata.categories`` populated from the
+trade's primary category). Callers that need the daemon-parity-test
+shape (8 wallets x5 markets, empty ``categories``) pass the keyword
+overrides.
+
+See ``refactor-plan-corpus-ml.md`` T3.26.
+"""
+
+from __future__ import annotations
+
+import random
+
+from pscanner.corpus.features import MarketMetadata, Trade
+
+
+def build_synthetic_trades(
+    *,
+    seed: int,
+    n: int,
+    n_wallets: int = 6,
+    n_markets: int = 4,
+) -> list[Trade]:
+    """Generate a deterministic synthetic trade stream covering common shapes.
+
+    Each trade picks a wallet from ``[0xw00 .. 0xw{N-1}]``, a market from
+    ``[0xm00 .. 0xm{M-1}]``, a YES/NO side, a 70/30 BUY/SELL bias, and a
+    price/size from uniform ranges. The PRNG is seeded so the output is
+    reproducible.
+    """
+    rng = random.Random(seed)  # noqa: S311  -- deterministic test seed, not crypto
+    wallets = [f"0xw{i:02d}" for i in range(n_wallets)]
+    markets = [f"0xm{i:02d}" for i in range(n_markets)]
+    base_ts = 1_700_000_000
+    trades: list[Trade] = []
+    for i in range(n):
+        wallet = rng.choice(wallets)
+        market = rng.choice(markets)
+        side = rng.choice(("YES", "NO"))
+        bs = rng.choices(("BUY", "SELL"), weights=(0.7, 0.3))[0]
+        price = round(rng.uniform(0.05, 0.95), 4)
+        size = round(rng.uniform(50.0, 500.0), 2)
+        trades.append(
+            Trade(
+                tx_hash=f"tx{i:04d}",
+                asset_id=f"{market}-{side}",
+                wallet_address=wallet,
+                condition_id=market,
+                outcome_side=side,
+                bs=bs,
+                price=price,
+                size=size,
+                notional_usd=round(price * size, 4),
+                ts=base_ts + i * 60,
+                category=rng.choice(("sports", "esports", "crypto")),
+            )
+        )
+    return trades
+
+
+def build_metadata(
+    trades: list[Trade],
+    *,
+    with_categories: bool = True,
+) -> dict[str, MarketMetadata]:
+    """Build a ``MarketMetadata`` for every market in ``trades``.
+
+    Each market's metadata inherits the primary category from the first
+    trade seen on that market, and gets a ``closed_at`` 7 days after that
+    trade's ts. When ``with_categories=True`` (the default), the
+    ``categories`` tuple is populated with a single-element tuple of the
+    primary category — matching the conftest fixture. When ``False``,
+    ``categories`` is left as the empty-tuple default — matching the
+    daemon parity-test shape.
+    """
+    by_market: dict[str, MarketMetadata] = {}
+    for t in trades:
+        if t.condition_id in by_market:
+            continue
+        kwargs: dict[str, object] = {
+            "condition_id": t.condition_id,
+            "category": t.category,
+            "closed_at": t.ts + 86_400 * 7,
+            "opened_at": t.ts - 60,
+        }
+        if with_categories:
+            kwargs["categories"] = (t.category,)
+        by_market[t.condition_id] = MarketMetadata(**kwargs)  # type: ignore[arg-type]  # ty:ignore[invalid-argument-type]
+    return by_market

--- a/tests/corpus/conftest.py
+++ b/tests/corpus/conftest.py
@@ -6,7 +6,6 @@ Mirrors the ``tmp_db`` pattern in ``tests/conftest.py`` but applies
 
 from __future__ import annotations
 
-import random
 import sqlite3
 from collections.abc import Iterator
 from pathlib import Path
@@ -19,6 +18,7 @@ from pscanner.corpus.features import (
     StreamingHistoryProvider,
     Trade,
 )
+from pscanner.testing.synthetic_trades import build_metadata, build_synthetic_trades
 
 
 @pytest.fixture
@@ -31,64 +31,16 @@ def tmp_corpus_db() -> Iterator[sqlite3.Connection]:
         conn.close()
 
 
-def _build_synthetic_trades(seed: int, n: int) -> list[Trade]:
-    """Generate a deterministic synthetic trade stream covering common shapes."""
-    rng = random.Random(seed)  # noqa: S311
-    wallets = [f"0xw{i:02d}" for i in range(6)]
-    markets = [f"0xm{i:02d}" for i in range(4)]
-    base_ts = 1_700_000_000
-    out: list[Trade] = []
-    for i in range(n):
-        wallet = rng.choice(wallets)
-        market = rng.choice(markets)
-        side = rng.choice(("YES", "NO"))
-        bs = rng.choices(("BUY", "SELL"), weights=(0.7, 0.3))[0]
-        price = round(rng.uniform(0.05, 0.95), 4)
-        size = round(rng.uniform(50.0, 500.0), 2)
-        out.append(
-            Trade(
-                tx_hash=f"tx{i:04d}",
-                asset_id=f"{market}-{side}",
-                wallet_address=wallet,
-                condition_id=market,
-                outcome_side=side,
-                bs=bs,
-                price=price,
-                size=size,
-                notional_usd=round(price * size, 4),
-                ts=base_ts + i * 60,
-                category=rng.choice(("sports", "esports", "crypto")),
-            )
-        )
-    return out
-
-
-def _build_metadata(trades: list[Trade]) -> dict[str, MarketMetadata]:
-    """Build a MarketMetadata for every market in the trade stream."""
-    by_market: dict[str, MarketMetadata] = {}
-    for t in trades:
-        if t.condition_id in by_market:
-            continue
-        by_market[t.condition_id] = MarketMetadata(
-            condition_id=t.condition_id,
-            category=t.category,
-            closed_at=t.ts + 86_400 * 7,
-            opened_at=t.ts - 60,
-            categories=(t.category,),
-        )
-    return by_market
-
-
 @pytest.fixture
 def trade_stream() -> list[Trade]:
     """Deterministic 80-trade stream for cross-feature parity tests."""
-    return _build_synthetic_trades(seed=42, n=80)
+    return build_synthetic_trades(seed=42, n=80)
 
 
 @pytest.fixture
 def metadata_for_stream(trade_stream: list[Trade]) -> dict[str, MarketMetadata]:
     """MarketMetadata covering every market in `trade_stream`."""
-    return _build_metadata(trade_stream)
+    return build_metadata(trade_stream)
 
 
 @pytest.fixture

--- a/tests/corpus/test_examples_field_parity.py
+++ b/tests/corpus/test_examples_field_parity.py
@@ -1,0 +1,66 @@
+"""Load-bearing parity test for FeatureRow ↔ TrainingExample field sets.
+
+Every column in :class:`TrainingExample` is either:
+
+- an identity column (set per-row from the source ``Trade``: ``tx_hash``,
+  ``asset_id``, ``wallet_address``, ``condition_id``, ``trade_ts``,
+  ``built_at``, ``platform``),
+- ``label_won`` (the supervised target, derived from the resolution),
+- or a feature column that mirrors a same-named field on
+  :class:`FeatureRow`.
+
+:data:`_FEATURE_ONLY_FIELDS` in ``examples.py`` drives the column copy via
+``**asdict(features)``; if a future FeatureRow field doesn't have a
+matching TrainingExample column the row would be silently inserted with
+that column as NULL, which is the silent-feature-loss footgun this test
+guards against.
+
+See ``refactor-plan-corpus-ml.md`` T3.22.
+"""
+
+from __future__ import annotations
+
+from dataclasses import fields
+
+from pscanner.corpus.examples import _FEATURE_ONLY_FIELDS
+from pscanner.corpus.features import FeatureRow
+from pscanner.corpus.repos import TrainingExample
+
+# Columns on TrainingExample that are NOT computed from FeatureRow; they
+# come from the source Trade, the orchestrator (``now_ts``, ``platform``),
+# or the resolution (``label_won``).
+_IDENTITY_COLUMNS = frozenset(
+    {
+        "tx_hash",
+        "asset_id",
+        "wallet_address",
+        "condition_id",
+        "trade_ts",
+        "built_at",
+        "platform",
+        "label_won",
+    }
+)
+
+# Fields on FeatureRow that are NOT persisted to training_examples. The
+# multi-label ``cat_*`` indicators DO persist; the only compute-only
+# transient is ``market_categories`` (see feature_projection.py:
+# ``project_to_sql=False``).
+_COMPUTE_ONLY_FEATUREROW_FIELDS = frozenset({"market_categories"})
+
+
+def test_feature_only_fields_match_featurerow_minus_compute_only() -> None:
+    """Every persisted FeatureRow field has a TrainingExample column."""
+    featurerow_fields = {f.name for f in fields(FeatureRow)}
+    assert featurerow_fields - _COMPUTE_ONLY_FEATUREROW_FIELDS == _FEATURE_ONLY_FIELDS
+
+
+def test_feature_only_fields_match_trainingexample_minus_identity() -> None:
+    """Every TrainingExample column comes from either FeatureRow or identity."""
+    trainingexample_fields = {f.name for f in fields(TrainingExample)}
+    assert trainingexample_fields - _IDENTITY_COLUMNS == _FEATURE_ONLY_FIELDS
+
+
+def test_no_overlap_between_identity_and_feature_columns() -> None:
+    """A TrainingExample column can't be both identity and a FeatureRow mirror."""
+    assert _IDENTITY_COLUMNS.isdisjoint(_FEATURE_ONLY_FIELDS)

--- a/tests/daemon/test_live_history_parity.py
+++ b/tests/daemon/test_live_history_parity.py
@@ -2,71 +2,24 @@
 
 from __future__ import annotations
 
-import random
 import sqlite3
 from pathlib import Path
 
 import pytest
 
 from pscanner.corpus.features import (
-    MarketMetadata,
     StreamingHistoryProvider,
-    Trade,
     compute_features,
 )
 from pscanner.daemon.live_history import LiveHistoryProvider
 from pscanner.store.db import init_db
-
-
-def _build_synthetic_trades(seed: int, n: int) -> list[Trade]:
-    rng = random.Random(seed)  # noqa: S311  -- deterministic test seed, not crypto
-    wallets = [f"0xw{i:02d}" for i in range(8)]
-    markets = [f"0xm{i:02d}" for i in range(5)]
-    trades: list[Trade] = []
-    base_ts = 1_700_000_000
-    for i in range(n):
-        wallet = rng.choice(wallets)
-        market = rng.choice(markets)
-        side = rng.choice(("YES", "NO"))
-        bs = rng.choices(("BUY", "SELL"), weights=(0.7, 0.3))[0]
-        price = round(rng.uniform(0.05, 0.95), 4)
-        size = round(rng.uniform(50.0, 500.0), 2)
-        trades.append(
-            Trade(
-                tx_hash=f"tx{i:04d}",
-                asset_id=f"{market}-{side}",
-                wallet_address=wallet,
-                condition_id=market,
-                outcome_side=side,
-                bs=bs,
-                price=price,
-                size=size,
-                notional_usd=round(price * size, 4),
-                ts=base_ts + i * 60,
-                category=rng.choice(("sports", "esports", "crypto")),
-            )
-        )
-    return trades
-
-
-def _build_metadata(trades: list[Trade]) -> dict[str, MarketMetadata]:
-    by_market: dict[str, MarketMetadata] = {}
-    for t in trades:
-        if t.condition_id in by_market:
-            continue
-        by_market[t.condition_id] = MarketMetadata(
-            condition_id=t.condition_id,
-            category=t.category,
-            closed_at=t.ts + 86_400 * 7,
-            opened_at=t.ts - 60,
-        )
-    return by_market
+from pscanner.testing.synthetic_trades import build_metadata, build_synthetic_trades
 
 
 @pytest.mark.parametrize("seed", [0, 1, 42, 1234])
 def test_compute_features_matches_streaming_provider(seed: int) -> None:
-    trades = _build_synthetic_trades(seed=seed, n=100)
-    metadata = _build_metadata(trades)
+    trades = build_synthetic_trades(seed=seed, n=100, n_wallets=8, n_markets=5)
+    metadata = build_metadata(trades, with_categories=False)
     streaming = StreamingHistoryProvider(metadata=metadata)
     conn: sqlite3.Connection = init_db(Path(":memory:"))
     try:


### PR DESCRIPTION
## Summary

Tier-3 follow-ups from the refactor-review wave (planned in `refactor-plan-corpus-ml.md`, deferred from PR #175 because they were either invasive or required cross-slice coordination).

- **T3.22** — `_example_from_features` rebuilt via `dataclasses.asdict`. Adds `tests/corpus/test_examples_field_parity.py` as the load-bearing safety net: a new FeatureRow field without a matching TrainingExample column fails CI immediately instead of silently inserting NULL.
- **T3.26** — Triplicated `_build_synthetic_trades` / `_build_metadata` helpers (conftest, daemon parity test, profile script with `sys.path` hack) consolidated to `pscanner.testing.synthetic_trades`. New `src/pscanner/testing/` package home so non-test consumers can import cleanly. Cross-slice: also edits `tests/daemon/test_live_history_parity.py` per the orchestrator brief.
- **T3.28** — 4 alt-platform handlers (`_run_{manifold,kalshi}_{backfill,refresh}`) collapse to a 2-entry `_ALT_PLATFORM_BINDINGS` table + 2 parameterized loops (`_run_alt_platform_backfill` / `_run_alt_platform_refresh`). Polymarket keeps its dedicated handlers — different shape (gamma+data dual clients, drain-pending, polymarket-specific resolution registration).

Also includes one prefix `chore` commit: `src/pscanner/detectors/cluster.py` was unformatted on clean main; reformatted at the head of the branch so `ruff format --check` passes from the first refactor commit.

## Test plan

- [x] Full `uv run pytest -q` green (1499 passed) on each commit.
- [x] `uv run ruff check . && uv run ruff format --check .` clean on the branch head.
- [x] T3.22 parity test verified to catch a synthetic added FeatureRow field with no TrainingExample mirror.
- [x] T3.26 preserves both fixture shapes (6w/4m with categories from conftest; 8w/5m without from daemon parity test) via keyword overrides.
- [x] T3.28 `_cmd_backfill` / `_cmd_refresh` route polymarket through the dedicated handler and alt platforms through the shared shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)