### PR TITLE
feat(corpus): backup Graph API key with quota-aware failover (#199)

### DIFF
--- a/src/pscanner/corpus/cli.py
+++ b/src/pscanner/corpus/cli.py
@@ -52,7 +52,7 @@ from pscanner.manifold.client import ManifoldClient
 from pscanner.manifold.ids import ManifoldMarketId
 from pscanner.poly.data import DataClient
 from pscanner.poly.gamma import GammaClient
-from pscanner.poly.subgraph import SubgraphClient
+from pscanner.poly.subgraph import SubgraphClient, SubgraphQuotaExhaustedError
 
 _log = structlog.get_logger(__name__)
 
@@ -678,20 +678,65 @@ def _default_duckdb_memory() -> str:
     )
 
 
+async def _preflight_subgraph_quota(client: SubgraphClient) -> None:
+    """Probe a subgraph endpoint with a tiny ``_meta`` query.
+
+    On :class:`SubgraphQuotaExhaustedError` (which has already attempted
+    failover internally if a backup URL is configured), let the caller
+    translate it into a clear operator-facing ``SystemExit``. Other
+    errors are swallowed — the dispatcher's own per-market error handling
+    will surface them in a more useful context.
+
+    Args:
+        client: A ``SubgraphClient`` whose URL points at the gateway
+            endpoint to probe.
+    """
+    try:
+        await client.query("{ _meta { block { number } } }", {})
+    except SubgraphQuotaExhaustedError:
+        raise
+    except Exception as exc:
+        # Non-quota errors are not preflight's concern; the per-market
+        # dispatcher path surfaces them in better context.
+        _log.debug("subgraph.preflight_non_quota_error", error=repr(exc))
+
+
 async def _cmd_subgraph_backfill(args: argparse.Namespace) -> int:
     """Run the subgraph-driven per-market backfill (V1+V2 dispatcher)."""
     api_key = args.api_key or os.environ.get("GRAPH_API_KEY")
     if not api_key:
         raise SystemExit("subgraph-backfill requires --api-key or $GRAPH_API_KEY")
+    backup_api_key = os.environ.get("GRAPH_API_KEY_BACKUP")
     resolved = _resolve_subgraph_flags(args)
     v2_url = _GATEWAY_URL_TEMPLATE.format(api_key=api_key, subgraph_id=resolved.v2_subgraph_id)
     v1_url = _GATEWAY_URL_TEMPLATE.format(api_key=api_key, subgraph_id=resolved.v1_subgraph_id)
+    v2_fallback_url = (
+        _GATEWAY_URL_TEMPLATE.format(api_key=backup_api_key, subgraph_id=resolved.v2_subgraph_id)
+        if backup_api_key
+        else None
+    )
+    v1_fallback_url = (
+        _GATEWAY_URL_TEMPLATE.format(api_key=backup_api_key, subgraph_id=resolved.v1_subgraph_id)
+        if backup_api_key
+        else None
+    )
     conn = init_corpus_db(Path(args.db))
     try:
         async with (
-            SubgraphClient(url=v2_url, rpm=args.rpm) as v2_client,
-            SubgraphClient(url=v1_url, rpm=args.rpm) as v1_client,
+            SubgraphClient(url=v2_url, rpm=args.rpm, fallback_url=v2_fallback_url) as v2_client,
+            SubgraphClient(url=v1_url, rpm=args.rpm, fallback_url=v1_fallback_url) as v1_client,
         ):
+            try:
+                # V1 burns ~2x the quota per market vs V2 — probing the V1
+                # endpoint surfaces exhaustion before either dispatcher runs.
+                await _preflight_subgraph_quota(v1_client)
+            except SubgraphQuotaExhaustedError:
+                msg = (
+                    "Graph API key quota exhausted"
+                    + (" (backup also exhausted)" if backup_api_key else "")
+                    + ". Set $GRAPH_API_KEY_BACKUP or wait for the monthly reset."
+                )
+                raise SystemExit(msg) from None
             summary = await run_subgraph_backfill_dispatched(
                 conn=conn,
                 v1_client=v1_client,

--- a/src/pscanner/corpus/subgraph_ingest.py
+++ b/src/pscanner/corpus/subgraph_ingest.py
@@ -24,7 +24,7 @@ from pscanner.poly.onchain_ingest import (
     UnsupportedFill,
     event_to_corpus_trade,
 )
-from pscanner.poly.subgraph import SubgraphClient
+from pscanner.poly.subgraph import SubgraphClient, SubgraphQuotaExhaustedError
 
 _LOG = structlog.get_logger(__name__)
 
@@ -495,6 +495,14 @@ async def run_subgraph_backfill(
                 trades_inserted=inserted,
                 trade_count=count,
             )
+        except SubgraphQuotaExhaustedError:
+            _LOG.error(
+                "subgraph.quota_exhausted",
+                idx=i,
+                of=len(pending),
+                condition_id=market.condition_id,
+            )
+            raise
         except Exception as exc:
             failed += 1
             _LOG.error(

--- a/src/pscanner/corpus/subgraph_ingest_v1.py
+++ b/src/pscanner/corpus/subgraph_ingest_v1.py
@@ -30,7 +30,7 @@ from pscanner.poly.onchain_ingest import (
     UnsupportedFill,
     event_to_corpus_trade,
 )
-from pscanner.poly.subgraph import SubgraphClient
+from pscanner.poly.subgraph import SubgraphClient, SubgraphQuotaExhaustedError
 
 # Earliest Unix-second timestamp the V1 Polymarket Orderbook subgraph
 # (`7fu2DWYK93ePfzB24c2wrP94S3x4LGHUrQxphhoEypyY`) has ever indexed an
@@ -439,6 +439,14 @@ async def run_v1_subgraph_backfill(
                 condition_id=market.condition_id,
                 page_size=page_size,
             )
+        except SubgraphQuotaExhaustedError:
+            _LOG.error(
+                "subgraph.v1.quota_exhausted",
+                idx=i,
+                of=len(pending),
+                condition_id=market.condition_id,
+            )
+            raise
         except Exception as exc:
             failed += 1
             _LOG.error(

--- a/src/pscanner/poly/subgraph.py
+++ b/src/pscanner/poly/subgraph.py
@@ -12,9 +12,37 @@ from collections.abc import Mapping
 from types import TracebackType
 from typing import Any, Self
 
+import structlog
+
 from pscanner.util.http_client import RateLimitedHttpClient
 
 _LOG_EVENT = "subgraph_retry"
+_LOG = structlog.get_logger()
+
+
+_QUOTA_ERROR_MARKER = "payment required"
+
+
+def _is_quota_exhausted(errors: list[dict[str, Any]]) -> bool:
+    """Return True if any GraphQL error message indicates an exhausted key.
+
+    The gateway returns ``{"message": "auth error: payment required for
+    subsequent requests for this API key"}`` once the monthly free-tier
+    quota runs out. Substring match keeps this resilient to minor wording
+    changes from The Graph.
+    """
+    return any(_QUOTA_ERROR_MARKER in str(err.get("message", "")).lower() for err in errors)
+
+
+class SubgraphQuotaExhaustedError(RuntimeError):
+    """Raised when the gateway rejects requests with `payment required`.
+
+    Distinct subclass of :class:`RuntimeError` so callers' broad
+    ``except RuntimeError`` still catch it, while a narrower
+    ``except SubgraphQuotaExhaustedError`` can branch on quota errors
+    specifically (used by the V1/V2 dispatchers to short-circuit and by
+    the CLI to print a clear remediation message).
+    """
 
 
 class SubgraphClient:
@@ -29,17 +57,31 @@ class SubgraphClient:
         timeout_seconds: Per-request timeout passed to :mod:`httpx`.
     """
 
-    def __init__(self, *, url: str, rpm: int, timeout_seconds: float = 30.0) -> None:
+    def __init__(
+        self,
+        *,
+        url: str,
+        rpm: int,
+        timeout_seconds: float = 30.0,
+        fallback_url: str | None = None,
+    ) -> None:
         """Store config without opening any sockets.
 
         Args:
             url: Full subgraph endpoint URL (e.g. the Graph gateway URL).
             rpm: Requests-per-minute budget.
             timeout_seconds: Default per-request timeout.
+            fallback_url: Optional secondary endpoint URL (typically the
+                same subgraph id with a backup API key baked in). On the
+                first :class:`SubgraphQuotaExhaustedError` from the
+                primary URL, the client swaps ``self.url`` to this value
+                and retries the in-flight query. A second quota error
+                (now from the fallback) propagates.
         """
         self.url = url
         self.rpm = rpm
         self.timeout_seconds = timeout_seconds
+        self._fallback_url = fallback_url
         self._inner = RateLimitedHttpClient(
             rpm=rpm,
             timeout_seconds=timeout_seconds,
@@ -62,9 +104,28 @@ class SubgraphClient:
             httpx.HTTPStatusError: On non-2xx after retries are exhausted.
         """
         body = {"query": graphql, "variables": dict(variables)}
+        try:
+            return await self._query_once(body)
+        except SubgraphQuotaExhaustedError:
+            if self._fallback_url is None:
+                raise
+            _LOG.warning(
+                "subgraph.api_key_rotated",
+                reason="primary_quota_exhausted",
+                primary_url=self.url,
+                fallback_url=self._fallback_url,
+            )
+            self.url = self._fallback_url
+            self._fallback_url = None
+            return await self._query_once(body)
+
+    async def _query_once(self, body: dict[str, Any]) -> dict[str, Any]:
+        """Execute a single GraphQL POST against ``self.url`` with no retries on quota errors."""
         response = await self._inner.post(self.url, json=body)
         payload = response.json()
         if payload.get("errors"):
+            if _is_quota_exhausted(payload["errors"]):
+                raise SubgraphQuotaExhaustedError(f"GraphQL quota exhausted: {payload['errors']}")
             raise RuntimeError(f"GraphQL errors: {payload['errors']}")
         data = payload.get("data")
         if not isinstance(data, dict):

--- a/tests/corpus/test_cli.py
+++ b/tests/corpus/test_cli.py
@@ -25,6 +25,7 @@ from pscanner.corpus.subgraph_ingest import SubgraphRunSummary
 from pscanner.corpus.subgraph_ingest_v1 import V1SubgraphRunSummary
 from pscanner.poly.data import DataClient
 from pscanner.poly.gamma import GammaClient
+from pscanner.poly.subgraph import SubgraphQuotaExhaustedError
 
 
 def test_parser_recognises_all_subcommands() -> None:
@@ -155,6 +156,116 @@ async def test_subgraph_backfill_subcommand_dispatches(
     assert captured["v2_rpm"] == 120
     assert captured["limit"] == 5
     assert captured["page_size"] == 1000  # default _DEFAULT_SUBGRAPH_PAGE_SIZE
+
+
+@pytest.mark.asyncio
+async def test_subgraph_backfill_passes_backup_key_as_fallback_url(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`GRAPH_API_KEY_BACKUP` env var becomes the fallback URL on both clients."""
+    db_path = tmp_path / "c.sqlite3"
+    monkeypatch.setenv("GRAPH_API_KEY_BACKUP", "backup-key")
+
+    captured: dict[str, object] = {}
+
+    async def fake_dispatched(  # type: ignore[no-untyped-def]
+        *, conn, v1_client, v2_client, versions, page_size, limit, **kwargs
+    ):
+        captured["v1_fallback"] = v1_client._fallback_url
+        captured["v2_fallback"] = v2_client._fallback_url
+        return DispatchedRunSummary(
+            v2_summary=SubgraphRunSummary(0, 0, 0, 0, 0, 0, 0),
+            v1_summary=V1SubgraphRunSummary(0, 0, 0, 0, 0, 0, 0, 0),
+            truncation_flags_cleared=0,
+        )
+
+    monkeypatch.setattr(corpus_cli, "run_subgraph_backfill_dispatched", fake_dispatched)
+    monkeypatch.setattr(corpus_cli, "_preflight_subgraph_quota", AsyncMock(return_value=None))
+
+    rc = await corpus_cli.run_corpus_command(
+        [
+            "subgraph-backfill",
+            "--db",
+            str(db_path),
+            "--api-key",
+            "primary-key",
+            "--subgraph-id",
+            "v2id",
+        ]
+    )
+    assert rc == 0
+    assert "backup-key" in str(captured["v1_fallback"])
+    assert "backup-key" in str(captured["v2_fallback"])
+
+
+@pytest.mark.asyncio
+async def test_subgraph_backfill_no_backup_env_yields_no_fallback_url(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No `GRAPH_API_KEY_BACKUP` env → fallback_url is None on both clients."""
+    monkeypatch.delenv("GRAPH_API_KEY_BACKUP", raising=False)
+
+    captured: dict[str, object] = {}
+
+    async def fake_dispatched(  # type: ignore[no-untyped-def]
+        *, conn, v1_client, v2_client, versions, page_size, limit, **kwargs
+    ):
+        captured["v1_fallback"] = v1_client._fallback_url
+        captured["v2_fallback"] = v2_client._fallback_url
+        return DispatchedRunSummary(
+            v2_summary=SubgraphRunSummary(0, 0, 0, 0, 0, 0, 0),
+            v1_summary=V1SubgraphRunSummary(0, 0, 0, 0, 0, 0, 0, 0),
+            truncation_flags_cleared=0,
+        )
+
+    monkeypatch.setattr(corpus_cli, "run_subgraph_backfill_dispatched", fake_dispatched)
+    monkeypatch.setattr(corpus_cli, "_preflight_subgraph_quota", AsyncMock(return_value=None))
+
+    rc = await corpus_cli.run_corpus_command(
+        [
+            "subgraph-backfill",
+            "--db",
+            str(tmp_path / "c.sqlite3"),
+            "--api-key",
+            "primary-key",
+            "--subgraph-id",
+            "v2id",
+        ]
+    )
+    assert rc == 0
+    assert captured["v1_fallback"] is None
+    assert captured["v2_fallback"] is None
+
+
+@pytest.mark.asyncio
+async def test_subgraph_backfill_exits_when_preflight_reports_quota_exhausted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Preflight raising `SubgraphQuotaExhaustedError` short-circuits to a clear SystemExit."""
+
+    async def raise_quota(_client: object) -> None:
+        raise SubgraphQuotaExhaustedError("GraphQL quota exhausted: stub")
+
+    monkeypatch.setattr(corpus_cli, "_preflight_subgraph_quota", raise_quota)
+    # Dispatcher must not be reached.
+    monkeypatch.setattr(
+        corpus_cli,
+        "run_subgraph_backfill_dispatched",
+        AsyncMock(side_effect=AssertionError("dispatcher should not be reached")),
+    )
+
+    with pytest.raises(SystemExit, match="quota exhausted"):
+        await corpus_cli.run_corpus_command(
+            [
+                "subgraph-backfill",
+                "--db",
+                str(tmp_path / "c.sqlite3"),
+                "--api-key",
+                "exhausted-key",
+                "--subgraph-id",
+                "v2id",
+            ]
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/corpus/test_subgraph_ingest.py
+++ b/tests/corpus/test_subgraph_ingest.py
@@ -28,7 +28,7 @@ from pscanner.corpus.subgraph_ingest import (
     subgraph_row_to_event,
 )
 from pscanner.poly.onchain import OrderFilledEvent
-from pscanner.poly.subgraph import SubgraphClient
+from pscanner.poly.subgraph import SubgraphClient, SubgraphQuotaExhaustedError
 
 _GATEWAY_URL = "https://gateway.example.test/api/k/subgraphs/id/abc"
 
@@ -615,3 +615,44 @@ async def test_run_subgraph_backfill_records_market_failure_and_continues(
         ("0xMARKET_B",),
     ).fetchone()
     assert row_b["onchain_processed_at"] is not None
+
+
+@respx.mock
+async def test_run_subgraph_backfill_reraises_on_quota_exhausted(
+    conn: sqlite3.Connection, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Quota exhaustion mid-run must short-circuit, not be swallowed."""
+    CorpusMarketsRepo(conn).insert_pending(
+        CorpusMarket(
+            condition_id="0xMARKET_B",
+            event_slug="event-b",
+            category=None,
+            closed_at=1_700_001_000,
+            total_volume_usd=10_000.0,
+            enumerated_at=1_700_000_000,
+            market_slug="market-b",
+        )
+    )
+    conn.execute(
+        "UPDATE corpus_markets SET truncated_at_offset_cap = 1, backfill_state = 'complete' "
+        "WHERE condition_id = ?",
+        ("0xMARKET_B",),
+    )
+    conn.commit()
+    AssetIndexRepo(conn).upsert(
+        AssetEntry(asset_id="333", condition_id="0xMARKET_B", outcome_side="YES", outcome_index=0)
+    )
+
+    async def quota_iter(**kwargs: object):  # type: ignore[no-untyped-def]
+        raise SubgraphQuotaExhaustedError("GraphQL quota exhausted: stub")
+        if False:
+            yield None  # pragma: no cover
+
+    monkeypatch.setattr("pscanner.corpus.subgraph_ingest.iter_market_trades", quota_iter)
+
+    client = SubgraphClient(url=_GATEWAY_URL, rpm=600)
+    try:
+        with pytest.raises(SubgraphQuotaExhaustedError):
+            await run_subgraph_backfill(conn=conn, client=client)
+    finally:
+        await client.aclose()

--- a/tests/corpus/test_subgraph_ingest_v1.py
+++ b/tests/corpus/test_subgraph_ingest_v1.py
@@ -15,7 +15,7 @@ from pscanner.corpus.subgraph_ingest_v1 import (
     _load_pending_v1_markets,
     subgraph_v1_row_to_event,
 )
-from pscanner.poly.subgraph import SubgraphClient
+from pscanner.poly.subgraph import SubgraphClient, SubgraphQuotaExhaustedError
 
 _FIXTURE = Path(__file__).parent / "fixtures" / "v1_v2_overlap.json"
 
@@ -520,9 +520,7 @@ async def test_orchestrator_skips_pre_v1_coverage_markets(tmp_path: Path) -> Non
             conn, "0x" + "a" * 64, "100", closed_at=_V1_SUBGRAPH_EARLIEST_TS - 1
         )
         # 2: at V1 earliest — should be included (boundary).
-        _seed_v1_pending_market(
-            conn, "0x" + "b" * 64, "200", closed_at=_V1_SUBGRAPH_EARLIEST_TS
-        )
+        _seed_v1_pending_market(conn, "0x" + "b" * 64, "200", closed_at=_V1_SUBGRAPH_EARLIEST_TS)
         # 3: post-V1 market — should be included.
         _seed_v1_pending_market(
             conn, "0x" + "c" * 64, "300", closed_at=_V1_SUBGRAPH_EARLIEST_TS + 86400
@@ -532,5 +530,44 @@ async def test_orchestrator_skips_pre_v1_coverage_markets(tmp_path: Path) -> Non
         cids = {m.condition_id for m in pending}
         assert cids == {"0x" + "b" * 64, "0x" + "c" * 64}
         assert _count_pre_v1_skipped(conn) == 1
+    finally:
+        conn.close()
+
+
+class _QuotaExhaustedClient(SubgraphClient):
+    """Subgraph client that always raises SubgraphQuotaExhaustedError on query."""
+
+    def __init__(self) -> None:
+        self.call_count = 0
+
+    async def query(self, graphql: str, variables: Mapping[str, Any]) -> dict[str, Any]:
+        self.call_count += 1
+        raise SubgraphQuotaExhaustedError("GraphQL quota exhausted: stub")
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_reraises_on_quota_exhausted(tmp_path: Path) -> None:
+    """Quota exhaustion mid-run must short-circuit the loop, not be swallowed.
+
+    Without this, an exhausted key produces 1,800 identical `market_failed`
+    log lines and burns wall time on guaranteed-fail markets.
+    """
+    conn = init_corpus_db(tmp_path / "corpus.sqlite3")
+    try:
+        cid_a = "0x" + "a" * 64
+        cid_b = "0x" + "b" * 64
+        _seed_v1_pending_market(conn, cid_a, "100")
+        _seed_v1_pending_market(conn, cid_b, "200")
+        client = _QuotaExhaustedClient()
+        with pytest.raises(SubgraphQuotaExhaustedError):
+            await run_v1_subgraph_backfill(
+                conn=conn,
+                client=client,
+                page_size=1000,
+                limit=None,
+                now_ts=1_700_000_999,
+            )
+        # only the first market triggers a query before short-circuit
+        assert client.call_count <= 2  # one or two passes for cid_a, then bail
     finally:
         conn.close()

--- a/tests/poly/test_subgraph.py
+++ b/tests/poly/test_subgraph.py
@@ -8,9 +8,10 @@ import httpx
 import pytest
 import respx
 
-from pscanner.poly.subgraph import SubgraphClient
+from pscanner.poly.subgraph import SubgraphClient, SubgraphQuotaExhaustedError
 
 _URL = "https://gateway.example.test/api/key/subgraphs/id/abc"
+_FALLBACK_URL = "https://gateway.example.test/api/key2/subgraphs/id/abc"
 
 
 @pytest.fixture
@@ -70,6 +71,76 @@ async def test_graphql_errors_surface_as_runtime_error(client: SubgraphClient) -
     try:
         with pytest.raises(RuntimeError, match="GraphQL errors"):
             await client.query("{ broken }", {})
+    finally:
+        await client.aclose()
+
+
+@respx.mock
+async def test_payment_required_raises_quota_exhausted(client: SubgraphClient) -> None:
+    respx.post(_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json={"errors": [{"message": "auth error: payment required for subsequent requests"}]},
+        )
+    )
+    try:
+        with pytest.raises(SubgraphQuotaExhaustedError):
+            await client.query("{ x }", {})
+    finally:
+        await client.aclose()
+
+
+@respx.mock
+async def test_fallback_url_swaps_on_quota_and_retries() -> None:
+    client = SubgraphClient(url=_URL, rpm=600, fallback_url=_FALLBACK_URL)
+    respx.post(_URL).mock(
+        return_value=httpx.Response(
+            200, json={"errors": [{"message": "auth error: payment required"}]}
+        )
+    )
+    fallback_route = respx.post(_FALLBACK_URL).mock(
+        return_value=httpx.Response(200, json={"data": {"ok": True}})
+    )
+    try:
+        result = await client.query("{ ok }", {})
+    finally:
+        await client.aclose()
+    assert result == {"ok": True}
+    assert fallback_route.called
+    assert client.url == _FALLBACK_URL  # one-shot swap is permanent
+
+
+@respx.mock
+async def test_fallback_url_double_quota_exhaustion_propagates() -> None:
+    client = SubgraphClient(url=_URL, rpm=600, fallback_url=_FALLBACK_URL)
+    respx.post(_URL).mock(
+        return_value=httpx.Response(
+            200, json={"errors": [{"message": "auth error: payment required"}]}
+        )
+    )
+    respx.post(_FALLBACK_URL).mock(
+        return_value=httpx.Response(
+            200, json={"errors": [{"message": "auth error: payment required"}]}
+        )
+    )
+    try:
+        with pytest.raises(SubgraphQuotaExhaustedError):
+            await client.query("{ x }", {})
+    finally:
+        await client.aclose()
+
+
+@respx.mock
+async def test_no_fallback_propagates_quota_error() -> None:
+    client = SubgraphClient(url=_URL, rpm=600)
+    respx.post(_URL).mock(
+        return_value=httpx.Response(
+            200, json={"errors": [{"message": "auth error: payment required"}]}
+        )
+    )
+    try:
+        with pytest.raises(SubgraphQuotaExhaustedError):
+            await client.query("{ x }", {})
     finally:
         await client.aclose()
 


### PR DESCRIPTION
Closes #199.

## Summary
- `SubgraphClient` distinguishes `payment required` gateway errors from generic GraphQL errors via a new `SubgraphQuotaExhaustedError` (subclass of `RuntimeError`, so existing `except RuntimeError` callers still catch it).
- The client accepts an optional `fallback_url`. On the first quota error against the primary, it swaps `self.url` to the fallback, logs `subgraph.api_key_rotated reason="primary_quota_exhausted"` once, and retries the in-flight query. Second quota error (now from the fallback) propagates.
- V1 and V2 dispatchers catch `SubgraphQuotaExhaustedError` ahead of their generic `except Exception` and re-raise, so an exhausted key short-circuits the loop instead of producing thousands of identical `market_failed` log lines.
- `pscanner corpus subgraph-backfill` reads `GRAPH_API_KEY_BACKUP` from the environment, builds matching fallback URLs for both subgraphs, and pre-flights a `_meta` query against the V1 endpoint before entering the dispatcher. A quota error that survives any configured failover becomes a `SystemExit` with a remediation message.

## Test plan
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run ty check` — 30 pre-existing diagnostics, zero new
- [x] `uv run pytest -q` — 1002 passed
- [ ] Live smoke on desktop with `GRAPH_API_KEY` (exhausted) + `GRAPH_API_KEY_BACKUP` set; expect one `subgraph.api_key_rotated` warning then normal backfill against the backup key
- [ ] Live smoke without `GRAPH_API_KEY_BACKUP`; expect `SystemExit` from preflight with the remediation message