### PR TITLE
fix(corpus): stamp V1 sentinel on no-new-trades and all-dup paths

### DIFF
--- a/src/pscanner/corpus/subgraph_ingest_v1.py
+++ b/src/pscanner/corpus/subgraph_ingest_v1.py
@@ -345,16 +345,18 @@ async def _backfill_one_v1_market(
     client: SubgraphClient,
     condition_id: str,
     page_size: int,
-) -> tuple[int, int, int, int, int]:
+) -> tuple[int, int, int, int, int] | None:
     """Drain one V1-pending market. Returns (events, inserted, unsup, unres, dups).
 
-    Returns (0, 0, 0, 0, 0) without querying the subgraph when asset_index
-    has no rows for this condition_id.
+    Returns ``None`` without querying the subgraph when ``asset_index``
+    has no rows for this condition_id; the orchestrator treats that as
+    a skip (no sentinel stamp) so the market is retried after
+    ``asset_index`` is populated.
     """
     asset_ids = _load_asset_ids_for_market(conn, condition_id)
     if not asset_ids:
         _LOG.warning("subgraph.v1.no_asset_index", condition_id=condition_id)
-        return 0, 0, 0, 0, 0
+        return None
 
     asset_repo = AssetIndexRepo(conn)
     trades_repo = CorpusTradesRepo(conn)
@@ -401,9 +403,15 @@ async def run_v1_subgraph_backfill(
     """Process every v1_history_pending market via the V1 subgraph.
 
     Stamps ``onchain_v1_processed_at`` and clears ``v1_history_pending``
-    only when ≥1 trade row was inserted. Zero-event drains and per-market
-    exceptions leave both sentinel columns unchanged so re-runs pick up
-    the market again.
+    after every market whose subgraph fetch completed without exception,
+    regardless of how many trades were inserted. The V1 Polymarket
+    Orderbook subgraph is an immutable historical indexer: a successful
+    response with zero new rows means "this market has no further V1
+    history to backfill" (either no V1 activity at all, or every event
+    was already in ``corpus_trades`` from a prior V2/V1 pass). Re-querying
+    burns ~60-90 s per market via The Graph's slow empty-result scans.
+    Per-market exceptions still leave both sentinel columns unchanged so
+    transient failures are retried on the next run.
 
     Args:
         conn: Open corpus DB connection.
@@ -433,7 +441,7 @@ async def run_v1_subgraph_backfill(
 
     for i, market in enumerate(pending, start=1):
         try:
-            events, inserted, unsup, unres, dups = await _backfill_one_v1_market(
+            result = await _backfill_one_v1_market(
                 conn=conn,
                 client=client,
                 condition_id=market.condition_id,
@@ -458,12 +466,22 @@ async def run_v1_subgraph_backfill(
             )
             continue
 
+        if result is None:
+            # asset_index empty for this market — already logged by
+            # _backfill_one_v1_market. Skip without stamping so a later
+            # asset_index repair lets this market be re-attempted.
+            continue
+        events, inserted, unsup, unres, dups = result
         total_events += events
         total_inserted += inserted
         total_unsupported += unsup
         total_unresolvable += unres
         total_dups += dups
 
+        _mark_v1_processed(
+            conn, market.condition_id, now_ts=now_ts if now_ts is not None else int(time.time())
+        )
+        processed += 1
         if inserted == 0:
             no_new_trades += 1
             _LOG.info(
@@ -472,23 +490,20 @@ async def run_v1_subgraph_backfill(
                 of=len(pending),
                 condition_id=market.condition_id,
                 slug=market.market_slug[:50],
+                events_decoded=events,
+                dups_dropped=dups,
             )
-            continue
-
-        _mark_v1_processed(
-            conn, market.condition_id, now_ts=now_ts if now_ts is not None else int(time.time())
-        )
-        processed += 1
-        _LOG.info(
-            "subgraph.v1.market_complete",
-            idx=i,
-            of=len(pending),
-            condition_id=market.condition_id[:14] + "...",
-            slug=market.market_slug[:50],
-            events_decoded=events,
-            trades_inserted=inserted,
-            dups_dropped=dups,
-        )
+        else:
+            _LOG.info(
+                "subgraph.v1.market_complete",
+                idx=i,
+                of=len(pending),
+                condition_id=market.condition_id[:14] + "...",
+                slug=market.market_slug[:50],
+                events_decoded=events,
+                trades_inserted=inserted,
+                dups_dropped=dups,
+            )
 
     summary = V1SubgraphRunSummary(
         markets_processed=processed,

--- a/tests/corpus/test_subgraph_ingest_v1.py
+++ b/tests/corpus/test_subgraph_ingest_v1.py
@@ -402,7 +402,11 @@ async def test_orchestrator_drains_one_market_and_stamps_sentinel(tmp_path: Path
 
 
 @pytest.mark.asyncio
-async def test_orchestrator_does_not_stamp_on_zero_events(tmp_path: Path):
+async def test_orchestrator_stamps_sentinel_on_zero_events(tmp_path: Path):
+    """V1 subgraph is immutable historical data: zero events means the market
+    has no V1 history, not "indexer is still catching up". Stamp the sentinel
+    so the queue drains and we don't waste 60-90 sec re-querying it next run.
+    """
     conn = init_corpus_db(tmp_path / "corpus.sqlite3")
     try:
         cid = "0x" + "b" * 64
@@ -413,14 +417,59 @@ async def test_orchestrator_does_not_stamp_on_zero_events(tmp_path: Path):
             conn=conn, client=client, page_size=1000, limit=None, now_ts=1_700_000_999
         )
         assert summary.markets_no_new_trades == 1
-        assert summary.markets_processed == 0
+        assert summary.markets_processed == 1  # stamped, not skipped
         row = conn.execute(
             "SELECT onchain_v1_processed_at, v1_history_pending FROM corpus_markets"
             " WHERE condition_id = ?",
             (cid,),
         ).fetchone()
-        assert row["onchain_v1_processed_at"] is None
-        assert row["v1_history_pending"] == 1
+        assert row["onchain_v1_processed_at"] == 1_700_000_999
+        assert row["v1_history_pending"] == 0
+    finally:
+        conn.close()
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_stamps_sentinel_on_all_dup_events(tmp_path: Path):
+    """V1 returned events but all of them duplicated existing corpus_trades.
+
+    This happens when V2 (or a prior V1 run) already inserted these rows.
+    The market's V1 history IS in the corpus — stamp the sentinel.
+    """
+    conn = init_corpus_db(tmp_path / "corpus.sqlite3")
+    try:
+        cid = "0x" + "e" * 64
+        aid = "8888888888"
+        _seed_v1_pending_market(conn, cid, aid)
+        # Pre-insert a trade row so the next subgraph fetch produces a dup.
+        rows = [_fat_buy_row(0, aid)]
+        pre_client = _FakeSubgraphClient(pages_by_query={"maker": [], "taker": [rows]})
+        await run_v1_subgraph_backfill(
+            conn=conn, client=pre_client, page_size=1000, limit=None, now_ts=1_700_000_500
+        )
+        # Re-flag the market so we can run a second backfill pass on it.
+        conn.execute(
+            "UPDATE corpus_markets SET v1_history_pending = 1,"
+            " onchain_v1_processed_at = NULL WHERE condition_id = ?",
+            (cid,),
+        )
+        conn.commit()
+
+        # Second pass: same rows come back, all dups.
+        client = _FakeSubgraphClient(pages_by_query={"maker": [], "taker": [rows]})
+        summary = await run_v1_subgraph_backfill(
+            conn=conn, client=client, page_size=1000, limit=None, now_ts=1_700_000_999
+        )
+        assert summary.trades_inserted == 0
+        assert summary.dups_dropped == 1
+        assert summary.markets_processed == 1  # stamped despite zero inserts
+        row = conn.execute(
+            "SELECT onchain_v1_processed_at, v1_history_pending FROM corpus_markets"
+            " WHERE condition_id = ?",
+            (cid,),
+        ).fetchone()
+        assert row["onchain_v1_processed_at"] == 1_700_000_999
+        assert row["v1_history_pending"] == 0
     finally:
         conn.close()
 


### PR DESCRIPTION
## Summary
Surfaced during the post-#199 desktop smoke. The first three markets in the V1 queue (Sacramento Kings 2025 NBA Finals, Zelenskyy-suit, Fed-50bps) all returned zero V1 events and took ~90 s each because The Graph's V1 indexer scans the full `id_gt` range to confirm "no rows." Pre-fix the orchestrator left them `v1_history_pending=1` so they'd be re-queried every run. The 1,952-market queue projected to ~49 h wall time of identical re-queries.

V1 is an immutable historical indexer — a successful response with zero new rows means the market has no further V1 history. Either:
- It has no V1 activity at all (purely V2 market), or
- Every V1 event was already inserted by a prior V2/V1 pass (the May 28 retry log showed 8.19M `dups_dropped`).

Either way, re-querying is pointless. `run_v1_subgraph_backfill` now calls `_mark_v1_processed` after every successful `_backfill_one_v1_market` return, regardless of inserted count.

To keep the missing-`asset_index` skip path from sweeping legitimately-unfinished markets out of the queue, `_backfill_one_v1_market` now returns `None` for that case (vs the zero-tuple meaning "queried, nothing came back"). The orchestrator skips without stamping when result is `None`.

## Test plan
- [x] `uv run pytest -q` — 1003 passed (one new test for the all-dup case)
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run ty check` — 30 pre-existing diagnostics, zero new
- [x] Inverted `test_orchestrator_does_not_stamp_on_zero_events` → `test_orchestrator_stamps_sentinel_on_zero_events`
- [x] Added `test_orchestrator_stamps_sentinel_on_all_dup_events`
- [x] `test_orchestrator_skips_market_with_empty_asset_index` still asserts no stamp (the new `None` return preserves this behavior)
- [ ] Re-trigger backfill on desktop and confirm `markets_processed` includes the no-new-trades markets