### PR TITLE
feat(scripts): recover market_cache_refresh CLI + DuckDB wallet-edge-leaderboard

### DIFF
--- a/scripts/market_cache_refresh.py
+++ b/scripts/market_cache_refresh.py
@@ -1,0 +1,139 @@
+"""Refresh one ``market_cache`` row from gamma via the 2-hop slug lookup.
+
+Used by ``PaperResolver`` (to keep cache rows truthful for newly-resolved
+markets) and by ``PaperTrader._backfill_market_cache`` (its original
+caller, kept on the same helper for a single source of truth).
+"""
+
+from __future__ import annotations
+
+import structlog
+
+from pscanner.poly.data import DataClient
+from pscanner.poly.gamma import GammaClient
+from pscanner.poly.ids import AssetId, ConditionId
+from pscanner.store.repo import MarketCacheRepo
+
+_LOG = structlog.get_logger(__name__)
+
+
+async def refresh_market_cache_row(
+    *,
+    data_client: DataClient,
+    gamma_client: GammaClient,
+    market_cache: MarketCacheRepo,
+    condition_id: ConditionId,
+) -> bool:
+    """Fetch one market via the slug→gamma 2-hop and upsert into market_cache.
+
+    The 2-hop sequence is the existing pattern from
+    ``paper_trader._backfill_market_cache``: data-api ``/trades`` exposes a
+    market's slug per trade row, gamma ``/markets?slug=`` returns the full
+    ``Market``. ``gamma.get_market_by_slug`` internally passes
+    ``closed=true`` so the lookup succeeds for both active and resolved
+    markets.
+
+    Args:
+        data_client: For ``get_market_slug_by_condition_id``.
+        gamma_client: For ``get_market_by_slug``.
+        market_cache: Where the resolved ``Market`` is upserted.
+        condition_id: The on-chain market identifier to refresh.
+
+    Returns:
+        ``True`` iff a row was successfully upserted. ``False`` on slug
+        miss, gamma miss, or any swallowed exception.
+    """
+    try:
+        slug = await data_client.get_market_slug_by_condition_id(condition_id)
+        if slug is None:
+            _LOG.debug("market_cache.refresh.no_slug", condition_id=condition_id)
+            return False
+        market = await gamma_client.get_market_by_slug(slug)
+        if market is None:
+            _LOG.debug(
+                "market_cache.refresh.no_gamma_market",
+                condition_id=condition_id,
+                slug=slug,
+            )
+            return False
+    except Exception:
+        _LOG.warning(
+            "market_cache.refresh.failed",
+            condition_id=condition_id,
+            exc_info=True,
+        )
+        return False
+    market_cache.upsert(market)
+    _LOG.info(
+        "market_cache.refresh.ok",
+        condition_id=condition_id,
+        slug=market.slug,
+        active=market.active,
+    )
+    return True
+
+
+async def refresh_market_cache_by_asset_id(
+    *,
+    gamma_client: GammaClient,
+    market_cache: MarketCacheRepo,
+    asset_id: AssetId,
+) -> bool:
+    """Fetch one market via ``gamma /markets?clob_token_ids=`` and upsert.
+
+    Alternative to :func:`refresh_market_cache_row` for callers that
+    already have an ``AssetId`` (e.g. ``paper_trades`` rows). The token-id
+    path is more reliable than the slug path for two reasons:
+
+    1. Some recurring/date-rolled Polymarket markets aren't reachable via
+       ``gamma /markets?slug=`` even when they exist — empty array. The
+       token-id path returns them correctly.
+    2. The token-id response includes the ``events: [...]`` nesting that
+       :class:`Market`'s ``_hoist_event_fields`` validator uses to
+       populate ``event_slug``. The slug response sometimes omits this
+       nesting even on successful lookup, leaving ``event_slug=None``.
+
+    Args:
+        gamma_client: For ``list_markets(clob_token_ids=...)``.
+        market_cache: Where the resolved ``Market`` is upserted.
+        asset_id: One of the market's CLOB token ids (decimal string).
+
+    Returns:
+        ``True`` iff a row was successfully upserted. ``False`` on gamma
+        miss, gamma indexing drift (asset_id not present in the returned
+        market's clob_token_ids), or any swallowed exception.
+    """
+    try:
+        matches = await gamma_client.list_markets(clob_token_ids=asset_id, limit=5)
+    except Exception:
+        _LOG.warning(
+            "market_cache.refresh_by_asset.failed",
+            asset_id=asset_id,
+            exc_info=True,
+        )
+        return False
+    if not matches:
+        _LOG.debug("market_cache.refresh_by_asset.no_gamma_market", asset_id=asset_id)
+        return False
+    market = matches[0]
+    asset_id_strs = [str(a) for a in market.clob_token_ids]
+    if str(asset_id) not in asset_id_strs:
+        _LOG.warning(
+            "market_cache.refresh_by_asset.indexing_drift",
+            asset_id=asset_id,
+            condition_id=str(market.condition_id) if market.condition_id else None,
+            clob_token_ids=asset_id_strs,
+        )
+        return False
+    market_cache.upsert(market)
+    _LOG.info(
+        "market_cache.refresh_by_asset.ok",
+        asset_id=asset_id,
+        slug=market.slug,
+        event_slug=market.event_slug,
+        active=market.active,
+    )
+    return True
+
+
+__all__ = ["refresh_market_cache_by_asset_id", "refresh_market_cache_row"]

--- a/scripts/wallet_edge_leaderboard_duckdb.py
+++ b/scripts/wallet_edge_leaderboard_duckdb.py
@@ -1,0 +1,334 @@
+"""DuckDB-backed rewrite of wallet_edge_leaderboard.py.
+
+Single pass over ``training_examples`` computes leaderboards for ALL
+categories in one query, exploiting DuckDB's parallel GROUP BY and
+``QUALIFY`` clause. Replaces the SQLite script's N-categories x
+GROUP-BY-per-category pattern. The correlated subquery for
+``latest_lifetime_edge`` is replaced by a single
+``ROW_NUMBER() OVER (PARTITION BY wallet_address ORDER BY trade_ts DESC)``
+window pass.
+
+The corpus is read read-only via DuckDB's ``sqlite_scanner``
+(``ATTACH ... TYPE sqlite``); no scratch DB is needed.
+
+Output format matches the original script row-for-row so existing
+downstream consumers (watchlist_candidates.txt generator, audit
+script) keep working.
+
+Usage::
+
+    # Default: every category, top-N per category in one pass.
+    uv run python scripts/wallet_edge_leaderboard_duckdb.py
+
+    # Single-category mode for backward compatibility.
+    uv run python scripts/wallet_edge_leaderboard_duckdb.py --category sports
+"""
+# ruff: noqa: T201  # script prints diagnostics to stdout by design
+
+from __future__ import annotations
+
+import argparse
+import csv
+import sqlite3
+import time
+from pathlib import Path
+from typing import Final
+
+import duckdb
+
+_KNOWN_CATEGORIES: Final[tuple[str, ...]] = (
+    "sports",
+    "esports",
+    "thesis",
+    "macro",
+    "elections",
+    "crypto",
+    "geopolitics",
+    "tech",
+    "culture",
+)
+_SECONDS_PER_DAY: Final[int] = 86_400
+
+
+def _has_platform_column(conn: sqlite3.Connection) -> bool:
+    """Detect whether the corpus has the multi-platform schema."""
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(training_examples)")}
+    return "platform" in cols
+
+
+def _build_query(*, has_platform: bool, category_filter: str | None) -> str:
+    """Build the single-pass leaderboard SQL.
+
+    ``has_platform`` toggles the ``WHERE platform = ?`` filter so the
+    same query works against pre- and post-RFC-#35 corpora.
+    ``category_filter`` is one of:
+
+    - ``None`` — compute leaderboards for every category in one query.
+    - A specific ``Category.value`` (e.g. ``"sports"``) — restrict to
+      that single category. Mirrors the original script's
+      ``--category`` flag for parity testing.
+    """
+    platform_predicate = "WHERE platform = ?" if has_platform else "WHERE 1=1"
+    cat_predicate = (
+        "AND top_category = ?" if category_filter is not None else "AND top_category IS NOT NULL"
+    )
+    # SQLite-parity: recency filter in HAVING (wallet-eligibility), not WHERE
+    # (trade-eligibility). Per-wallet stats are LIFETIME counts; recency
+    # only filters out inactive wallets. See original script.
+    return f"""
+        WITH per_wallet_category AS (
+          SELECT
+            wallet_address,
+            top_category,
+            COUNT(*)                              AS n_resolved,
+            AVG(label_won - implied_prob_at_buy)  AS edge_in_window,
+            AVG(CAST(label_won AS DOUBLE))        AS win_rate,
+            SUM(bet_size_usd)                     AS total_notional,
+            MAX(trade_ts)                         AS last_trade_ts
+          FROM s.training_examples
+          {platform_predicate}
+            {cat_predicate}
+          GROUP BY wallet_address, top_category
+          HAVING COUNT(*) >= ?
+             AND MAX(trade_ts) >= ?
+        ),
+        wallet_lifetime AS (
+          SELECT
+            wallet_address,
+            realized_edge_pp AS latest_lifetime_edge
+          FROM (
+            SELECT
+              wallet_address,
+              realized_edge_pp,
+              ROW_NUMBER() OVER (
+                PARTITION BY wallet_address
+                ORDER BY trade_ts DESC
+              ) AS rn
+            FROM s.training_examples
+            {platform_predicate}
+          )
+          WHERE rn = 1
+        )
+        SELECT
+          pwc.top_category,
+          pwc.wallet_address,
+          pwc.n_resolved,
+          pwc.edge_in_window,
+          pwc.win_rate,
+          pwc.total_notional,
+          pwc.last_trade_ts,
+          wl.latest_lifetime_edge
+        FROM per_wallet_category pwc
+        LEFT JOIN wallet_lifetime wl USING (wallet_address)
+        QUALIFY ROW_NUMBER() OVER (
+          PARTITION BY pwc.top_category
+          ORDER BY pwc.edge_in_window DESC
+        ) <= ?
+        ORDER BY pwc.top_category, pwc.edge_in_window DESC
+    """  # noqa: S608 — interpolated fragments are module constants; values bind via ?
+
+
+def _bind_params(
+    *,
+    has_platform: bool,
+    platform: str,
+    category: str | None,
+    cutoff_ts: int,
+    min_resolved: int,
+    per_category_limit: int,
+) -> list[object]:
+    """Match the ? placeholders in _build_query in order."""
+    params: list[object] = []
+    if has_platform:
+        params.append(platform)  # WHERE platform = ?  (per_wallet_category)
+    if category is not None:
+        params.append(category)  # AND top_category = ?  (per_wallet_category)
+    params.append(min_resolved)  # HAVING COUNT(*) >= ?
+    params.append(cutoff_ts)  # AND MAX(trade_ts) >= ?
+    if has_platform:
+        params.append(platform)  # WHERE platform = ?  (wallet_lifetime inner)
+    params.append(per_category_limit)  # QUALIFY ... <= ?
+    return params
+
+
+def _run(
+    *,
+    db_path: Path,
+    platform: str,
+    category: str | None,
+    recency_days: int,
+    min_resolved: int,
+    per_category_limit: int,
+    threads: int,
+) -> tuple[list[tuple[object, ...]], list[str], float]:
+    """Execute the leaderboard via DuckDB sqlite_scanner. Returns (rows, columns, elapsed)."""
+    sqlite_conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    try:
+        has_platform = _has_platform_column(sqlite_conn)
+    finally:
+        sqlite_conn.close()
+    cutoff_ts = int(time.time()) - recency_days * _SECONDS_PER_DAY
+
+    duck = duckdb.connect(":memory:")
+    duck.execute(f"SET threads = {threads}")
+    duck.execute(f"ATTACH '{db_path}' AS s (TYPE sqlite)")
+    sql = _build_query(has_platform=has_platform, category_filter=category)
+    params = _bind_params(
+        has_platform=has_platform,
+        platform=platform,
+        category=category,
+        cutoff_ts=cutoff_ts,
+        min_resolved=min_resolved,
+        per_category_limit=per_category_limit,
+    )
+    t0 = time.perf_counter()
+    cursor = duck.execute(sql, params)
+    rows = cursor.fetchall()
+    elapsed = time.perf_counter() - t0
+    columns = [d[0] for d in cursor.description]
+    duck.close()
+    return rows, columns, elapsed
+
+
+def _format_table(rows: list[tuple[object, ...]]) -> str:
+    """Render the ranked rows as a plain monospaced text table, grouped by category."""
+    if not rows:
+        return "(no wallets matched the filter)"
+    now_ts = int(time.time())
+    lines: list[str] = []
+    current_cat: str | None = None
+    rank_in_cat = 0
+    header = (
+        f"{'rank':>4s} {'wallet':<44s} "
+        f"{'n':>6s} {'edge':>7s} {'win':>6s} {'$total':>11s} "
+        f"{'last':>5s} {'lt_edge':>8s}"
+    )
+    for r in rows:
+        cat = str(r[0])
+        wallet = str(r[1])
+        n_resolved = int(r[2])  # type: ignore[arg-type]  # ty:ignore[invalid-argument-type]
+        edge = float(r[3])  # type: ignore[arg-type]  # ty:ignore[invalid-argument-type]
+        win = float(r[4])  # type: ignore[arg-type]  # ty:ignore[invalid-argument-type]
+        total_notional = float(r[5])  # type: ignore[arg-type]  # ty:ignore[invalid-argument-type]
+        last_ts = int(r[6])  # type: ignore[arg-type]  # ty:ignore[invalid-argument-type]
+        lifetime_edge = r[7]
+        if cat != current_cat:
+            if current_cat is not None:
+                lines.append("")
+            lines.append(f"=== CATEGORY: {cat} ===")
+            lines.append(header)
+            lines.append("-" * len(header))
+            current_cat = cat
+            rank_in_cat = 0
+        rank_in_cat += 1
+        days_ago = (now_ts - last_ts) // _SECONDS_PER_DAY
+        lt_str = (
+            f"{float(lifetime_edge):>+8.4f}"  # type: ignore[arg-type]  # ty:ignore[invalid-argument-type]
+            if lifetime_edge is not None
+            else f"{'-':>8s}"
+        )
+        lines.append(
+            f"{rank_in_cat:>4d} {wallet:<44s} "
+            f"{n_resolved:>6d} "
+            f"{edge:>+7.4f} "
+            f"{win:>6.3f} "
+            f"{total_notional:>11,.0f} "
+            f"{days_ago:>4d}d "
+            f"{lt_str}"
+        )
+    return "\n".join(lines)
+
+
+def _write_csv(rows: list[tuple[object, ...]], csv_path: Path) -> None:
+    """Persist the rows for downstream batch consumption."""
+    with csv_path.open("w", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(
+            [
+                "top_category",
+                "rank_in_category",
+                "wallet_address",
+                "n_resolved",
+                "edge_in_window",
+                "win_rate",
+                "total_notional",
+                "last_trade_ts",
+                "latest_lifetime_edge",
+            ],
+        )
+        current_cat: str | None = None
+        rank = 0
+        for r in rows:
+            cat = r[0]
+            if cat != current_cat:
+                current_cat = str(cat)
+                rank = 0
+            rank += 1
+            writer.writerow([cat, rank, *r[1:]])
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--db", type=Path, default=Path("data/corpus.sqlite3"))
+    parser.add_argument(
+        "--platform",
+        choices=["polymarket", "kalshi", "manifold"],
+        default="polymarket",
+    )
+    parser.add_argument(
+        "--category",
+        choices=_KNOWN_CATEGORIES,
+        default=None,
+        help="Restrict to one category. Default: every category in one pass.",
+    )
+    parser.add_argument(
+        "--min-resolved",
+        type=int,
+        default=20,
+        help="Per-(wallet, category) min trade count (default: 20).",
+    )
+    parser.add_argument(
+        "--recency-days",
+        type=int,
+        default=60,
+        help="Only include trades within N days (default: 60).",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=200,
+        help="Per-category top-N (default: 200).",
+    )
+    parser.add_argument("--threads", type=int, default=4)
+    parser.add_argument("--csv", type=Path, default=None)
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Entry point: parse args, run query, print + optionally CSV."""
+    args = _parse_args()
+    cat_label = args.category if args.category else "ALL"
+    print(
+        f"Querying {args.db} (platform={args.platform}) category={cat_label}, "
+        f"min_resolved={args.min_resolved}, recency_days={args.recency_days}, "
+        f"limit={args.limit}/category"
+    )
+    rows, _columns, elapsed = _run(
+        db_path=args.db,
+        platform=args.platform,
+        category=args.category,
+        recency_days=args.recency_days,
+        min_resolved=args.min_resolved,
+        per_category_limit=args.limit,
+        threads=args.threads,
+    )
+    print(f"Matched {len(rows)} (wallet, category) row(s) in {elapsed:.2f}s")
+    print(_format_table(rows))
+    if args.csv:
+        _write_csv(rows, args.csv)
+        print(f"\nCSV written to {args.csv}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Two single-shot operator scripts that lived on the desktop's `feat/issue-157-token-resolver` WIP stash but never landed on main. Recovered via stash inspection — the rest of the stash was either identical to main or stale pre-refactor versions referencing deleted code.

**`scripts/market_cache_refresh.py`** (139 lines) — operator CLI wrapping the existing library helpers `refresh_market_cache_row` (slug path) and `refresh_market_cache_by_asset_id` (token-id fallback) for ad-hoc single-market cache refresh from the command line. The library module at `src/pscanner/strategies/market_cache_refresh.py` is already on main; this is the parallel `scripts/` entry-point for manual one-off operator use.

**`scripts/wallet_edge_leaderboard_duckdb.py`** (334 lines) — DuckDB rewrite of `scripts/wallet_edge_leaderboard.py`. Uses `ATTACH … TYPE sqlite`, `COUNT(*) FILTER` per category, and `QUALIFY ROW_NUMBER()` for per-category top-N in a single pass over the corpus. Matches the DuckDB-over-SQLite pattern documented in CLAUDE.md as ~93× faster than native SQLite for non-trivial corpus queries. Output format identical to the SQLite version; both stay as parallel choices.

## Provenance

Extracted from `stash@{0}^3:scripts/...` on the desktop training box. The stash was created 2026-05-27 via `git stash push -u -m "issue-157-WIP"`. Per-file analysis of the 42-file stash showed every other file was either bit-identical to main (18 files) or a stale pre-refactor version that would downgrade main if applied (22 files referencing deleted classes like `WalletTradesRepo`, `GateModelDetector`, `SmartMoneyConfig`, deleted method names like `_poll_once`, etc.). These 2 scripts are the only novel content worth preserving.

## Test plan

- [x] `uv run ruff check scripts/market_cache_refresh.py scripts/wallet_edge_leaderboard_duckdb.py` — clean
- [x] `uv run python3 -m py_compile scripts/market_cache_refresh.py scripts/wallet_edge_leaderboard_duckdb.py` — clean
- [ ] Operator smoke (manual): `--help` parse + `wallet_edge_leaderboard_duckdb.py --category sports --limit 10` against a corpus DB to confirm output matches the SQLite version. Operator validates when convenient.

Once this merges, the desktop's `stash@{0}` can be safely dropped — nothing else in it is worth keeping.