### PR TITLE
refactor(daemon): state serialization helpers + drop private-internals reach

### DIFF
--- a/src/pscanner/daemon/_state_persistence.py
+++ b/src/pscanner/daemon/_state_persistence.py
@@ -1,0 +1,212 @@
+"""Column-list-driven SQLite serializers for ``wallet_state_live`` + ``market_state_live``.
+
+The same ``WalletState`` / ``MarketState`` snapshots used by the streaming
+provider (``pscanner.corpus.features``) are persisted by two distinct
+write paths:
+
+* :class:`pscanner.daemon.live_history.LiveHistoryProvider` (the live
+  daemon) writes per-observe via UPSERT.
+* :mod:`pscanner.daemon.bootstrap` (the cold-start CLI) writes the final
+  in-memory state via bulk INSERT.
+
+Both paths used to hand-write the column list + tuple unpacking, which
+made adding a new ``WalletState`` field a 3-place lockstep edit and
+risked silent column-drops. This module centralises:
+
+* the column tuples (single source of truth for column order),
+* the upsert / insert SQL (built from the column tuples),
+* the dataclass ↔ tuple converters used by every writer + reader.
+
+A parity test (``tests/daemon/test_state_persistence_parity.py``) asserts
+that every dataclass field has a corresponding column entry so the
+column tuples can't drift behind the dataclass.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from collections import deque
+from collections.abc import Iterable
+
+from pscanner.corpus.features import (
+    _RECENT_PRICES_MAX,
+    MarketState,
+    WalletState,
+)
+
+_WALLET_STATE_TABLE = "wallet_state_live"
+_MARKET_STATE_TABLE = "market_state_live"
+
+WALLET_STATE_COLUMNS: tuple[str, ...] = (
+    "wallet_address",
+    "first_seen_ts",
+    "prior_trades_count",
+    "prior_buys_count",
+    "prior_resolved_buys",
+    "prior_wins",
+    "prior_losses",
+    "cumulative_buy_price_sum",
+    "cumulative_buy_count",
+    "realized_pnl_usd",
+    "last_trade_ts",
+    "bet_size_sum",
+    "bet_size_count",
+    "recent_30d_trades_json",
+    "category_counts_json",
+    "unresolved_buys_json",
+)
+"""Order is load-bearing — matches every row tuple this module produces."""
+
+MARKET_STATE_COLUMNS: tuple[str, ...] = (
+    "condition_id",
+    "market_age_start_ts",
+    "volume_so_far_usd",
+    "unique_traders_count",
+    "last_trade_price",
+    "recent_prices_json",
+    "traders_json",
+)
+"""Order is load-bearing — matches every row tuple this module produces."""
+
+
+def _build_upsert_sql(table: str, columns: tuple[str, ...], *, conflict_on: str) -> str:
+    """Build the INSERT...ON CONFLICT(...) DO UPDATE SET... SQL for a column tuple.
+
+    The table and column names are module-level constants (not caller input), so
+    the f-string interpolation is safe from injection.
+    """
+    placeholders = ", ".join(["?"] * len(columns))
+    sets = ",\n          ".join(f"{col} = excluded.{col}" for col in columns if col != conflict_on)
+    cols_joined = ", ".join(columns)
+    return (
+        f"INSERT INTO {table} ({cols_joined})\n"
+        f"VALUES ({placeholders})\n"
+        f"ON CONFLICT({conflict_on}) DO UPDATE SET\n"
+        f"          {sets}"
+    )
+
+
+def _build_insert_sql(table: str, columns: tuple[str, ...]) -> str:
+    """Build the plain INSERT SQL used by the cold-start bulk writer.
+
+    Table and column names are module-level constants — safe from injection.
+    """
+    placeholders = ", ".join(["?"] * len(columns))
+    cols_joined = ", ".join(columns)
+    # `table` / `columns` are module-level constants — see module docstring.
+    return f"INSERT INTO {table} ({cols_joined}) VALUES ({placeholders})"  # noqa: S608
+
+
+WALLET_STATE_UPSERT_SQL = _build_upsert_sql(
+    _WALLET_STATE_TABLE, WALLET_STATE_COLUMNS, conflict_on="wallet_address"
+)
+WALLET_STATE_INSERT_SQL = _build_insert_sql(_WALLET_STATE_TABLE, WALLET_STATE_COLUMNS)
+MARKET_STATE_UPSERT_SQL = _build_upsert_sql(
+    _MARKET_STATE_TABLE, MARKET_STATE_COLUMNS, conflict_on="condition_id"
+)
+MARKET_STATE_INSERT_SQL = _build_insert_sql(_MARKET_STATE_TABLE, MARKET_STATE_COLUMNS)
+
+
+def wallet_state_to_row(
+    wallet_address: str,
+    state: WalletState,
+    *,
+    unresolved_buys_json: str,
+) -> tuple[object, ...]:
+    """Build the ``wallet_state_live`` row tuple for ``state``.
+
+    Order matches :data:`WALLET_STATE_COLUMNS`. ``unresolved_buys_json``
+    is supplied by the caller because it lives outside ``WalletState``
+    (per-wallet pending-buy queue is owned by the provider, not the
+    state dataclass).
+    """
+    return (
+        wallet_address,
+        state.first_seen_ts,
+        state.prior_trades_count,
+        state.prior_buys_count,
+        state.prior_resolved_buys,
+        state.prior_wins,
+        state.prior_losses,
+        state.cumulative_buy_price_sum,
+        state.cumulative_buy_count,
+        state.realized_pnl_usd,
+        state.last_trade_ts,
+        state.bet_size_sum,
+        state.bet_size_count,
+        json.dumps(list(state.recent_30d_trades)),
+        json.dumps(state.category_counts),
+        unresolved_buys_json,
+    )
+
+
+def wallet_state_from_row(row: sqlite3.Row) -> WalletState:
+    """Rebuild a :class:`WalletState` from a ``wallet_state_live`` row.
+
+    Caller is responsible for reading ``row["unresolved_buys_json"]``
+    separately when it needs the queue — see
+    :meth:`LiveHistoryProvider.wallet_state` for the drain path.
+    """
+    return WalletState(
+        first_seen_ts=row["first_seen_ts"],
+        prior_trades_count=row["prior_trades_count"],
+        prior_buys_count=row["prior_buys_count"],
+        prior_resolved_buys=row["prior_resolved_buys"],
+        prior_wins=row["prior_wins"],
+        prior_losses=row["prior_losses"],
+        cumulative_buy_price_sum=row["cumulative_buy_price_sum"],
+        cumulative_buy_count=row["cumulative_buy_count"],
+        realized_pnl_usd=row["realized_pnl_usd"],
+        last_trade_ts=row["last_trade_ts"],
+        recent_30d_trades=deque(json.loads(row["recent_30d_trades_json"])),
+        bet_size_sum=row["bet_size_sum"],
+        bet_size_count=row["bet_size_count"],
+        category_counts=dict(json.loads(row["category_counts_json"])),
+    )
+
+
+def market_state_to_row(
+    condition_id: str,
+    state: MarketState,
+    *,
+    traders: Iterable[str],
+) -> tuple[object, ...]:
+    """Build the ``market_state_live`` row tuple for ``state``.
+
+    Order matches :data:`MARKET_STATE_COLUMNS`. ``traders`` is the
+    market's distinct-wallet set; serialised as a sorted JSON array.
+    """
+    return (
+        condition_id,
+        state.market_age_start_ts,
+        state.volume_so_far_usd,
+        state.unique_traders_count,
+        state.last_trade_price,
+        json.dumps(list(state.recent_prices)),
+        json.dumps(sorted(traders)),
+    )
+
+
+def market_state_from_row(row: sqlite3.Row) -> MarketState:
+    """Rebuild a :class:`MarketState` from a ``market_state_live`` row.
+
+    ``recent_prices`` is reconstructed with the same ``maxlen`` enforced
+    by the streaming provider so the deque doesn't grow unbounded once
+    the live daemon resumes folding trades.
+    """
+    return MarketState(
+        market_age_start_ts=row["market_age_start_ts"],
+        volume_so_far_usd=row["volume_so_far_usd"],
+        unique_traders_count=row["unique_traders_count"],
+        last_trade_price=row["last_trade_price"],
+        recent_prices=deque(
+            json.loads(row["recent_prices_json"]),
+            maxlen=_RECENT_PRICES_MAX,
+        ),
+    )
+
+
+def market_traders_from_row(row: sqlite3.Row) -> set[str]:
+    """Read the trader-address set serialized at ``traders_json``."""
+    return set(json.loads(row["traders_json"]))

--- a/src/pscanner/daemon/bootstrap.py
+++ b/src/pscanner/daemon/bootstrap.py
@@ -35,8 +35,8 @@ from pscanner.corpus.db import init_corpus_db
 from pscanner.corpus.features import (
     StreamingHistoryProvider,
     Trade,
-    _UnresolvedBuy,
-    _WalletAccumulator,
+    WalletState,
+    _UnresolvedBuy,  # TODO: drop once StreamingHistoryProvider exposes unresolved buys publicly
 )
 from pscanner.daemon._state_persistence import (
     MARKET_STATE_INSERT_SQL,
@@ -138,16 +138,26 @@ def _bulk_write_wallets(
     daemon_conn: sqlite3.Connection,
     provider: StreamingHistoryProvider,
 ) -> None:
-    rows = [
-        _wallet_row(wallet_address, accum) for wallet_address, accum in provider._wallets.items()
-    ]
+    rows: list[tuple[object, ...]] = []
+    for wallet_address, state in provider.iter_wallet_states():
+        # TODO: drop _wallets access after StreamingHistoryProvider exposes
+        # the per-wallet unresolved-buy queue publicly. iter_wallet_states
+        # currently yields state-only; extending it to a 3-tuple with the
+        # unresolved-buys list is corpus-ml-owned scope.
+        accum = provider._wallets[wallet_address]
+        unresolved: list[_UnresolvedBuy] = list(accum.unscheduled)
+        unresolved.extend(buy for _resolved_at, _seq, buy in accum.heap)
+        rows.append(_wallet_row(wallet_address, state, unresolved=unresolved))
     daemon_conn.executemany(WALLET_STATE_INSERT_SQL, rows)
     daemon_conn.commit()
 
 
-def _wallet_row(wallet_address: str, accum: _WalletAccumulator) -> tuple[object, ...]:
-    unresolved: list[_UnresolvedBuy] = list(accum.unscheduled)
-    unresolved.extend(buy for _resolved_at, _seq, buy in accum.heap)
+def _wallet_row(
+    wallet_address: str,
+    state: WalletState,
+    *,
+    unresolved: list[_UnresolvedBuy],
+) -> tuple[object, ...]:
     unresolved_json = json.dumps(
         [
             {
@@ -164,7 +174,7 @@ def _wallet_row(wallet_address: str, accum: _WalletAccumulator) -> tuple[object,
     )
     return wallet_state_to_row(
         wallet_address,
-        accum.state,
+        state,
         unresolved_buys_json=unresolved_json,
     )
 
@@ -173,13 +183,13 @@ def _bulk_write_markets(
     daemon_conn: sqlite3.Connection,
     provider: StreamingHistoryProvider,
 ) -> None:
-    rows: list[tuple[object, ...]] = [
-        market_state_to_row(
-            cond_id,
-            market,
-            traders=provider._market_traders.get(cond_id, set()),
-        )
-        for cond_id, market in provider._markets.items()
-    ]
+    rows: list[tuple[object, ...]] = []
+    for cond_id, market in provider.iter_market_states():
+        # TODO: drop _market_traders access after StreamingHistoryProvider
+        # exposes the per-market trader set publicly. iter_market_states
+        # currently yields state-only; extending it to a 3-tuple with the
+        # traders set is corpus-ml-owned scope.
+        traders = provider._market_traders.get(cond_id, set())
+        rows.append(market_state_to_row(cond_id, market, traders=traders))
     daemon_conn.executemany(MARKET_STATE_INSERT_SQL, rows)
     daemon_conn.commit()

--- a/src/pscanner/daemon/bootstrap.py
+++ b/src/pscanner/daemon/bootstrap.py
@@ -38,6 +38,12 @@ from pscanner.corpus.features import (
     _UnresolvedBuy,
     _WalletAccumulator,
 )
+from pscanner.daemon._state_persistence import (
+    MARKET_STATE_INSERT_SQL,
+    WALLET_STATE_INSERT_SQL,
+    market_state_to_row,
+    wallet_state_to_row,
+)
 from pscanner.daemon.corpus_loader import (
     load_corpus_metadata,
     load_corpus_resolutions_into,
@@ -135,23 +141,11 @@ def _bulk_write_wallets(
     rows = [
         _wallet_row(wallet_address, accum) for wallet_address, accum in provider._wallets.items()
     ]
-    daemon_conn.executemany(
-        """
-        INSERT INTO wallet_state_live (
-          wallet_address, first_seen_ts, prior_trades_count, prior_buys_count,
-          prior_resolved_buys, prior_wins, prior_losses,
-          cumulative_buy_price_sum, cumulative_buy_count, realized_pnl_usd,
-          last_trade_ts, bet_size_sum, bet_size_count,
-          recent_30d_trades_json, category_counts_json, unresolved_buys_json
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-        """,
-        rows,
-    )
+    daemon_conn.executemany(WALLET_STATE_INSERT_SQL, rows)
     daemon_conn.commit()
 
 
 def _wallet_row(wallet_address: str, accum: _WalletAccumulator) -> tuple[object, ...]:
-    state = accum.state
     unresolved: list[_UnresolvedBuy] = list(accum.unscheduled)
     unresolved.extend(buy for _resolved_at, _seq, buy in accum.heap)
     unresolved_json = json.dumps(
@@ -168,23 +162,10 @@ def _wallet_row(wallet_address: str, accum: _WalletAccumulator) -> tuple[object,
             for buy in unresolved
         ]
     )
-    return (
+    return wallet_state_to_row(
         wallet_address,
-        state.first_seen_ts,
-        state.prior_trades_count,
-        state.prior_buys_count,
-        state.prior_resolved_buys,
-        state.prior_wins,
-        state.prior_losses,
-        state.cumulative_buy_price_sum,
-        state.cumulative_buy_count,
-        state.realized_pnl_usd,
-        state.last_trade_ts,
-        state.bet_size_sum,
-        state.bet_size_count,
-        json.dumps(list(state.recent_30d_trades)),
-        json.dumps(state.category_counts),
-        unresolved_json,
+        accum.state,
+        unresolved_buys_json=unresolved_json,
     )
 
 
@@ -192,28 +173,13 @@ def _bulk_write_markets(
     daemon_conn: sqlite3.Connection,
     provider: StreamingHistoryProvider,
 ) -> None:
-    rows: list[tuple[object, ...]] = []
-    for cond_id, market in provider._markets.items():
-        traders = sorted(provider._market_traders.get(cond_id, set()))
-        rows.append(
-            (
-                cond_id,
-                market.market_age_start_ts,
-                market.volume_so_far_usd,
-                market.unique_traders_count,
-                market.last_trade_price,
-                json.dumps(list(market.recent_prices)),
-                json.dumps(traders),
-            )
+    rows: list[tuple[object, ...]] = [
+        market_state_to_row(
+            cond_id,
+            market,
+            traders=provider._market_traders.get(cond_id, set()),
         )
-    daemon_conn.executemany(
-        """
-        INSERT INTO market_state_live (
-          condition_id, market_age_start_ts, volume_so_far_usd,
-          unique_traders_count, last_trade_price, recent_prices_json,
-          traders_json
-        ) VALUES (?, ?, ?, ?, ?, ?, ?)
-        """,
-        rows,
-    )
+        for cond_id, market in provider._markets.items()
+    ]
+    daemon_conn.executemany(MARKET_STATE_INSERT_SQL, rows)
     daemon_conn.commit()

--- a/src/pscanner/daemon/live_history.py
+++ b/src/pscanner/daemon/live_history.py
@@ -17,12 +17,10 @@ from __future__ import annotations
 import heapq
 import json
 import sqlite3
-from collections import deque
 from collections.abc import Sequence
 from typing import Protocol, cast, runtime_checkable
 
 from pscanner.corpus.features import (
-    _RECENT_PRICES_MAX,  # intentionally imported; see MarketState docstring
     MarketMetadata,
     MarketState,
     Trade,
@@ -34,6 +32,15 @@ from pscanner.corpus.features import (
     apply_trade_to_market,
     empty_market_state,
     empty_wallet_state,
+)
+from pscanner.daemon._state_persistence import (
+    MARKET_STATE_UPSERT_SQL,
+    WALLET_STATE_UPSERT_SQL,
+    market_state_from_row,
+    market_state_to_row,
+    market_traders_from_row,
+    wallet_state_from_row,
+    wallet_state_to_row,
 )
 
 
@@ -119,22 +126,7 @@ class LiveHistoryProvider:
         ).fetchone()
         if row is None:
             return empty_wallet_state(first_seen_ts=as_of_ts)
-        state = WalletState(
-            first_seen_ts=row["first_seen_ts"],
-            prior_trades_count=row["prior_trades_count"],
-            prior_buys_count=row["prior_buys_count"],
-            prior_resolved_buys=row["prior_resolved_buys"],
-            prior_wins=row["prior_wins"],
-            prior_losses=row["prior_losses"],
-            cumulative_buy_price_sum=row["cumulative_buy_price_sum"],
-            cumulative_buy_count=row["cumulative_buy_count"],
-            realized_pnl_usd=row["realized_pnl_usd"],
-            last_trade_ts=row["last_trade_ts"],
-            recent_30d_trades=deque(json.loads(row["recent_30d_trades_json"])),
-            bet_size_sum=row["bet_size_sum"],
-            bet_size_count=row["bet_size_count"],
-            category_counts=dict(json.loads(row["category_counts_json"])),
-        )
+        state = wallet_state_from_row(row)
         unresolved = list(json.loads(row["unresolved_buys_json"]))
         new_state, remaining = self._drain_resolved_buys(state, unresolved, as_of_ts)
         if remaining is not unresolved:
@@ -198,13 +190,7 @@ class LiveHistoryProvider:
         ).fetchone()
         if row is None:
             return empty_market_state(market_age_start_ts=0)
-        return MarketState(
-            market_age_start_ts=row["market_age_start_ts"],
-            volume_so_far_usd=row["volume_so_far_usd"],
-            unique_traders_count=row["unique_traders_count"],
-            last_trade_price=row["last_trade_price"],
-            recent_prices=deque(json.loads(row["recent_prices_json"]), maxlen=_RECENT_PRICES_MAX),
-        )
+        return market_state_from_row(row)
 
     def observe(self, trade: Trade) -> None:
         """Fold a trade into running wallet + market state.
@@ -250,17 +236,8 @@ class LiveHistoryProvider:
             current = empty_market_state(market_age_start_ts=trade.ts)
             traders: set[str] = set()
         else:
-            current = MarketState(
-                market_age_start_ts=market_row["market_age_start_ts"],
-                volume_so_far_usd=market_row["volume_so_far_usd"],
-                unique_traders_count=market_row["unique_traders_count"],
-                last_trade_price=market_row["last_trade_price"],
-                recent_prices=deque(
-                    json.loads(market_row["recent_prices_json"]),
-                    maxlen=_RECENT_PRICES_MAX,
-                ),
-            )
-            traders = set(json.loads(market_row["traders_json"]))
+            current = market_state_from_row(market_row)
+            traders = market_traders_from_row(market_row)
         is_new_trader = trade.wallet_address not in traders
         if is_new_trader:
             traders.add(trade.wallet_address)
@@ -283,77 +260,19 @@ class LiveHistoryProvider:
         unresolved: list[dict[str, object]],
     ) -> None:
         self._conn.execute(
-            """
-            INSERT INTO wallet_state_live (
-              wallet_address, first_seen_ts, prior_trades_count, prior_buys_count,
-              prior_resolved_buys, prior_wins, prior_losses,
-              cumulative_buy_price_sum, cumulative_buy_count, realized_pnl_usd,
-              last_trade_ts, bet_size_sum, bet_size_count,
-              recent_30d_trades_json, category_counts_json, unresolved_buys_json
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            ON CONFLICT(wallet_address) DO UPDATE SET
-              first_seen_ts = excluded.first_seen_ts,
-              prior_trades_count = excluded.prior_trades_count,
-              prior_buys_count = excluded.prior_buys_count,
-              prior_resolved_buys = excluded.prior_resolved_buys,
-              prior_wins = excluded.prior_wins,
-              prior_losses = excluded.prior_losses,
-              cumulative_buy_price_sum = excluded.cumulative_buy_price_sum,
-              cumulative_buy_count = excluded.cumulative_buy_count,
-              realized_pnl_usd = excluded.realized_pnl_usd,
-              last_trade_ts = excluded.last_trade_ts,
-              bet_size_sum = excluded.bet_size_sum,
-              bet_size_count = excluded.bet_size_count,
-              recent_30d_trades_json = excluded.recent_30d_trades_json,
-              category_counts_json = excluded.category_counts_json,
-              unresolved_buys_json = excluded.unresolved_buys_json
-            """,
-            (
+            WALLET_STATE_UPSERT_SQL,
+            wallet_state_to_row(
                 wallet_address,
-                state.first_seen_ts,
-                state.prior_trades_count,
-                state.prior_buys_count,
-                state.prior_resolved_buys,
-                state.prior_wins,
-                state.prior_losses,
-                state.cumulative_buy_price_sum,
-                state.cumulative_buy_count,
-                state.realized_pnl_usd,
-                state.last_trade_ts,
-                state.bet_size_sum,
-                state.bet_size_count,
-                json.dumps(list(state.recent_30d_trades)),
-                json.dumps(state.category_counts),
-                json.dumps(unresolved),
+                state,
+                unresolved_buys_json=json.dumps(unresolved),
             ),
         )
         self._conn.commit()
 
     def _persist_market(self, condition_id: str, state: MarketState, traders: set[str]) -> None:
         self._conn.execute(
-            """
-            INSERT INTO market_state_live (
-              condition_id, market_age_start_ts, volume_so_far_usd,
-              unique_traders_count, last_trade_price, recent_prices_json,
-              traders_json
-            ) VALUES (?, ?, ?, ?, ?, ?, ?)
-            ON CONFLICT(condition_id) DO UPDATE SET
-              market_age_start_ts = excluded.market_age_start_ts,
-              volume_so_far_usd = excluded.volume_so_far_usd,
-              unique_traders_count = excluded.unique_traders_count,
-              last_trade_price = excluded.last_trade_price,
-              recent_prices_json = excluded.recent_prices_json,
-              traders_json = excluded.traders_json
-            """,
-            (
-                condition_id,
-                state.market_age_start_ts,
-                state.volume_so_far_usd,
-                state.unique_traders_count,
-                state.last_trade_price,
-                json.dumps(list(state.recent_prices)),
-                json.dumps(sorted(traders)),
-            ),
+            MARKET_STATE_UPSERT_SQL,
+            market_state_to_row(condition_id, state, traders=traders),
         )
         self._conn.commit()
 

--- a/tests/daemon/test_state_persistence_parity.py
+++ b/tests/daemon/test_state_persistence_parity.py
@@ -1,0 +1,160 @@
+"""Column-list ↔ dataclass parity regression for ``_state_persistence``.
+
+The serializers in :mod:`pscanner.daemon._state_persistence` are driven
+by hand-written column tuples (``WALLET_STATE_COLUMNS`` /
+``MARKET_STATE_COLUMNS``). If a new field is added to ``WalletState`` or
+``MarketState`` without a matching column entry, the silent column-drop
+would only surface as missing-feature drift in the live daemon, not at
+test time.
+
+These tests assert that every dataclass field maps to exactly one column
+and vice versa, so adding a field forces a corresponding column update
+in the same PR.
+
+If you're hitting these tests after adding a state field:
+
+1. Add the column to the matching ``*_COLUMNS`` tuple in
+   ``_state_persistence.py`` (in the correct serialization order).
+2. Update ``*_to_row`` and ``*_from_row`` to include the new field.
+3. If the field needs a special serialization name (e.g.
+   ``_json``-suffixed for collections), add it to ``_JSON_SUFFIX_FIELDS``
+   in this test module too.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+from pscanner.corpus.features import (
+    MarketState,
+    WalletState,
+    empty_market_state,
+    empty_wallet_state,
+)
+from pscanner.daemon._state_persistence import (
+    MARKET_STATE_COLUMNS,
+    WALLET_STATE_COLUMNS,
+    market_state_to_row,
+    wallet_state_to_row,
+)
+
+# Columns added by the persist layer that don't correspond to a
+# WalletState field (the wallet address and the per-wallet pending-buy
+# queue, both owned by the provider rather than the state dataclass).
+_WALLET_PERSIST_ONLY_COLUMNS: frozenset[str] = frozenset(
+    {
+        "wallet_address",
+        "unresolved_buys_json",
+    }
+)
+
+# Columns added by the persist layer that don't correspond to a
+# MarketState field (the market identifier and the per-market trader
+# set, both owned by the provider rather than the state dataclass).
+_MARKET_PERSIST_ONLY_COLUMNS: frozenset[str] = frozenset(
+    {
+        "condition_id",
+        "traders_json",
+    }
+)
+
+# Fields whose column name takes a ``_json`` suffix because they're
+# serialized as JSON arrays/objects (collections that don't round-trip
+# through SQLite's primitive types).
+_WALLET_JSON_SUFFIX_FIELDS: frozenset[str] = frozenset(
+    {
+        "recent_30d_trades",
+        "category_counts",
+    }
+)
+_MARKET_JSON_SUFFIX_FIELDS: frozenset[str] = frozenset(
+    {
+        "recent_prices",
+    }
+)
+
+
+def _expected_columns(
+    dataclass_type: type,
+    *,
+    persist_only: frozenset[str],
+    json_suffix_fields: frozenset[str],
+) -> frozenset[str]:
+    """Derive the column-name set a serializer should produce for a dataclass."""
+    from_fields = {
+        f"{f.name}_json" if f.name in json_suffix_fields else f.name
+        for f in dataclasses.fields(dataclass_type)
+    }
+    return frozenset(persist_only | from_fields)
+
+
+def test_wallet_state_columns_cover_every_wallet_state_field() -> None:
+    """A new WalletState field without a column update must fail this test."""
+    expected = _expected_columns(
+        WalletState,
+        persist_only=_WALLET_PERSIST_ONLY_COLUMNS,
+        json_suffix_fields=_WALLET_JSON_SUFFIX_FIELDS,
+    )
+    actual = frozenset(WALLET_STATE_COLUMNS)
+    missing_columns = expected - actual
+    unexpected_columns = actual - expected
+    assert not missing_columns, (
+        f"WALLET_STATE_COLUMNS is missing entries derived from WalletState: "
+        f"{sorted(missing_columns)}. Add them in _state_persistence.py and "
+        f"update wallet_state_to_row / wallet_state_from_row to cover the new field."
+    )
+    assert not unexpected_columns, (
+        f"WALLET_STATE_COLUMNS has entries with no WalletState counterpart: "
+        f"{sorted(unexpected_columns)}. Either add the field to WalletState, "
+        f"remove the column, or list it in _WALLET_PERSIST_ONLY_COLUMNS in this test."
+    )
+
+
+def test_market_state_columns_cover_every_market_state_field() -> None:
+    """A new MarketState field without a column update must fail this test."""
+    expected = _expected_columns(
+        MarketState,
+        persist_only=_MARKET_PERSIST_ONLY_COLUMNS,
+        json_suffix_fields=_MARKET_JSON_SUFFIX_FIELDS,
+    )
+    actual = frozenset(MARKET_STATE_COLUMNS)
+    missing_columns = expected - actual
+    unexpected_columns = actual - expected
+    assert not missing_columns, (
+        f"MARKET_STATE_COLUMNS is missing entries derived from MarketState: "
+        f"{sorted(missing_columns)}. Add them in _state_persistence.py and "
+        f"update market_state_to_row / market_state_from_row to cover the new field."
+    )
+    assert not unexpected_columns, (
+        f"MARKET_STATE_COLUMNS has entries with no MarketState counterpart: "
+        f"{sorted(unexpected_columns)}. Either add the field to MarketState, "
+        f"remove the column, or list it in _MARKET_PERSIST_ONLY_COLUMNS in this test."
+    )
+
+
+def test_wallet_state_row_tuple_length_matches_column_tuple() -> None:
+    """to_row must produce a tuple whose length matches the column tuple."""
+    row = wallet_state_to_row(
+        "0xtest",
+        empty_wallet_state(first_seen_ts=0),
+        unresolved_buys_json="[]",
+    )
+    assert len(row) == len(WALLET_STATE_COLUMNS), (
+        f"wallet_state_to_row produced {len(row)} fields but WALLET_STATE_COLUMNS "
+        f"declares {len(WALLET_STATE_COLUMNS)}. The tuple builder must stay in "
+        f"sync with the column list."
+    )
+
+
+def test_market_state_row_tuple_length_matches_column_tuple() -> None:
+    """to_row must produce a tuple whose length matches the column tuple."""
+    row = market_state_to_row(
+        "0xtest",
+        empty_market_state(market_age_start_ts=0),
+        traders=(),
+    )
+    assert len(row) == len(MARKET_STATE_COLUMNS), (
+        f"market_state_to_row produced {len(row)} fields but MARKET_STATE_COLUMNS "
+        f"declares {len(MARKET_STATE_COLUMNS)}. The tuple builder must stay in "
+        f"sync with the column list."
+    )


### PR DESCRIPTION
## Summary

Two Tier-3 cleanups in `pscanner.daemon` that finish the strategies-slice refactor wave:

- **T3.23** — Lift `WalletState` / `MarketState` ↔ SQLite row serialization into a single helper module. The 16-column `wallet_state_live` INSERT used to live in three places (live_history's UPSERT, bootstrap's bulk INSERT, bootstrap's tuple builder); the 7-column `market_state_live` INSERT in two. Adding a field to either dataclass meant editing every column list in lockstep. The two `MarketState`-from-row reconstructions inside `live_history.py` collapse into one.
- **T3.24** — Switch `daemon/bootstrap.py` from `provider._wallets.items()` / `_markets.items()` / `accum.state` to the public `iter_wallet_states()` / `iter_market_states()` shipped by corpus-ml in PR #175. `_WalletAccumulator` import dropped.

## Files

| File | Change |
|---|---|
| `src/pscanner/daemon/_state_persistence.py` (new) | Column tuples, generated SQL constants, `wallet_state_to_row` / `wallet_state_from_row` / `market_state_to_row` / `market_state_from_row` / `market_traders_from_row`. |
| `src/pscanner/daemon/live_history.py` | `_persist_wallet`, `_persist_market`, `wallet_state`, `market_state`, `_observe_market` consume the helpers. |
| `src/pscanner/daemon/bootstrap.py` | `_bulk_write_wallets`, `_bulk_write_markets`, `_wallet_row` consume the helpers + new public iterators. |
| `tests/daemon/test_state_persistence_parity.py` (new) | Regression suite asserting column tuples cover every dataclass field. |

## Why the parity test matters

The risk T3.23 introduces is silent column-drop: a future developer adds a field to `WalletState` (e.g. `bet_size_relative_to_history_sum` for ML v2), forgets to update `WALLET_STATE_COLUMNS`, and the bulk INSERT silently writes a row without the new column. The parity test asserts that every `WalletState` / `MarketState` field maps to exactly one entry in the corresponding `_COLUMNS` tuple, so the drift is caught at test time. Acceptance criterion verified via mutation: dropping any column from either tuple fails the parity check.

## Residual scope / follow-ups

T3.24 ships partial. The corpus-ml T2.24 public API (PR #175) yields state-only 2-tuples; bootstrap also needs the per-wallet unresolved-buy queue (`accum.unscheduled` + `accum.heap`) and the per-market trader set (`provider._market_traders`) to write byte-identical rows. Two private accesses remain with inline `TODO` comments pointing at the missing API.

The clean extension would change the producer-side signatures to 3-tuples:

```python
def iter_wallet_states(self) -> Iterator[tuple[str, WalletState, list[_UnresolvedBuy]]]: ...
def iter_market_states(self) -> Iterator[tuple[str, MarketState, frozenset[str]]]: ...
```

That work is corpus-ml-owned scope (touches `src/pscanner/corpus/features.py`); none of corpus-ml's currently-tracked T3 items (T3.22, T3.26, T3.28) touch features.py, so a future extension PR can land without conflicting with their queue. When it does, bootstrap drops the two remaining `provider._*` accesses and the `_UnresolvedBuy` import.

## Test plan

- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run ty check` — 26 errors, all pre-existing in `tests/corpus/` and `tests/poly/`; identical count before vs after these commits (no new diagnostics)
- [x] `uv run pytest -q` — 1500 passed (1 deselected)
- [x] `tests/daemon/test_live_history.py` (existing coverage of all 5 read/write paths in live_history.py)
- [x] `tests/daemon/test_bootstrap.py` (existing end-to-end coverage of the cold-start path)
- [x] `tests/daemon/test_state_persistence_parity.py` (new — 4 tests, mutation-verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)