### PR TITLE
feat(corpus): skip pre-V1-coverage markets in V1 backfill queue (#197)

### DIFF
--- a/src/pscanner/corpus/subgraph_ingest_v1.py
+++ b/src/pscanner/corpus/subgraph_ingest_v1.py
@@ -19,7 +19,7 @@ import sqlite3
 import time
 from collections.abc import AsyncGenerator, AsyncIterator, Mapping, Sequence
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Final
 
 import structlog
 
@@ -31,6 +31,16 @@ from pscanner.poly.onchain_ingest import (
     event_to_corpus_trade,
 )
 from pscanner.poly.subgraph import SubgraphClient
+
+# Earliest Unix-second timestamp the V1 Polymarket Orderbook subgraph
+# (`7fu2DWYK93ePfzB24c2wrP94S3x4LGHUrQxphhoEypyY`) has ever indexed an
+# OrderFilledEvent for. Verified by Stage 0 investigation (commit
+# `e430e54`). Markets that closed before this date have no V1 history
+# the subgraph can serve, so backfilling them is wasted gamma quota
+# AND wall time (The Graph's indexer is slow to return empty results
+# on wide id_gt scans — ~60-90s per market observed in the 2026-05-27
+# production run before this filter was added).
+_V1_SUBGRAPH_EARLIEST_TS: Final[int] = 1744013119  # 2025-04-07 UTC
 
 _LOG = structlog.get_logger(__name__)
 
@@ -259,7 +269,14 @@ class _PendingV1Market:
 def _load_pending_v1_markets(
     conn: sqlite3.Connection, *, limit: int | None
 ) -> list[_PendingV1Market]:
-    """Return v1_history_pending markets not yet processed, ordered by volume desc."""
+    """Return v1_history_pending markets not yet processed, ordered by volume desc.
+
+    Markets that closed before the V1 subgraph's earliest indexed event
+    (``_V1_SUBGRAPH_EARLIEST_TS``) are excluded — V1 has nothing for
+    them and confirming that round-trips slow indexer queries. They
+    keep their ``v1_history_pending=1`` flag (still pending in a
+    literal sense — there is just no upstream that can serve them).
+    """
     sql = """
         SELECT condition_id,
                COALESCE(market_slug, '') AS market_slug,
@@ -268,11 +285,12 @@ def _load_pending_v1_markets(
         WHERE platform = 'polymarket'
           AND v1_history_pending = 1
           AND onchain_v1_processed_at IS NULL
+          AND closed_at >= ?
         ORDER BY total_volume_usd DESC
     """
     if limit is not None:
         sql += f" LIMIT {int(limit)}"
-    rows = conn.execute(sql).fetchall()
+    rows = conn.execute(sql, (_V1_SUBGRAPH_EARLIEST_TS,)).fetchall()
     return [
         _PendingV1Market(
             condition_id=r["condition_id"],
@@ -281,6 +299,21 @@ def _load_pending_v1_markets(
         )
         for r in rows
     ]
+
+
+def _count_pre_v1_skipped(conn: sqlite3.Connection) -> int:
+    """Count v1_history_pending markets excluded by the pre-V1-coverage filter."""
+    row = conn.execute(
+        """
+        SELECT COUNT(*) FROM corpus_markets
+        WHERE platform = 'polymarket'
+          AND v1_history_pending = 1
+          AND onchain_v1_processed_at IS NULL
+          AND closed_at < ?
+        """,
+        (_V1_SUBGRAPH_EARLIEST_TS,),
+    ).fetchone()
+    return int(row[0])
 
 
 def _load_asset_ids_for_market(conn: sqlite3.Connection, condition_id: str) -> list[str]:
@@ -381,7 +414,13 @@ async def run_v1_subgraph_backfill(
             ``int(time.time())`` at each market's completion.
     """
     pending = _load_pending_v1_markets(conn, limit=limit)
-    _LOG.info("subgraph.v1.start", markets=len(pending))
+    skipped_pre_v1 = _count_pre_v1_skipped(conn)
+    _LOG.info(
+        "subgraph.v1.start",
+        markets=len(pending),
+        skipped_pre_v1=skipped_pre_v1,
+        v1_earliest_ts=_V1_SUBGRAPH_EARLIEST_TS,
+    )
 
     processed = 0
     failed = 0

--- a/tests/corpus/test_subgraph_ingest_v1.py
+++ b/tests/corpus/test_subgraph_ingest_v1.py
@@ -9,7 +9,12 @@ from typing import Any
 
 import pytest
 
-from pscanner.corpus.subgraph_ingest_v1 import subgraph_v1_row_to_event
+from pscanner.corpus.subgraph_ingest_v1 import (
+    _V1_SUBGRAPH_EARLIEST_TS,
+    _count_pre_v1_skipped,
+    _load_pending_v1_markets,
+    subgraph_v1_row_to_event,
+)
 from pscanner.poly.subgraph import SubgraphClient
 
 _FIXTURE = Path(__file__).parent / "fixtures" / "v1_v2_overlap.json"
@@ -336,12 +341,18 @@ def _fat_buy_row(idx: int, asset_id: str) -> dict[str, str]:
     }
 
 
-def _seed_v1_pending_market(conn: sqlite3.Connection, condition_id: str, asset_id: str) -> None:
+def _seed_v1_pending_market(
+    conn: sqlite3.Connection,
+    condition_id: str,
+    asset_id: str,
+    *,
+    closed_at: int = 1_760_000_000,  # 2025-10-09, post-V1-earliest (1744013119)
+) -> None:
     market = CorpusMarket(
         condition_id=condition_id,
         event_slug="test-event",
         category=None,
-        closed_at=1_700_000_000,
+        closed_at=closed_at,
         total_volume_usd=50_000.0,
         enumerated_at=1_700_000_000,
         market_slug="test-market",
@@ -490,5 +501,36 @@ async def test_hybrid_market_sets_both_sentinels(tmp_path: Path):
         assert row["onchain_processed_at"] == 1_600_000_000  # untouched by V1
         assert row["onchain_v1_processed_at"] == 1_700_000_999  # set by V1
         assert row["v1_history_pending"] == 0  # cleared by V1
+    finally:
+        conn.close()
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_skips_pre_v1_coverage_markets(tmp_path: Path) -> None:
+    """Markets with closed_at < V1 earliest are excluded from the queue (#197).
+
+    The V1 subgraph's earliest indexed event is at 1744013119 (2025-04-07).
+    Markets that closed before that have no V1 history to serve and were
+    wasting ~60-90 sec each on empty `id_gt` scans before this filter.
+    """
+    conn = init_corpus_db(tmp_path / "corpus.sqlite3")
+    try:
+        # 1: pre-V1 market — should be filtered out.
+        _seed_v1_pending_market(
+            conn, "0x" + "a" * 64, "100", closed_at=_V1_SUBGRAPH_EARLIEST_TS - 1
+        )
+        # 2: at V1 earliest — should be included (boundary).
+        _seed_v1_pending_market(
+            conn, "0x" + "b" * 64, "200", closed_at=_V1_SUBGRAPH_EARLIEST_TS
+        )
+        # 3: post-V1 market — should be included.
+        _seed_v1_pending_market(
+            conn, "0x" + "c" * 64, "300", closed_at=_V1_SUBGRAPH_EARLIEST_TS + 86400
+        )
+
+        pending = _load_pending_v1_markets(conn, limit=None)
+        cids = {m.condition_id for m in pending}
+        assert cids == {"0x" + "b" * 64, "0x" + "c" * 64}
+        assert _count_pre_v1_skipped(conn) == 1
     finally:
         conn.close()


### PR DESCRIPTION
## Summary

- One-line SQL filter on the V1 backfill queue: `AND closed_at >= _V1_SUBGRAPH_EARLIEST_TS` where `_V1_SUBGRAPH_EARLIEST_TS = 1744013119` (2025-04-07, V1 subgraph's earliest indexed event).
- New module-level constant for the threshold.
- Startup log event now carries `skipped_pre_v1=N v1_earliest_ts=...` so operators see the count.
- One unit test covers the boundary (`closed_at == V1_EARLIEST` is included; `< V1_EARLIEST` is filtered out).

## Why

Surfaced during the 2026-05-27 V1 backfill run on the desktop. At both `rpm=50` and the default `rpm=600`, markets with `closed_at < 1744013119` took **~60-90 seconds each** for the orchestrator to confirm empty — The Graph's indexer scans a wide `id_gt` range looking for `makerAssetId_in` matches that don't exist, and the response time dominates the per-market loop time. Rate-limit changes had no effect; the bottleneck is upstream.

On the production corpus this affects **752 of 2,768 v1_history_pending markets (27.2%)**. At the observed pace, skipping them saves **~16 hours** off a single full V1 backfill run.

Previous behavior (without this filter):
- Markets correctly returned `markets_no_new_trades=1` after the slow drain
- Sentinel correctly NOT stamped (no V1 events were inserted)
- → market stays `v1_history_pending=1` and gets re-queued every subsequent run, wasting time and gamma quota in perpetuity

This PR turns those into a SQL no-op at queue load — they retain `v1_history_pending=1` (still pending in the literal sense) but never get queried.

## Test plan

- [x] `uv run pytest tests/corpus -q` — 304 passed, 0 regressions (16 prior V1 tests + 1 new boundary test).
- [x] `uv run ruff check . && uv run ruff format --check .` — clean.
- [x] `uv run ty check src/pscanner/corpus/subgraph_ingest_v1.py` — zero new diagnostics.
- [ ] Desktop V1 backfill restart post-merge — expected behavior: `subgraph.v1.start markets=N skipped_pre_v1=752` and ~16 hours faster overall.

Closes #197.