### PR TITLE
feat(backtest): causal wallet-selection mode for copy-trading backtest

### DIFF
--- a/docs/superpowers/plans/2026-05-30-causal-copy-selection.md
+++ b/docs/superpowers/plans/2026-05-30-causal-copy-selection.md
@@ -1,0 +1,1050 @@
+# Causal Wallet Selection — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `--causal-select` mode to `scripts/backtest_copy_sizing.py` that qualifies wallets at ≥N resolved trades, ranks them by causal (no-lookahead) edge, freezes a global top-K copy set on a rebalance cadence (positive-edge hard floor), and backtests copying only that evolving set — so results resemble live performance.
+
+**Architecture:** A new `scripts/copy_selection.py` does the heavy lifting in DuckDB (resolved-buy fact table → per-boundary edge → ranked qualifiers), returns the same event-row tuples the existing Simulator already consumes. The per-boundary top-K cut is applied in Python (`resolve_k`) for testability, then pushed back as a DuckDB temp table to emit the selected-trade stream. The existing `Simulator`, four sizing schemes, and #204 capacity gates are unchanged.
+
+**Tech Stack:** Python 3.13, DuckDB (`ATTACH ... TYPE sqlite`), sqlite3, pytest, uv/ruff/ty.
+
+**Spec:** `docs/superpowers/specs/2026-05-30-causal-copy-selection-design.md`
+
+---
+
+## File structure
+
+- **Create** `scripts/copy_selection.py` — DuckDB causal-selection precompute + selected-trade stream. Public surface: `KPolicy`, `resolve_k`, `has_platform_column`, `iter_selected_rows`.
+- **Create** `tests/scripts/test_copy_selection.py` — unit + cross-validation tests for the selector.
+- **Create** `tests/scripts/conftest.py` — shared `corpus_factory` fixture (builds a tiny corpus sqlite DB).
+- **Modify** `scripts/backtest_copy_sizing.py` — add a shared `has_platform_column` use, refactor row→event into `_rows_to_events`, add `--causal-select` + new flags, branch `main`, add report selection-summary.
+- **Modify** `tests/scripts/test_backtest_simulator.py` — parser tests for the new flags + an end-to-end causal-mode integration test.
+
+The event-row tuple shape (used everywhere) matches the existing `load_event_stream` SELECT:
+`(kind, ts, wallet, condition_id, outcome_side, price, notional_usd, outcome_yes_won)`.
+
+---
+
+## Task 1: Shared `corpus_factory` test fixture
+
+**Files:**
+- Create: `tests/scripts/conftest.py`
+
+- [ ] **Step 1: Write the fixture**
+
+```python
+"""Shared fixtures for scripts tests."""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+# trade tuple: (wallet, condition_id, outcome_side, bs, price, notional_usd, ts)
+# resolution tuple: (condition_id, outcome_yes_won, resolved_at)
+Trade = tuple[str, str, str, str, float, float, int]
+Resolution = tuple[str, int, int]
+
+
+def _build(path: Path, trades: list[Trade], resolutions: list[Resolution],
+           *, with_platform: bool) -> None:
+    plat_col = "platform TEXT NOT NULL DEFAULT 'polymarket'," if with_platform else ""
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        f"""
+        CREATE TABLE corpus_trades (
+          {plat_col}
+          tx_hash TEXT NOT NULL, asset_id TEXT NOT NULL,
+          wallet_address TEXT NOT NULL, condition_id TEXT NOT NULL,
+          outcome_side TEXT NOT NULL, bs TEXT NOT NULL,
+          price REAL NOT NULL, size REAL NOT NULL,
+          notional_usd REAL NOT NULL, ts INTEGER NOT NULL
+        );
+        CREATE TABLE market_resolutions (
+          {plat_col}
+          condition_id TEXT NOT NULL, winning_outcome_index INTEGER NOT NULL,
+          outcome_yes_won INTEGER NOT NULL, resolved_at INTEGER NOT NULL,
+          source TEXT NOT NULL, recorded_at INTEGER NOT NULL
+        );
+        """
+    )
+    prefix = "'polymarket'," if with_platform else ""
+    for i, (w, cid, side, bs, price, notional, ts) in enumerate(trades):
+        conn.execute(
+            f"INSERT INTO corpus_trades VALUES ({prefix}?,?,?,?,?,?,?,?,?,?)",
+            (f"0xtx{i}", f"asset{i}", w, cid, side, bs, price,
+             notional / price, notional, ts),
+        )
+    for cid, yes_won, resolved_at in resolutions:
+        conn.execute(
+            f"INSERT INTO market_resolutions VALUES ({prefix}?,?,?,?,'test',?)",
+            (cid, 0 if yes_won else 1, yes_won, resolved_at, resolved_at),
+        )
+    conn.commit()
+    conn.close()
+
+
+@pytest.fixture
+def corpus_factory(tmp_path: Path) -> Callable[..., Path]:
+    """Return a builder: corpus_factory(trades, resolutions, with_platform=True) -> db path."""
+    counter = {"n": 0}
+
+    def make(trades: list[Trade], resolutions: list[Resolution],
+             *, with_platform: bool = True) -> Path:
+        counter["n"] += 1
+        db = tmp_path / f"corpus{counter['n']}.sqlite3"
+        _build(db, trades, resolutions, with_platform=with_platform)
+        return db
+
+    return make
+```
+
+- [ ] **Step 2: Verify it imports cleanly**
+
+Run: `uv run pytest tests/scripts/ -q --co`
+Expected: collection succeeds (no errors), existing tests still listed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/scripts/conftest.py
+git commit -m "test(scripts): shared corpus_factory fixture"
+```
+
+---
+
+## Task 2: `KPolicy` + `resolve_k`
+
+**Files:**
+- Create: `scripts/copy_selection.py`
+- Test: `tests/scripts/test_copy_selection.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+"""Tests for the causal copy-selection precompute."""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.copy_selection import KPolicy, resolve_k
+
+
+def test_resolve_k_fixed_count() -> None:
+    assert resolve_k(KPolicy(top_k=25), bankroll=10_000.0, qualified_count=500) == 25
+
+
+def test_resolve_k_capital_per_wallet_floors() -> None:
+    # 10_000 / 750 = 13.33 -> 13
+    assert resolve_k(KPolicy(capital_per_wallet=750.0), bankroll=10_000.0,
+                     qualified_count=500) == 13
+
+
+def test_resolve_k_top_frac_ceils_against_qualified() -> None:
+    # ceil(0.1 * 95) = 10
+    assert resolve_k(KPolicy(top_frac=0.1), bankroll=10_000.0, qualified_count=95) == 10
+
+
+def test_resolve_k_top_frac_zero_qualified_is_zero() -> None:
+    assert resolve_k(KPolicy(top_frac=0.1), bankroll=10_000.0, qualified_count=0) == 0
+
+
+def test_resolve_k_no_mode_raises() -> None:
+    with pytest.raises(ValueError, match="no mode"):
+        resolve_k(KPolicy(), bankroll=10_000.0, qualified_count=10)
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/scripts/test_copy_selection.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'scripts.copy_selection'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+"""Causal copy-trading wallet selection precompute (DuckDB-backed).
+
+Qualifies wallets at >= min_resolved resolved trades, ranks by causal
+(no-lookahead) edge, freezes a global top-K copy set per rebalance
+boundary, and emits the selected trades + their resolutions as event
+rows for scripts.backtest_copy_sizing's Simulator.
+
+Spec: docs/superpowers/specs/2026-05-30-causal-copy-selection-design.md
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class KPolicy:
+    """Top-K policy for the copy set. Exactly one field is set."""
+
+    top_k: int | None = None
+    capital_per_wallet: float | None = None
+    top_frac: float | None = None
+
+
+def resolve_k(policy: KPolicy, *, bankroll: float, qualified_count: int) -> int:
+    """Return the top-K cut for one rebalance boundary.
+
+    Args:
+        policy: which sizing rule to apply.
+        bankroll: constant starting bankroll (USD).
+        qualified_count: number of qualified wallets at this boundary.
+    """
+    if policy.top_k is not None:
+        return policy.top_k
+    if policy.capital_per_wallet is not None:
+        return max(0, int(bankroll // policy.capital_per_wallet))
+    if policy.top_frac is not None:
+        return math.ceil(policy.top_frac * qualified_count)
+    raise ValueError("KPolicy has no mode set")
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/scripts/test_copy_selection.py -q`
+Expected: PASS (5 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/copy_selection.py tests/scripts/test_copy_selection.py
+git commit -m "feat(copy-selection): KPolicy + resolve_k"
+```
+
+---
+
+## Task 3: `has_platform_column`
+
+**Files:**
+- Modify: `scripts/copy_selection.py`
+- Test: `tests/scripts/test_copy_selection.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+from pathlib import Path
+
+from scripts.copy_selection import has_platform_column
+
+
+def test_has_platform_column_true(corpus_factory) -> None:
+    db: Path = corpus_factory([], [], with_platform=True)
+    assert has_platform_column(db) is True
+
+
+def test_has_platform_column_false(corpus_factory) -> None:
+    db: Path = corpus_factory([], [], with_platform=False)
+    assert has_platform_column(db) is False
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/scripts/test_copy_selection.py -k has_platform -q`
+Expected: FAIL — `ImportError: cannot import name 'has_platform_column'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `scripts/copy_selection.py` (and `import sqlite3` / `from pathlib import Path` at top):
+
+```python
+def has_platform_column(db_path: Path) -> bool:
+    """Return True if corpus_trades carries the multi-platform `platform` column."""
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    cols = [r[1] for r in conn.execute("PRAGMA table_info(corpus_trades)")]
+    conn.close()
+    return "platform" in cols
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/scripts/test_copy_selection.py -k has_platform -q`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/copy_selection.py tests/scripts/test_copy_selection.py
+git commit -m "feat(copy-selection): has_platform_column detection"
+```
+
+---
+
+## Task 4: `_ranked_qualifiers` — per-boundary edge, lifetime (the causal core)
+
+This builds the DuckDB pipeline up to the ranked, qualified, positive-edge wallet list per boundary. It returns rows `(boundary_ts, wallet, edge, n_resolved, rank, n_qualified)` ordered by `(boundary_ts, rank)`.
+
+**Files:**
+- Modify: `scripts/copy_selection.py`
+- Test: `tests/scripts/test_copy_selection.py`
+
+- [ ] **Step 1: Write the failing test (cross-validation vs brute-force Python)**
+
+```python
+from scripts.copy_selection import ranked_qualifiers
+
+
+def _brute_edge(trades, resolutions, boundary_ts, *, min_resolved, window_days):
+    """Reference: causal mean(won - price) per wallet at one boundary."""
+    res = {cid: (yw, rt) for cid, yw, rt in resolutions}
+    per_wallet: dict[str, list[tuple[int, float]]] = {}
+    for w, cid, side, bs, price, _notional, ts in trades:
+        if bs != "BUY" or cid not in res:
+            continue
+        yw, rt = res[cid]
+        if not (ts <= rt and rt < boundary_ts):
+            continue
+        if window_days and rt < boundary_ts - window_days * 86400:
+            continue
+        won = 1.0 if ((yw == 1 and side == "YES") or (yw == 0 and side == "NO")) else 0.0
+        per_wallet.setdefault(w, []).append((rt, won - price))
+    out = {}
+    for w, recs in per_wallet.items():
+        if len(recs) < min_resolved:
+            continue
+        edge = sum(d for _, d in recs) / len(recs)
+        if edge > 0:
+            out[w] = edge
+    return out
+
+
+def test_ranked_qualifiers_matches_bruteforce_lifetime(corpus_factory) -> None:
+    # Two wallets: A strongly positive, B negative. min_resolved=2 for a tiny case.
+    trades = [
+        ("A", "m1", "YES", "BUY", 0.40, 100.0, 10),
+        ("A", "m2", "YES", "BUY", 0.30, 100.0, 20),
+        ("B", "m3", "YES", "BUY", 0.80, 100.0, 15),
+        ("B", "m4", "YES", "BUY", 0.70, 100.0, 25),
+    ]
+    resolutions = [("m1", 1, 100), ("m2", 1, 110), ("m3", 0, 120), ("m4", 0, 130)]
+    boundary = 200
+    rows = ranked_qualifiers(
+        corpus_factory(trades, resolutions),
+        platform="polymarket", min_resolved=2, edge_window_days=0,
+        boundaries=[boundary],
+    )
+    got = {w: edge for (b, w, edge, n, rk, nq) in rows if b == boundary}
+    expected = _brute_edge(trades, resolutions, boundary, min_resolved=2, window_days=0)
+    assert set(got) == set(expected)  # only A qualifies (positive edge); B excluded
+    for w in expected:
+        assert got[w] == pytest.approx(expected[w])
+    # rank is deterministic and 1-based
+    a_row = next(r for r in rows if r[1] == "A")
+    assert a_row[4] == 1
+
+
+def test_ranked_qualifiers_excludes_below_min_resolved(corpus_factory) -> None:
+    trades = [("A", "m1", "YES", "BUY", 0.40, 100.0, 10)]  # only 1 resolved
+    resolutions = [("m1", 1, 100)]
+    rows = ranked_qualifiers(
+        corpus_factory(trades, resolutions),
+        platform="polymarket", min_resolved=2, edge_window_days=0, boundaries=[200],
+    )
+    assert rows == []
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/scripts/test_copy_selection.py -k ranked_qualifiers -q`
+Expected: FAIL — `ImportError: cannot import name 'ranked_qualifiers'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `scripts/copy_selection.py` (and `import duckdb`, `from collections.abc import Sequence` at top):
+
+```python
+def _attach(db_path: Path) -> duckdb.DuckDBPyConnection:
+    con = duckdb.connect(":memory:")
+    con.execute("PRAGMA memory_limit='3GB'")
+    con.execute(f"ATTACH '{db_path}' AS s (TYPE sqlite, READONLY)")
+    return con
+
+
+def _build_rb(con: duckdb.DuckDBPyConnection, *, platform: str, has_platform: bool) -> None:
+    """Materialize the causal resolved-buy fact table `rb`."""
+    tpred = "AND t.platform = ?" if has_platform else ""
+    rpred = "AND r.platform = ?" if has_platform else ""
+    params = ([platform, platform] if has_platform else [])
+    con.execute(
+        f"""
+        CREATE TEMP TABLE rb AS
+        SELECT t.wallet_address AS wallet, t.condition_id AS condition_id,
+               t.price AS price, t.ts AS ts, t.outcome_side AS outcome_side,
+               r.resolved_at AS resolved_at,
+               CASE WHEN (r.outcome_yes_won = 1 AND t.outcome_side = 'YES')
+                      OR (r.outcome_yes_won = 0 AND t.outcome_side = 'NO')
+                    THEN 1 ELSE 0 END AS won
+        FROM s.corpus_trades t
+        JOIN s.market_resolutions r ON r.condition_id = t.condition_id {rpred}
+        WHERE t.bs = 'BUY' AND t.ts <= r.resolved_at {tpred}
+        """,  # noqa: S608 -- predicates are fixed literals; values via ? params
+        params,
+    )
+
+
+def ranked_qualifiers(
+    db_path: Path, *, platform: str, min_resolved: int, edge_window_days: int,
+    boundaries: Sequence[int],
+) -> list[tuple[int, str, float, int, int, int]]:
+    """Return (boundary_ts, wallet, edge, n_resolved, rank, n_qualified) rows.
+
+    Only qualified (>= min_resolved within window) AND positive-edge wallets,
+    ranked per boundary by (edge DESC, wallet ASC). No lookahead: each
+    boundary's edge uses only resolutions with resolved_at < boundary_ts.
+    """
+    if not boundaries:
+        return []
+    has_plat = has_platform_column(db_path)
+    con = _attach(db_path)
+    try:
+        _build_rb(con, platform=platform, has_platform=has_plat)
+        con.execute("CREATE TEMP TABLE bnd(boundary_ts BIGINT)")
+        con.executemany("INSERT INTO bnd VALUES (?)", [(int(b),) for b in boundaries])
+        window_pred = (
+            "" if edge_window_days == 0
+            else "AND rb.resolved_at >= b.boundary_ts - ? * 86400"
+        )
+        params = [] if edge_window_days == 0 else [edge_window_days]
+        rows = con.execute(
+            f"""
+            WITH agg AS (
+              SELECT b.boundary_ts AS boundary_ts, rb.wallet AS wallet,
+                     COUNT(*) AS n_resolved, AVG(rb.won - rb.price) AS edge
+              FROM bnd b
+              JOIN rb ON rb.resolved_at < b.boundary_ts {window_pred}
+              GROUP BY b.boundary_ts, rb.wallet
+              HAVING COUNT(*) >= ? AND AVG(rb.won - rb.price) > 0
+            )
+            SELECT boundary_ts, wallet, edge, n_resolved,
+                   ROW_NUMBER() OVER (PARTITION BY boundary_ts
+                                      ORDER BY edge DESC, wallet ASC) AS rank,
+                   COUNT(*) OVER (PARTITION BY boundary_ts) AS n_qualified
+            FROM agg
+            ORDER BY boundary_ts, rank
+            """,  # noqa: S608 -- window_pred is a fixed literal; values via ? params
+            [*params, min_resolved],
+        ).fetchall()
+    finally:
+        con.close()
+    return [(int(b), str(w), float(e), int(n), int(rk), int(nq))
+            for (b, w, e, n, rk, nq) in rows]
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/scripts/test_copy_selection.py -k ranked_qualifiers -q`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/copy_selection.py tests/scripts/test_copy_selection.py
+git commit -m "feat(copy-selection): ranked per-boundary qualifiers (causal, positive-edge floor)"
+```
+
+---
+
+## Task 5: No-lookahead + rolling-window coverage for `ranked_qualifiers`
+
+**Files:**
+- Modify: `tests/scripts/test_copy_selection.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+def test_ranked_qualifiers_no_lookahead(corpus_factory) -> None:
+    # A's trades resolve at 250/260, AFTER boundary 200 -> A not qualified at 200.
+    trades = [
+        ("A", "m1", "YES", "BUY", 0.40, 100.0, 10),
+        ("A", "m2", "YES", "BUY", 0.30, 100.0, 20),
+    ]
+    resolutions = [("m1", 1, 250), ("m2", 1, 260)]
+    rows = ranked_qualifiers(
+        corpus_factory(trades, resolutions),
+        platform="polymarket", min_resolved=2, edge_window_days=0, boundaries=[200],
+    )
+    assert rows == []  # no resolutions before the boundary
+
+
+def test_ranked_qualifiers_rolling_window_drops_old_trades(corpus_factory) -> None:
+    # window=1 day: at boundary 200 (ts), only trades resolved within [200-86400, 200).
+    # Put 2 old resolutions far in the past and 1 recent -> under min_resolved=2 in window.
+    day = 86400
+    trades = [
+        ("A", "m1", "YES", "BUY", 0.40, 100.0, 1),
+        ("A", "m2", "YES", "BUY", 0.40, 100.0, 2),
+        ("A", "m3", "YES", "BUY", 0.40, 100.0, 3),
+    ]
+    boundary = 10 * day
+    resolutions = [("m1", 1, 1 * day), ("m2", 1, 2 * day), ("m3", 1, boundary - 100)]
+    rows = ranked_qualifiers(
+        corpus_factory(trades, resolutions),
+        platform="polymarket", min_resolved=2, edge_window_days=1, boundaries=[boundary],
+    )
+    assert rows == []  # only 1 trade inside the 1-day window -> below min_resolved
+```
+
+- [ ] **Step 2: Run to verify failure first, then pass**
+
+Run: `uv run pytest tests/scripts/test_copy_selection.py -k "no_lookahead or rolling_window" -q`
+Expected: PASS (these exercise already-implemented logic; if either fails, the bug is in Task 4's SQL — fix there, do not weaken the test).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/scripts/test_copy_selection.py
+git commit -m "test(copy-selection): no-lookahead + rolling-window qualifier coverage"
+```
+
+---
+
+## Task 6: `iter_selected_rows` — copy-set freeze → selected event stream
+
+Applies `resolve_k` per boundary to `ranked_qualifiers`, builds the frozen copy set, and yields event rows (trades + their resolutions) ordered by ts.
+
+**Files:**
+- Modify: `scripts/copy_selection.py`
+- Test: `tests/scripts/test_copy_selection.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+from scripts.copy_selection import iter_selected_rows
+
+
+def test_iter_selected_rows_only_copies_top_k_in_frozen_period(corpus_factory) -> None:
+    # Boundaries every 100s from ts=0. A & B both qualify positive by boundary 100;
+    # A has higher edge. top_k=1 -> only A copied. Each makes a NEW trade in [100,200).
+    trades = [
+        # qualifying history (resolves before boundary 100)
+        ("A", "h1", "YES", "BUY", 0.30, 100.0, 1),
+        ("A", "h2", "YES", "BUY", 0.30, 100.0, 2),
+        ("B", "h3", "YES", "BUY", 0.45, 100.0, 1),
+        ("B", "h4", "YES", "BUY", 0.45, 100.0, 2),
+        # new trades inside period [100,200)
+        ("A", "n1", "YES", "BUY", 0.50, 100.0, 150),
+        ("B", "n2", "YES", "BUY", 0.50, 100.0, 160),
+    ]
+    resolutions = [
+        ("h1", 1, 50), ("h2", 1, 60), ("h3", 1, 50), ("h4", 1, 60),
+        ("n1", 1, 300), ("n2", 1, 300),
+    ]
+    rows = list(iter_selected_rows(
+        corpus_factory(trades, resolutions),
+        platform="polymarket", min_resolved=2, edge_window_days=0,
+        rebalance_days=None, rebalance_seconds=100, policy=KPolicy(top_k=1),
+        bankroll=10_000.0, start_ts=None, end_ts=None,
+    ))
+    trade_rows = [r for r in rows if r[0] == "trade"]
+    copied_new = {r[2] for r in trade_rows if r[3] in ("n1", "n2")}
+    assert copied_new == {"A"}  # only top-1 wallet A copied; B excluded
+    # resolutions for copied markets are present and stream is ts-ordered
+    assert any(r[0] == "resolution" and r[3] == "n1" for r in rows)
+    assert [r[1] for r in rows] == sorted(r[1] for r in rows)
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/scripts/test_copy_selection.py -k iter_selected -q`
+Expected: FAIL — `ImportError: cannot import name 'iter_selected_rows'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `scripts/copy_selection.py` (add `from collections.abc import Iterator` at top):
+
+```python
+def _make_boundaries(con: duckdb.DuckDBPyConnection, *, period: int,
+                     start_ts: int | None, end_ts: int | None) -> list[int]:
+    """Boundary grid spanning the trade ts range (or the provided window), step=period."""
+    lo, hi = con.execute("SELECT MIN(ts), MAX(ts) FROM rb").fetchone()
+    if lo is None:
+        return []
+    lo = start_ts if start_ts is not None else int(lo)
+    hi = end_ts if end_ts is not None else int(hi)
+    return list(range(lo, hi + 1, period))
+
+
+def iter_selected_rows(
+    db_path: Path, *, platform: str, min_resolved: int, edge_window_days: int,
+    rebalance_days: int | None, policy: KPolicy, bankroll: float,
+    start_ts: int | None, end_ts: int | None, rebalance_seconds: int | None = None,
+) -> Iterator[tuple]:
+    """Yield (kind, ts, wallet, condition_id, outcome_side, price, notional_usd,
+    outcome_yes_won) rows for the causally-selected copy stream, ts-ordered.
+
+    rebalance_seconds overrides rebalance_days (tests use small windows).
+    """
+    period = rebalance_seconds if rebalance_seconds is not None else rebalance_days * 86400
+    has_plat = has_platform_column(db_path)
+    con = _attach(db_path)
+    try:
+        _build_rb(con, platform=platform, has_platform=has_plat)
+        boundaries = _make_boundaries(con, period=period, start_ts=start_ts, end_ts=end_ts)
+        if not boundaries:
+            return
+        con.close()  # ranked_qualifiers reopens its own connection
+        con = None
+        ranked = ranked_qualifiers(
+            db_path, platform=platform, min_resolved=min_resolved,
+            edge_window_days=edge_window_days, boundaries=boundaries,
+        )
+        # apply per-boundary K cut
+        n_qual_by_b: dict[int, int] = {}
+        for b, _w, _e, _n, _rk, nq in ranked:
+            n_qual_by_b[b] = nq
+        copyset: list[tuple[int, str]] = []
+        for b, w, _e, _n, rk, _nq in ranked:
+            k = resolve_k(policy, bankroll=bankroll, qualified_count=n_qual_by_b[b])
+            if rk <= k:
+                copyset.append((b, w))
+        if not copyset:
+            return
+        yield from _stream_selected(
+            db_path, platform=platform, has_platform=has_plat, period=period,
+            copyset=copyset,
+        )
+    finally:
+        if con is not None:
+            con.close()
+
+
+def _stream_selected(
+    db_path: Path, *, platform: str, has_platform: bool, period: int,
+    copyset: list[tuple[int, str]],
+) -> Iterator[tuple]:
+    tpred = "AND t.platform = ?" if has_platform else ""
+    rpred = "AND r.platform = ?" if has_platform else ""
+    tparams = [platform] if has_platform else []
+    rparams = [platform] if has_platform else []
+    con = _attach(db_path)
+    try:
+        con.execute("CREATE TEMP TABLE copyset(boundary_ts BIGINT, wallet VARCHAR)")
+        con.executemany("INSERT INTO copyset VALUES (?, ?)", copyset)
+        query = f"""
+            WITH selected AS (
+              SELECT t.wallet_address AS wallet, t.condition_id AS condition_id,
+                     t.outcome_side AS outcome_side, t.price AS price,
+                     t.notional_usd AS notional_usd, t.ts AS ts
+              FROM s.corpus_trades t
+              JOIN copyset cs ON cs.wallet = t.wallet_address
+                AND t.ts >= cs.boundary_ts AND t.ts < cs.boundary_ts + {period}
+              WHERE t.bs = 'BUY' {tpred}
+            ),
+            sel_res AS (
+              SELECT r.condition_id AS condition_id, r.outcome_yes_won AS outcome_yes_won,
+                     r.resolved_at AS ts
+              FROM s.market_resolutions r
+              WHERE r.condition_id IN (SELECT DISTINCT condition_id FROM selected) {rpred}
+            )
+            SELECT 'trade' AS kind, ts, wallet, condition_id, outcome_side,
+                   price, notional_usd, NULL AS outcome_yes_won FROM selected
+            UNION ALL
+            SELECT 'resolution' AS kind, ts, NULL, condition_id, NULL,
+                   NULL, NULL, outcome_yes_won FROM sel_res
+            ORDER BY ts ASC
+        """  # noqa: S608 -- period/predicates are fixed literals; values via ? params
+        cur = con.execute(query, [*tparams, *rparams])
+        while True:
+            batch = cur.fetchmany(100_000)
+            if not batch:
+                break
+            yield from batch
+    finally:
+        con.close()
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/scripts/test_copy_selection.py -k iter_selected -q`
+Expected: PASS (1 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/copy_selection.py tests/scripts/test_copy_selection.py
+git commit -m "feat(copy-selection): iter_selected_rows freeze + selected stream"
+```
+
+---
+
+## Task 7: Edge-case coverage for `iter_selected_rows`
+
+**Files:**
+- Modify: `tests/scripts/test_copy_selection.py`
+
+- [ ] **Step 1: Write the tests**
+
+```python
+def test_iter_selected_rows_empty_universe(corpus_factory) -> None:
+    rows = list(iter_selected_rows(
+        corpus_factory([], []), platform="polymarket", min_resolved=20,
+        edge_window_days=0, rebalance_days=None, rebalance_seconds=100,
+        policy=KPolicy(top_k=5), bankroll=10_000.0, start_ts=None, end_ts=None,
+    ))
+    assert rows == []
+
+
+def test_iter_selected_rows_k_larger_than_qualified(corpus_factory) -> None:
+    trades = [
+        ("A", "h1", "YES", "BUY", 0.30, 100.0, 1),
+        ("A", "h2", "YES", "BUY", 0.30, 100.0, 2),
+        ("A", "n1", "YES", "BUY", 0.50, 100.0, 150),
+    ]
+    resolutions = [("h1", 1, 50), ("h2", 1, 60), ("n1", 1, 300)]
+    rows = list(iter_selected_rows(
+        corpus_factory(trades, resolutions), platform="polymarket", min_resolved=2,
+        edge_window_days=0, rebalance_days=None, rebalance_seconds=100,
+        policy=KPolicy(top_k=50), bankroll=10_000.0, start_ts=None, end_ts=None,
+    ))
+    copied = {r[2] for r in rows if r[0] == "trade" and r[3] == "n1"}
+    assert copied == {"A"}  # only 1 qualifies; K=50 just takes all qualified
+
+
+def test_iter_selected_rows_no_platform_corpus(corpus_factory) -> None:
+    trades = [
+        ("A", "h1", "YES", "BUY", 0.30, 100.0, 1),
+        ("A", "h2", "YES", "BUY", 0.30, 100.0, 2),
+        ("A", "n1", "YES", "BUY", 0.50, 100.0, 150),
+    ]
+    resolutions = [("h1", 1, 50), ("h2", 1, 60), ("n1", 1, 300)]
+    rows = list(iter_selected_rows(
+        corpus_factory(trades, resolutions, with_platform=False),
+        platform="polymarket", min_resolved=2, edge_window_days=0,
+        rebalance_days=None, rebalance_seconds=100, policy=KPolicy(top_k=5),
+        bankroll=10_000.0, start_ts=None, end_ts=None,
+    ))
+    assert any(r[0] == "trade" and r[3] == "n1" for r in rows)
+```
+
+- [ ] **Step 2: Run to verify pass**
+
+Run: `uv run pytest tests/scripts/test_copy_selection.py -q`
+Expected: PASS (all copy_selection tests green).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/scripts/test_copy_selection.py
+git commit -m "test(copy-selection): empty universe, K>qualified, no-platform corpus"
+```
+
+---
+
+## Task 8: Refactor `backtest_copy_sizing` row→event into a shared helper
+
+Avoids duplicating row→event construction between the watchlist and causal paths.
+
+**Files:**
+- Modify: `scripts/backtest_copy_sizing.py` (the `load_event_stream` body, ~lines 398-421)
+
+- [ ] **Step 1: Add the shared helper and call it from `load_event_stream`**
+
+Add this module-level function (place it just above `load_event_stream`):
+
+```python
+def _rows_to_events(rows: Iterable[tuple]) -> Iterator[TradeEvent | ResolutionEvent]:
+    """Convert event-row tuples into TradeEvent / ResolutionEvent objects.
+
+    Row shape: (kind, ts, wallet, condition_id, outcome_side, price,
+    notional_usd, outcome_yes_won).
+    """
+    for kind, ts, wallet, cid, side, price, notional, yes_won in rows:
+        if kind == "trade":
+            yield TradeEvent(
+                kind="trade", ts=int(ts),
+                trade=Trade(wallet=str(wallet), condition_id=str(cid),
+                            outcome_side=str(side), price=float(price),
+                            notional_usd=float(notional), ts=int(ts)),
+            )
+        else:
+            yield ResolutionEvent(
+                kind="resolution", ts=int(ts),
+                resolution=Resolution(condition_id=str(cid),
+                                      winning_side="YES" if int(yes_won) == 1 else "NO",
+                                      resolved_at=int(ts)),
+            )
+```
+
+Then replace the trailing `for kind, ts, ... yield ...` loop at the end of `load_event_stream` with:
+
+```python
+    rows = con.execute(query, [platform, *params, platform]).fetchall()
+    con.close()
+    yield from _rows_to_events(rows)
+```
+
+Add `Iterable` to the existing `from collections.abc import Iterator, Sequence` import → `from collections.abc import Iterable, Iterator, Sequence`.
+
+- [ ] **Step 2: Run existing stream tests to verify no behavior change**
+
+Run: `uv run pytest tests/scripts/test_backtest_simulator.py -k load_event_stream -q`
+Expected: PASS (all existing `load_event_stream` tests still green).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/backtest_copy_sizing.py
+git commit -m "refactor(backtest): extract _rows_to_events shared helper"
+```
+
+---
+
+## Task 9: Add `--causal-select` + selection flags to the parser
+
+**Files:**
+- Modify: `scripts/backtest_copy_sizing.py` (`build_parser`)
+- Test: `tests/scripts/test_backtest_simulator.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+def test_build_parser_causal_select_defaults() -> None:
+    args = build_parser().parse_args(["--causal-select"])
+    assert args.causal_select is True
+    assert args.min_resolved == 20
+    assert args.edge_window == 0
+    assert args.rebalance_days == 14
+    assert args.copy_top_k is None
+    assert args.copy_capital_per_wallet is None
+    assert args.copy_top_frac is None
+
+
+def test_build_parser_causal_off_by_default() -> None:
+    args = build_parser().parse_args([])
+    assert args.causal_select is False
+
+
+def test_build_parser_rejects_two_copy_policies() -> None:
+    with pytest.raises(SystemExit):
+        build_parser().parse_args(["--copy-top-k", "10", "--copy-top-frac", "0.1"])
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/scripts/test_backtest_simulator.py -k "causal or copy_polic" -q`
+Expected: FAIL — `AttributeError: 'Namespace' object has no attribute 'causal_select'`.
+
+- [ ] **Step 3: Add the flags in `build_parser`** (just before the `--csv` argument)
+
+```python
+    p.add_argument("--causal-select", action="store_true",
+                   help="Causally qualify+rank+select wallets from the corpus"
+                        " (ignores --watchlist-db).")
+    p.add_argument("--min-resolved", type=int, default=20,
+                   help="Qualification: min resolved trades within the edge window.")
+    p.add_argument("--edge-window", type=int, default=0,
+                   help="Rolling edge window in days; 0 = lifetime.")
+    p.add_argument("--rebalance-days", type=int, default=14,
+                   help="Days between top-K copy-set recomputes.")
+    copy_policy = p.add_mutually_exclusive_group()
+    copy_policy.add_argument("--copy-top-k", type=int, default=None,
+                             help="Copy the top N wallets by causal edge.")
+    copy_policy.add_argument("--copy-capital-per-wallet", type=float, default=None,
+                             help="K = floor(bankroll / C).")
+    copy_policy.add_argument("--copy-top-frac", type=float, default=None,
+                             help="Copy the top X fraction of qualified wallets.")
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/scripts/test_backtest_simulator.py -k "causal or copy_polic" -q`
+Expected: PASS (3 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/backtest_copy_sizing.py tests/scripts/test_backtest_simulator.py
+git commit -m "feat(backtest): --causal-select + selection flags"
+```
+
+---
+
+## Task 10: Wire the causal stream into `main` + report selection summary
+
+**Files:**
+- Modify: `scripts/backtest_copy_sizing.py` (`main`, `render_report`/header, add `_resolve_policy`)
+- Test: `tests/scripts/test_backtest_simulator.py`
+
+- [ ] **Step 1: Write the failing integration test**
+
+```python
+def test_main_causal_select_end_to_end(corpus_factory, capsys) -> None:
+    # A qualifies positive and is copied; B never positive -> never copied.
+    trades = [
+        ("A", "h1", "YES", "BUY", 0.30, 100.0, 1),
+        ("A", "h2", "YES", "BUY", 0.30, 100.0, 2),
+        ("B", "h3", "YES", "BUY", 0.90, 100.0, 1),
+        ("B", "h4", "YES", "BUY", 0.90, 100.0, 2),
+        ("A", "n1", "YES", "BUY", 0.50, 100.0, 150),
+        ("B", "n2", "YES", "BUY", 0.50, 100.0, 160),
+    ]
+    resolutions = [
+        ("h1", 1, 50), ("h2", 1, 60), ("h3", 0, 50), ("h4", 0, 60),
+        ("n1", 1, 300), ("n2", 1, 300),
+    ]
+    db = corpus_factory(trades, resolutions)
+    rc = main([
+        "--db", str(db), "--causal-select", "--min-resolved", "2",
+        "--rebalance-days", "1", "--copy-top-k", "5",
+    ])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Causal selection" in out
+    assert "equal_weight" in out
+```
+
+(Note: `--rebalance-days 1` → 86400s period; the test's ts values fall in the first
+period since they are < 86400.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/scripts/test_backtest_simulator.py -k causal_select_end_to_end -q`
+Expected: FAIL — `--causal-select` is parsed but `main` ignores it / no "Causal selection" header.
+
+- [ ] **Step 3: Implement the branch + summary**
+
+Add the import at the top of `backtest_copy_sizing.py`: `from scripts import copy_selection`.
+
+Add a policy resolver just above `main` (defaults to top-k 25 so causal mode always has a
+policy; `ConcentrationCapped`'s anti-concentration target uses the copy-set size as the
+watchlist-size proxy, computed as `wl_size` below):
+
+```python
+def _resolve_policy(args: argparse.Namespace) -> copy_selection.KPolicy:
+    """Build the KPolicy from CLI args, defaulting to top-k 25."""
+    if args.copy_capital_per_wallet is not None:
+        return copy_selection.KPolicy(capital_per_wallet=args.copy_capital_per_wallet)
+    if args.copy_top_frac is not None:
+        return copy_selection.KPolicy(top_frac=args.copy_top_frac)
+    return copy_selection.KPolicy(top_k=args.copy_top_k if args.copy_top_k is not None else 25)
+```
+
+Then replace the body of `main` (everything after `args = build_parser().parse_args(argv)`)
+with this single concrete block, which decides the mode, builds the schemes, runs the walk,
+and prints the report:
+
+```python
+    if args.causal_select:
+        wl_size = args.copy_top_k or 25
+    else:
+        watchlist = load_watchlist(Path(args.watchlist_db))
+        if not watchlist:
+            print("Watchlist is empty; nothing to backtest.", file=sys.stderr)
+            return 1
+        wl_size = len(watchlist)
+    schemes = _build_schemes(args, wl_size)
+    max_exposure = args.max_open_exposure_usd
+    if args.max_open_exposure_frac is not None:
+        max_exposure = args.max_open_exposure_frac * args.starting_bankroll_usd
+    sim = Simulator(schemes=schemes, bankroll=args.starting_bankroll_usd,
+                    enforce_capacity=args.enforce_capacity,
+                    max_open_exposure_usd=max_exposure)
+    if args.causal_select:
+        policy = _resolve_policy(args)
+        events = _rows_to_events(copy_selection.iter_selected_rows(
+            Path(args.db), platform=args.platform, min_resolved=args.min_resolved,
+            edge_window_days=args.edge_window, rebalance_days=args.rebalance_days,
+            policy=policy, bankroll=args.starting_bankroll_usd,
+            start_ts=args.start_ts, end_ts=args.end_ts))
+        selection_header = (
+            f"Causal selection: min_resolved={args.min_resolved}, "
+            f"edge_window={args.edge_window}d, rebalance_days={args.rebalance_days}, "
+            f"policy={policy}\n")
+    else:
+        events = load_event_stream(Path(args.db), watchlist=watchlist,
+                                   platform=args.platform, start_ts=args.start_ts,
+                                   end_ts=args.end_ts)
+        selection_header = ""
+    for event in events:
+        if isinstance(event, TradeEvent):
+            sim.on_trade(event.trade)
+        else:
+            sim.on_resolution(event.resolution)
+    print(selection_header + render_report(
+        sim, schemes=schemes, bankroll=args.starting_bankroll_usd,
+        enforce_capacity=args.enforce_capacity, max_open_exposure_usd=max_exposure))
+    if args.csv:
+        _write_csv(sim, schemes, args.csv)
+    return 0
+```
+
+Remove the now-duplicated original `watchlist = load_watchlist(...)` / loop / print block.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/scripts/test_backtest_simulator.py -k causal_select_end_to_end -q`
+Expected: PASS (1 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/backtest_copy_sizing.py tests/scripts/test_backtest_simulator.py
+git commit -m "feat(backtest): wire causal-select stream into main + selection header"
+```
+
+---
+
+## Task 11: Full gate — lint, format, type-check, whole suite
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the project gate on the changed files**
+
+Run:
+```bash
+uv run ruff check scripts/copy_selection.py scripts/backtest_copy_sizing.py tests/scripts/
+uv run ruff format --check scripts/copy_selection.py scripts/backtest_copy_sizing.py tests/scripts/
+uv run ty check scripts/copy_selection.py scripts/backtest_copy_sizing.py
+uv run pytest tests/scripts/ -q
+```
+Expected: ruff clean, format clean, ty "All checks passed!", all tests pass.
+
+- [ ] **Step 2: Fix any findings**
+
+Fix lint/format/type issues inline (e.g. add `# noqa: S608` justifications already present; ensure `Iterable` import added in Task 8). Re-run until clean. Do not weaken tests to pass.
+
+- [ ] **Step 3: Commit any fixes**
+
+```bash
+git add -A
+git commit -m "chore(copy-selection): satisfy ruff/ty gate"
+```
+
+---
+
+## Task 12: Smoke against the real desktop corpus (manual, operator step)
+
+**Files:** none (operator validation; not a unit test)
+
+- [ ] **Step 1: Run a small causal backtest on the desktop corpus**
+
+From the laptop (the desktop has the 69 GB corpus + the merged branch — pull this branch there first):
+```bash
+ssh -p 2222 macph@10.0.0.143 \
+  'cd ~/projects/polymarketscanner/pscanner && export PATH="$HOME/.local/bin:$PATH" && \
+   uv run python scripts/backtest_copy_sizing.py --db data/corpus.sqlite3 \
+     --causal-select --min-resolved 20 --edge-window 0 --rebalance-days 14 \
+     --copy-top-k 25 --enforce-capacity --max-open-exposure-frac 1 \
+     > /tmp/causal_backtest.txt 2>&1; echo exit=$?'
+```
+Expected: completes in ~3–5 min, exit=0, report prints with the "Causal selection" header and a much lower "Skipped" count than the 1,790-wallet runs.
+
+- [ ] **Step 2: Sanity-check the output**
+
+Confirm: trade counts are non-zero, win rate is plausible (not 100%), and the headline ROI is far more conservative than the in-sample 1,790-wallet run. Record numbers for comparison.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** universe pre-filter (Task 4 `_build_rb` + min_resolved) ✓; causal edge lifetime (Task 4) ✓ / rolling (Task 5) ✓; qualification-within-window (Tasks 4-5) ✓; positive-edge floor (Task 4 `HAVING ... > 0`) ✓; top-K freeze + three policies (Tasks 2, 6) ✓; deterministic tiebreak (Task 4 `ORDER BY edge DESC, wallet ASC`) ✓; freeze-on-trade-ts (Task 6 `_stream_selected` join) ✓; no-lookahead two guards (Task 4 `t.ts <= r.resolved_at` + `rb.resolved_at < boundary_ts`) ✓; platform detection both paths (Task 3 + Task 8 reused) ✓; CLI surface (Task 9) ✓; report header (Task 10) ✓; perf tactics — read-only attach, memory_limit, fetchmany (Tasks 4, 6) ✓; testing incl. cross-validation (Task 4) ✓.
+- **Deviation noted:** the per-boundary K cut is applied in Python (`resolve_k`) rather than SQL, for testability — the heavy edge/qualification stays in DuckDB, faithful to the design's intent. The "Not selected" per-scheme counter from the spec is realized instead as the selection header + the (already-present) capacity `Skipped` column, because non-selected trades never enter Python in the DuckDB-first design — so a per-scheme not-selected count isn't meaningful; the header conveys the selector's filtering.
+- **Type consistency:** row tuple shape `(kind, ts, wallet, condition_id, outcome_side, price, notional_usd, outcome_yes_won)` is identical in `copy_selection._stream_selected`, `backtest_copy_sizing._rows_to_events`, and `load_event_stream`. `KPolicy` fields (`top_k`, `capital_per_wallet`, `top_frac`) match across `resolve_k`, `_resolve_policy`, and the parser flags.

--- a/docs/superpowers/specs/2026-05-30-causal-copy-selection-design.md
+++ b/docs/superpowers/specs/2026-05-30-causal-copy-selection-design.md
@@ -1,0 +1,239 @@
+# Causal wallet selection for the copy-trading backtest
+
+Date: 2026-05-30
+Status: Design — pending implementation plan
+Related: `scripts/backtest_copy_sizing.py` (#203, #204), `scripts/wallet_edge_leaderboard.py`,
+`docs/superpowers/specs/2026-05-28-backtest-copy-sizing-design.md`
+
+## Problem
+
+The current `backtest_copy_sizing.py` backtests a **fixed watchlist** of wallets. The
+2026-05-30 run loaded the 1,790 wallets surfaced by `wallet_edge_leaderboard.py` and
+copied each from its **first** trade. Two flaws make those results un-deployable:
+
+1. **In-sample / circular.** The wallets were selected by their *full-corpus* edge, then
+   copied over that same corpus. The headline +30–49% ROI is a restatement of "we picked
+   the winners," not a forward-looking estimate.
+2. **Copy-from-trade-1.** At a wallet's first trade its edge is unknown, yet every sizing
+   scheme copied it immediately. Combined with the capacity gates (#204), >97% of signals
+   were skipped because 1,790 wallets out-signal a $10K bankroll by a wide margin.
+
+This design adds a **causal qualify → rank → select** layer so the backtest resembles live
+performance: a wallet is only copied after it has proven an edge over its *own past*
+trades, and only the current best wallets are copied, sized to what the bankroll can fund.
+
+## Goals
+
+- Decide *causally* (no lookahead) which wallets to copy at each point in time.
+- Never copy a wallet before it has `min_resolved` resolved trades (applies to all four
+  sizing schemes uniformly).
+- Copy only the globally top-K wallets by causal edge, with K tunable, re-evaluated on a
+  cadence. Positive causal edge is a hard floor.
+- Keep the four sizing schemes and the #204 capacity gates unchanged underneath.
+- Run in minutes / sub-GB on the 18.8M-row corpus.
+
+## Non-goals
+
+- No change to the daemon's live trader (its constant-bankroll design is intentional).
+- No selling / mid-position exits — positions are held to resolution, as today.
+- No NAV-driven sizing (bankroll stays constant; out of scope per #204).
+- The existing watchlist mode is retained, not replaced — it answers a different question
+  ("backtest this specific set"). The new mode is additive, gated behind `--causal-select`.
+
+## Architecture: three-layer copy pipeline
+
+```
+corpus (all wallets with >=20 lifetime resolved BUY trades)
+        │
+        ▼
+┌──────────────────────────────┐
+│ 1. Selection  (DuckDB)       │  WHO to copy
+│    qualify -> rank -> freeze  │  → a (boundary_ts, wallet) copy-set table
+└──────────────┬───────────────┘
+               │ selected trades + their resolutions, ts-ordered
+               ▼
+┌──────────────────────────────┐
+│ 2. SizingScheme  (Python)    │  HOW MUCH  (4 schemes, unchanged)
+└──────────────┬───────────────┘
+               ▼
+┌──────────────────────────────┐
+│ 3. CapacityGate  (Python)    │  CAN we afford it  (#204, unchanged)
+└──────────────────────────────┘
+```
+
+The selector is **scheme-independent** (a wallet's edge is a property of its own trades),
+so one selection feeds all four schemes identically. Idea #1 ("don't copy from trade 1")
+is enforced once, in layer 1, for every scheme.
+
+## Layer 1 — DuckDB selection precompute
+
+All of qualification, edge, ranking, and the top-K freeze are window/aggregate SQL. Python
+never holds per-wallet history or an all-wallet pending book. Measured against the corpus:
+universe build + per-boundary edge (lifetime) ~36s, rolling-window ~11s, copy-set →
+**~146K selected trades** (a ~100× reduction from 15.5M resolved-buys).
+
+### 1a. Resolved-buy fact table (causal)
+
+```sql
+CREATE TABLE rb AS
+SELECT t.wallet_address AS wallet, t.condition_id, t.price, t.ts,
+       t.outcome_side, r.resolved_at,
+       CASE WHEN (r.outcome_yes_won = 1 AND t.outcome_side = 'YES')
+              OR (r.outcome_yes_won = 0 AND t.outcome_side = 'NO')
+            THEN 1 ELSE 0 END AS won
+FROM s.corpus_trades t
+JOIN s.market_resolutions r ON r.condition_id = t.condition_id
+WHERE t.bs = 'BUY' AND t.ts <= r.resolved_at;   -- no-lookahead guard #1
+```
+
+Universe = wallets with `COUNT(*) >= min_resolved` rows in `rb` (lifetime). This is a
+count filter (not outcome-based) and a necessary condition for qualifying under any window,
+so it never drops a wallet that could later qualify.
+
+### 1b. Per-boundary edge + qualification + positive-edge floor
+
+```sql
+CREATE TABLE rebalance AS
+  SELECT range AS boundary_ts FROM range(:lo, :hi, :rebalance_days * 86400);
+
+CREATE TABLE wallet_edge_at_boundary AS
+SELECT b.boundary_ts, rb.wallet,
+       COUNT(*)               AS n_resolved,
+       AVG(rb.won - rb.price) AS edge
+FROM rebalance b
+JOIN rb
+  ON rb.resolved_at < b.boundary_ts                                  -- no-lookahead guard #2
+ AND (:edge_window = 0
+      OR rb.resolved_at >= b.boundary_ts - :edge_window * 86400)     -- rolling window
+GROUP BY b.boundary_ts, rb.wallet
+HAVING COUNT(*) >= :min_resolved                                     -- qualification
+   AND AVG(rb.won - rb.price) > 0;                                   -- positive-edge floor
+```
+
+The `edge_window` rolling variant is a double-bounded range join (no per-wallet history
+needed). Qualification (`COUNT >= min_resolved`) is measured **within the same window** as
+the edge, so a wallet is never ranked on fewer than `min_resolved` samples, and a wallet
+with 19 recent + 50 old trades does not qualify under a rolling window.
+
+### 1c. Top-K freeze
+
+```sql
+CREATE TABLE copyset AS
+SELECT boundary_ts, wallet FROM (
+  SELECT boundary_ts, wallet, edge, n_resolved,
+         ROW_NUMBER() OVER (PARTITION BY boundary_ts
+                            ORDER BY edge DESC, wallet ASC) AS rk   -- deterministic tiebreak
+  FROM wallet_edge_at_boundary)
+WHERE rk <= :k_for_boundary;
+```
+
+`k_for_boundary` per policy (mutually exclusive; bankroll is constant, so all three are
+SQL-expressible):
+- `--copy-top-k N`        → `k = N`
+- `--copy-capital-per-wallet C` → `k = floor(bankroll / C)`
+- `--copy-top-frac X`     → `k = ceil(X * count(qualified at that boundary))`
+
+Because of the positive-edge floor, **positive edge is a hard floor and K is an upper
+bound**: if fewer than K wallets have positive causal edge at a boundary, only those are
+copied — never a negative-edge wallet to fill a quota.
+
+### 1d. Selected-trade stream (the only rows Python sees)
+
+```sql
+SELECT t.*
+FROM s.corpus_trades t
+JOIN copyset cs
+  ON cs.wallet = t.wallet_address
+ AND t.ts >= cs.boundary_ts
+ AND t.ts <  cs.boundary_ts + :rebalance_days * 86400     -- this period's frozen set
+WHERE t.bs = 'BUY'
+ORDER BY t.ts;
+```
+
+Freeze membership gates on **trade ts**, not resolution time: a wallet in period B's set is
+copied for *all* its trades in `[B, B+N)`, including ones on markets resolving before
+`B+N`. Resolutions for these markets are unioned into the stream (as today) so the Simulator
+can close positions.
+
+## Layer 2/3 — what stays in Python (unchanged)
+
+The `Simulator` event-walk over the selected stream, the four `SizingScheme`s, and the #204
+capacity gates (`_can_open`, `open_cost`, `skipped_trades`, `cumulative_pnl`) are inherently
+sequential and stay exactly as they are. The new mode only changes *which* events enter the
+walk and adds a "not selected" accounting at the report layer.
+
+## Correctness guards
+
+1. **No lookahead (load-bearing, two guards):** `t.ts <= r.resolved_at` when building `rb`,
+   **and** `rb.resolved_at < boundary_ts` when computing each boundary's edge. Both required.
+2. **Positive-edge floor is causal:** the `> 0` test is on the per-boundary causal edge, not
+   a lifetime/final edge — a hot-then-cold wallet is still copied during its positive periods.
+3. **Freeze semantics:** selection membership keys on trade ts and the period's `boundary_ts`,
+   never on `resolved_at`.
+4. **Deterministic tiebreak:** `ORDER BY edge DESC, wallet ASC` so runs reproduce.
+5. **Platform-column portability:** the corpus may or may not carry a `platform` column
+   (the laptop's 24.6 GB corpus does not; the desktop's 69 GB does). The new mode detects it
+   the way `wallet_edge_leaderboard.py` does (`_has_platform_column`) and conditionally drops
+   the `platform = ?` predicate, rather than hardcoding it.
+
+## CLI surface
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--causal-select` | off | activate qualify→rank→freeze; ignores `--watchlist-db` |
+| `--min-resolved` | 20 | qualification threshold (resolved trades within the edge window) |
+| `--edge-window` | 0 | rolling edge window in days; `0` = lifetime |
+| `--rebalance-days` | 14 | cadence for recomputing/freezing the top-K set |
+| `--copy-top-k` | 25 (default policy) | copy-set policy: fixed N wallets |
+| `--copy-capital-per-wallet` | — | copy-set policy: K = floor(bankroll / C) |
+| `--copy-top-frac` | — | copy-set policy: top X% of qualified |
+
+The three `--copy-*` flags are a mutually-exclusive group; if none is given with
+`--causal-select`, default to `--copy-top-k 25`. All existing flags (`--enforce-capacity`,
+`--max-open-exposure-usd/-frac`, scheme params, `--start-ts/--end-ts`, `--csv`, `--db`)
+compose unchanged.
+
+## Report additions
+
+- A header block: universe size, # rebalances, K policy/value, `edge_window`, `rebalance_days`,
+  and the qualified-wallet count range across boundaries.
+- A new **"Not selected"** counter per scheme in the Headline table, distinct from the
+  capacity **"Skipped"** counter, so the selector's filtering is visible separately from the
+  capacity gate's.
+- Headline / Risk / Quarterly / Top-contributors tables work as-is on the booked subset.
+
+## Performance
+
+DuckDB holds the heavy intermediates; Python gets a ~146K-row sorted result set.
+- Read-only attach: `ATTACH '...' AS s (TYPE sqlite, READONLY)`.
+- `memory_limit='3GB'`, `temp_directory='data/duckdb_spill'`.
+- Stream the selected trades with `fetchmany(100_000)` (never `fetchall` of the raw stream).
+- `__slots__` on `OpenPos` / `BacktestState` for free per-object savings.
+- Materialize `rb` once and reuse across boundary queries.
+- Expected end-to-end: **~3–4 min wall, <500 MB Python RSS** on the 18.8M-row corpus.
+
+## Testing (TDD, `tests/scripts/`)
+
+Tiny synthetic corpus DBs via the existing `_make_corpus_db` helper, hand-computed expecteds.
+
+- **No-lookahead (highest value):** a wallet whose strong trades resolve *after* boundary B
+  is not qualified/ranked on them at B.
+- **Cross-validation:** DuckDB per-boundary edge vs a brute-force pure-Python recomputation
+  agree on every `(boundary, wallet)`.
+- **Qualification gate:** 19 → excluded, 20 → included; counted *within the window*.
+- **Positive-edge floor:** a qualified but non-positive-edge wallet is never selected; K is an
+  upper bound when fewer than K wallets are positive.
+- **Lifetime vs rolling:** same wallet, different `--edge-window`, different result.
+- **Top-K freeze + tiebreak:** only top-K; deterministic ties; membership frozen across a period.
+- **Three K-modes:** fixed-k, capital-per-wallet, top-frac.
+- **Freeze membership:** copied for all trades in `[B, B+N)`, incl. markets resolving before `B+N`.
+- **Platform detection:** precompute runs on a corpus with and without the `platform` column.
+- **Integration:** full `--causal-select` run → only selected wallets booked; sizing + #204
+  gates compose; "Not selected" counter correct.
+- **Edge cases:** empty universe, zero qualified, K > qualified count, `--start-ts/--end-ts`.
+
+## Tunable parameters (for backtest sweeps)
+
+`--min-resolved`, `--edge-window`, `--rebalance-days`, and the K policy/value are all knobs
+to sweep. The positive-edge floor is fixed (not a knob) — copying negative-edge wallets is
+never desired.

--- a/scripts/backtest_copy_sizing.py
+++ b/scripts/backtest_copy_sizing.py
@@ -17,7 +17,7 @@ import csv as _csv
 import datetime as dt
 import math
 import sys
-from collections.abc import Iterator, Sequence
+from collections.abc import Iterable, Iterator, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal, Protocol
@@ -365,6 +365,38 @@ def load_watchlist(daemon_db: Path) -> set[str]:
     return {r[0] for r in rows}
 
 
+def _rows_to_events(rows: Iterable[tuple]) -> Iterator[TradeEvent | ResolutionEvent]:
+    """Convert event-row tuples into TradeEvent / ResolutionEvent objects.
+
+    Row shape: (kind, ts, wallet, condition_id, outcome_side, price,
+    notional_usd, outcome_yes_won).
+    """
+    for kind, ts, wallet, cid, side, price, notional, yes_won in rows:
+        if kind == "trade":
+            yield TradeEvent(
+                kind="trade",
+                ts=int(ts),
+                trade=Trade(
+                    wallet=str(wallet),
+                    condition_id=str(cid),
+                    outcome_side=str(side),
+                    price=float(price),
+                    notional_usd=float(notional),
+                    ts=int(ts),
+                ),
+            )
+        else:
+            yield ResolutionEvent(
+                kind="resolution",
+                ts=int(ts),
+                resolution=Resolution(
+                    condition_id=str(cid),
+                    winning_side="YES" if int(yes_won) == 1 else "NO",
+                    resolved_at=int(ts),
+                ),
+            )
+
+
 def load_event_stream(
     corpus_db: Path,
     *,
@@ -436,30 +468,7 @@ def load_event_stream(
     """  # noqa: S608
     rows = con.execute(query, [platform, *params, platform]).fetchall()
     con.close()
-    for kind, ts, wallet, cid, side, price, notional, yes_won in rows:
-        if kind == "trade":
-            yield TradeEvent(
-                kind="trade",
-                ts=int(ts),
-                trade=Trade(
-                    wallet=str(wallet),
-                    condition_id=str(cid),
-                    outcome_side=str(side),
-                    price=float(price),
-                    notional_usd=float(notional),
-                    ts=int(ts),
-                ),
-            )
-        else:
-            yield ResolutionEvent(
-                kind="resolution",
-                ts=int(ts),
-                resolution=Resolution(
-                    condition_id=str(cid),
-                    winning_side="YES" if int(yes_won) == 1 else "NO",
-                    resolved_at=int(ts),
-                ),
-            )
+    yield from _rows_to_events(rows)
 
 
 def _running_max_drawdown(nav_series: list[tuple[int, float]]) -> tuple[float, int]:

--- a/scripts/backtest_copy_sizing.py
+++ b/scripts/backtest_copy_sizing.py
@@ -26,6 +26,10 @@ import duckdb
 
 from scripts import copy_selection
 
+# Default top-K when no copy policy is given. 25 matches the live daemon's
+# watchlist target order of magnitude (anti-concentration sizing divides by it).
+_DEFAULT_TOP_K = 25
+
 
 @dataclass(frozen=True)
 class Trade:
@@ -371,7 +375,9 @@ def _rows_to_events(rows: Iterable[tuple]) -> Iterator[TradeEvent | ResolutionEv
     """Convert event-row tuples into TradeEvent / ResolutionEvent objects.
 
     Row shape: (kind, ts, wallet, condition_id, outcome_side, price,
-    notional_usd, outcome_yes_won).
+    notional_usd, outcome_yes_won). This shape mirrors the SELECT in
+    ``copy_selection._stream_selected`` (and ``load_event_stream`` below)
+    and MUST stay in sync with both — they all feed this converter.
     """
     for kind, ts, wallet, cid, side, price, notional, yes_won in rows:
         if kind == "trade":
@@ -809,20 +815,34 @@ def _build_schemes(args: argparse.Namespace, watchlist_size: int) -> list[Sizing
 
 
 def _resolve_policy(args: argparse.Namespace) -> copy_selection.KPolicy:
-    """Build the KPolicy from CLI args, defaulting to top-k 25."""
+    """Build the KPolicy from CLI args, defaulting to top-k _DEFAULT_TOP_K."""
     if args.copy_capital_per_wallet is not None:
         return copy_selection.KPolicy(capital_per_wallet=args.copy_capital_per_wallet)
     if args.copy_top_frac is not None:
         return copy_selection.KPolicy(top_frac=args.copy_top_frac)
-    return copy_selection.KPolicy(top_k=args.copy_top_k if args.copy_top_k is not None else 25)
+    return copy_selection.KPolicy(
+        top_k=args.copy_top_k if args.copy_top_k is not None else _DEFAULT_TOP_K
+    )
+
+
+def _watchlist_size_for_policy(policy: copy_selection.KPolicy, bankroll: float) -> int:
+    """Anti-concentration watchlist size implied by a resolved copy policy."""
+    if policy.top_k is not None:
+        return policy.top_k
+    if policy.capital_per_wallet is not None:
+        return max(1, int(bankroll // policy.capital_per_wallet))
+    # top_frac: K varies per boundary; use the default as an anti-concentration proxy.
+    return _DEFAULT_TOP_K
 
 
 def main(argv: list[str] | None = None) -> int:
     """Run the backtest end-to-end against the corpus and print the report."""
     args = build_parser().parse_args(argv)
     watchlist: set[str] = set()
+    policy: copy_selection.KPolicy | None = None
     if args.causal_select:
-        wl_size = args.copy_top_k or 25
+        policy = _resolve_policy(args)
+        wl_size = _watchlist_size_for_policy(policy, args.starting_bankroll_usd)
     else:
         watchlist = load_watchlist(Path(args.watchlist_db))
         if not watchlist:
@@ -840,7 +860,7 @@ def main(argv: list[str] | None = None) -> int:
         max_open_exposure_usd=max_exposure,
     )
     if args.causal_select:
-        policy = _resolve_policy(args)
+        assert policy is not None  # noqa: S101  # set in the causal branch above
         events = _rows_to_events(
             copy_selection.iter_selected_rows(
                 Path(args.db),

--- a/scripts/backtest_copy_sizing.py
+++ b/scripts/backtest_copy_sizing.py
@@ -24,6 +24,8 @@ from typing import Literal, Protocol
 
 import duckdb
 
+from scripts import copy_selection
+
 
 @dataclass(frozen=True)
 class Trade:
@@ -806,14 +808,28 @@ def _build_schemes(args: argparse.Namespace, watchlist_size: int) -> list[Sizing
     ]
 
 
+def _resolve_policy(args: argparse.Namespace) -> copy_selection.KPolicy:
+    """Build the KPolicy from CLI args, defaulting to top-k 25."""
+    if args.copy_capital_per_wallet is not None:
+        return copy_selection.KPolicy(capital_per_wallet=args.copy_capital_per_wallet)
+    if args.copy_top_frac is not None:
+        return copy_selection.KPolicy(top_frac=args.copy_top_frac)
+    return copy_selection.KPolicy(top_k=args.copy_top_k if args.copy_top_k is not None else 25)
+
+
 def main(argv: list[str] | None = None) -> int:
     """Run the backtest end-to-end against the corpus and print the report."""
     args = build_parser().parse_args(argv)
-    watchlist = load_watchlist(Path(args.watchlist_db))
-    if not watchlist:
-        print("Watchlist is empty; nothing to backtest.", file=sys.stderr)
-        return 1
-    schemes = _build_schemes(args, len(watchlist))
+    watchlist: set[str] = set()
+    if args.causal_select:
+        wl_size = args.copy_top_k or 25
+    else:
+        watchlist = load_watchlist(Path(args.watchlist_db))
+        if not watchlist:
+            print("Watchlist is empty; nothing to backtest.", file=sys.stderr)
+            return 1
+        wl_size = len(watchlist)
+    schemes = _build_schemes(args, wl_size)
     max_exposure = args.max_open_exposure_usd
     if args.max_open_exposure_frac is not None:
         max_exposure = args.max_open_exposure_frac * args.starting_bankroll_usd
@@ -823,19 +839,43 @@ def main(argv: list[str] | None = None) -> int:
         enforce_capacity=args.enforce_capacity,
         max_open_exposure_usd=max_exposure,
     )
-    for event in load_event_stream(
-        Path(args.db),
-        watchlist=watchlist,
-        platform=args.platform,
-        start_ts=args.start_ts,
-        end_ts=args.end_ts,
-    ):
+    if args.causal_select:
+        policy = _resolve_policy(args)
+        events = _rows_to_events(
+            copy_selection.iter_selected_rows(
+                Path(args.db),
+                platform=args.platform,
+                min_resolved=args.min_resolved,
+                edge_window_days=args.edge_window,
+                rebalance_days=args.rebalance_days,
+                policy=policy,
+                bankroll=args.starting_bankroll_usd,
+                start_ts=args.start_ts,
+                end_ts=args.end_ts,
+            )
+        )
+        selection_header = (
+            f"Causal selection: min_resolved={args.min_resolved}, "
+            f"edge_window={args.edge_window}d, rebalance_days={args.rebalance_days}, "
+            f"policy={policy}\n"
+        )
+    else:
+        events = load_event_stream(
+            Path(args.db),
+            watchlist=watchlist,
+            platform=args.platform,
+            start_ts=args.start_ts,
+            end_ts=args.end_ts,
+        )
+        selection_header = ""
+    for event in events:
         if isinstance(event, TradeEvent):
             sim.on_trade(event.trade)
         else:
             sim.on_resolution(event.resolution)
     print(
-        render_report(
+        selection_header
+        + render_report(
             sim,
             schemes=schemes,
             bankroll=args.starting_bankroll_usd,

--- a/scripts/backtest_copy_sizing.py
+++ b/scripts/backtest_copy_sizing.py
@@ -692,6 +692,48 @@ def build_parser() -> argparse.ArgumentParser:
         help="Same cap as --max-open-exposure-usd, expressed as a fraction of bankroll.",
     )
     p.add_argument(
+        "--causal-select",
+        action="store_true",
+        help="Causally qualify+rank+select wallets from the corpus (ignores --watchlist-db).",
+    )
+    p.add_argument(
+        "--min-resolved",
+        type=int,
+        default=20,
+        help="Qualification: min resolved trades within the edge window.",
+    )
+    p.add_argument(
+        "--edge-window",
+        type=int,
+        default=0,
+        help="Rolling edge window in days; 0 = lifetime.",
+    )
+    p.add_argument(
+        "--rebalance-days",
+        type=int,
+        default=14,
+        help="Days between top-K copy-set recomputes.",
+    )
+    copy_policy = p.add_mutually_exclusive_group()
+    copy_policy.add_argument(
+        "--copy-top-k",
+        type=int,
+        default=None,
+        help="Copy the top N wallets by causal edge.",
+    )
+    copy_policy.add_argument(
+        "--copy-capital-per-wallet",
+        type=float,
+        default=None,
+        help="K = floor(bankroll / C).",
+    )
+    copy_policy.add_argument(
+        "--copy-top-frac",
+        type=float,
+        default=None,
+        help="Copy the top X fraction of qualified wallets.",
+    )
+    p.add_argument(
         "--csv",
         default=None,
         help="Optional path to dump per-trade per-scheme rows.",

--- a/scripts/backtest_copy_sizing.py
+++ b/scripts/backtest_copy_sizing.py
@@ -24,7 +24,11 @@ from typing import Literal, Protocol
 
 import duckdb
 
-from scripts import copy_selection
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts import copy_selection  # noqa: E402  (import after sys.path bootstrap)
 
 # Default top-K when no copy policy is given. 25 matches the live daemon's
 # watchlist target order of magnitude (anti-concentration sizing divides by it).

--- a/scripts/copy_selection.py
+++ b/scripts/copy_selection.py
@@ -128,3 +128,103 @@ def ranked_qualifiers(
         con.close()
     return [(int(b), str(w), float(e), int(n), int(rk), int(nq))
             for (b, w, e, n, rk, nq) in rows]
+
+
+def _make_boundaries(con: duckdb.DuckDBPyConnection, *, period: int,
+                     start_ts: int | None, end_ts: int | None) -> list[int]:
+    """Boundary grid spanning the trade ts range (or the provided window), step=period."""
+    lo, hi = con.execute("SELECT MIN(ts), MAX(ts) FROM rb").fetchone()
+    if lo is None:
+        return []
+    lo = start_ts if start_ts is not None else int(lo)
+    hi = end_ts if end_ts is not None else int(hi)
+    return list(range(lo, hi + 1, period))
+
+
+def iter_selected_rows(
+    db_path: Path, *, platform: str, min_resolved: int, edge_window_days: int,
+    rebalance_days: int | None, policy: KPolicy, bankroll: float,
+    start_ts: int | None, end_ts: int | None, rebalance_seconds: int | None = None,
+) -> Iterator[tuple]:
+    """Yield (kind, ts, wallet, condition_id, outcome_side, price, notional_usd,
+    outcome_yes_won) rows for the causally-selected copy stream, ts-ordered.
+
+    rebalance_seconds overrides rebalance_days (tests use small windows).
+    """
+    period = rebalance_seconds if rebalance_seconds is not None else rebalance_days * 86400
+    has_plat = has_platform_column(db_path)
+    con = _attach(db_path)
+    try:
+        _build_rb(con, platform=platform, has_platform=has_plat)
+        boundaries = _make_boundaries(con, period=period, start_ts=start_ts, end_ts=end_ts)
+        if not boundaries:
+            return
+        con.close()  # ranked_qualifiers reopens its own connection
+        con = None
+        ranked = ranked_qualifiers(
+            db_path, platform=platform, min_resolved=min_resolved,
+            edge_window_days=edge_window_days, boundaries=boundaries,
+        )
+        # apply per-boundary K cut
+        n_qual_by_b: dict[int, int] = {}
+        for b, _w, _e, _n, _rk, nq in ranked:
+            n_qual_by_b[b] = nq
+        copyset: list[tuple[int, str]] = []
+        for b, w, _e, _n, rk, _nq in ranked:
+            k = resolve_k(policy, bankroll=bankroll, qualified_count=n_qual_by_b[b])
+            if rk <= k:
+                copyset.append((b, w))
+        if not copyset:
+            return
+        yield from _stream_selected(
+            db_path, platform=platform, has_platform=has_plat, period=period,
+            copyset=copyset,
+        )
+    finally:
+        if con is not None:
+            con.close()
+
+
+def _stream_selected(
+    db_path: Path, *, platform: str, has_platform: bool, period: int,
+    copyset: list[tuple[int, str]],
+) -> Iterator[tuple]:
+    tpred = "AND t.platform = ?" if has_platform else ""
+    rpred = "AND r.platform = ?" if has_platform else ""
+    tparams = [platform] if has_platform else []
+    rparams = [platform] if has_platform else []
+    con = _attach(db_path)
+    try:
+        con.execute("CREATE TEMP TABLE copyset(boundary_ts BIGINT, wallet VARCHAR)")
+        con.executemany("INSERT INTO copyset VALUES (?, ?)", copyset)
+        query = f"""
+            WITH selected AS (
+              SELECT t.wallet_address AS wallet, t.condition_id AS condition_id,
+                     t.outcome_side AS outcome_side, t.price AS price,
+                     t.notional_usd AS notional_usd, t.ts AS ts
+              FROM s.corpus_trades t
+              JOIN copyset cs ON cs.wallet = t.wallet_address
+                AND t.ts >= cs.boundary_ts AND t.ts < cs.boundary_ts + {period}
+              WHERE t.bs = 'BUY' {tpred}
+            ),
+            sel_res AS (
+              SELECT r.condition_id AS condition_id, r.outcome_yes_won AS outcome_yes_won,
+                     r.resolved_at AS ts
+              FROM s.market_resolutions r
+              WHERE r.condition_id IN (SELECT DISTINCT condition_id FROM selected) {rpred}
+            )
+            SELECT 'trade' AS kind, ts, wallet, condition_id, outcome_side,
+                   price, notional_usd, NULL AS outcome_yes_won FROM selected
+            UNION ALL
+            SELECT 'resolution' AS kind, ts, NULL, condition_id, NULL,
+                   NULL, NULL, outcome_yes_won FROM sel_res
+            ORDER BY ts ASC
+        """  # noqa: S608 -- period/predicates are fixed literals; values via ? params
+        cur = con.execute(query, [*tparams, *rparams])
+        while True:
+            batch = cur.fetchmany(100_000)
+            if not batch:
+                break
+            yield from batch
+    finally:
+        con.close()

--- a/scripts/copy_selection.py
+++ b/scripts/copy_selection.py
@@ -43,3 +43,11 @@ def resolve_k(policy: KPolicy, *, bankroll: float, qualified_count: int) -> int:
     if policy.top_frac is not None:
         return math.ceil(policy.top_frac * qualified_count)
     raise ValueError("KPolicy has no mode set")
+
+
+def has_platform_column(db_path: Path) -> bool:
+    """Return True if corpus_trades carries the multi-platform `platform` column."""
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    cols = [r[1] for r in conn.execute("PRAGMA table_info(corpus_trades)")]
+    conn.close()
+    return "platform" in cols

--- a/scripts/copy_selection.py
+++ b/scripts/copy_selection.py
@@ -18,6 +18,8 @@ from pathlib import Path
 
 import duckdb
 
+_SECONDS_PER_DAY = 86_400
+
 
 @dataclass(frozen=True)
 class KPolicy:
@@ -26,6 +28,12 @@ class KPolicy:
     top_k: int | None = None
     capital_per_wallet: float | None = None
     top_frac: float | None = None
+
+    def __post_init__(self) -> None:
+        """Enforce that exactly one sizing field is set."""
+        modes = [self.top_k, self.capital_per_wallet, self.top_frac]
+        if sum(m is not None for m in modes) != 1:
+            raise ValueError("KPolicy requires exactly one of top_k, capital_per_wallet, top_frac")
 
 
 def resolve_k(policy: KPolicy, *, bankroll: float, qualified_count: int) -> int:
@@ -48,8 +56,10 @@ def resolve_k(policy: KPolicy, *, bankroll: float, qualified_count: int) -> int:
 def has_platform_column(db_path: Path) -> bool:
     """Return True if corpus_trades carries the multi-platform `platform` column."""
     conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
-    cols = [r[1] for r in conn.execute("PRAGMA table_info(corpus_trades)")]
-    conn.close()
+    try:
+        cols = [r[1] for r in conn.execute("PRAGMA table_info(corpus_trades)")]
+    finally:
+        conn.close()
     return "platform" in cols
 
 
@@ -105,7 +115,9 @@ def ranked_qualifiers(
         con.execute("CREATE TEMP TABLE bnd(boundary_ts BIGINT)")
         con.executemany("INSERT INTO bnd VALUES (?)", [(int(b),) for b in boundaries])
         window_pred = (
-            "" if edge_window_days == 0 else "AND rb.resolved_at >= b.boundary_ts - ? * 86400"
+            ""
+            if edge_window_days == 0
+            else f"AND rb.resolved_at >= b.boundary_ts - ? * {_SECONDS_PER_DAY}"
         )
         params = [] if edge_window_days == 0 else [edge_window_days]
         rows = con.execute(
@@ -147,17 +159,18 @@ def _make_boundaries(
     return list(range(lo, hi + 1, period))
 
 
-def _resolve_period(rebalance_days: int | None, rebalance_seconds: int | None) -> int:
+def _resolve_period(*, rebalance_days: int | None, rebalance_seconds: int | None) -> int:
     """Return the rebalance period in seconds, validating inputs."""
     if rebalance_seconds is not None:
         return rebalance_seconds
     if rebalance_days is None:
         raise ValueError("rebalance_days must be set when rebalance_seconds is None")
-    return rebalance_days * 86400
+    return rebalance_days * _SECONDS_PER_DAY
 
 
 def _build_copyset(
     ranked: list[tuple[int, str, float, int, int, int]],
+    *,
     policy: KPolicy,
     bankroll: float,
 ) -> list[tuple[int, str]]:
@@ -191,7 +204,7 @@ def iter_selected_rows(
 
     rebalance_seconds overrides rebalance_days (tests use small windows).
     """
-    period = _resolve_period(rebalance_days, rebalance_seconds)
+    period = _resolve_period(rebalance_days=rebalance_days, rebalance_seconds=rebalance_seconds)
     has_plat = has_platform_column(db_path)
     con = _attach(db_path)
     try:
@@ -208,7 +221,7 @@ def iter_selected_rows(
             edge_window_days=edge_window_days,
             boundaries=boundaries,
         )
-        copyset = _build_copyset(ranked, policy, bankroll)
+        copyset = _build_copyset(ranked, policy=policy, bankroll=bankroll)
         if not copyset:
             return
         yield from _stream_selected(
@@ -231,6 +244,11 @@ def _stream_selected(
     period: int,
     copyset: list[tuple[int, str]],
 ) -> Iterator[tuple]:
+    """Stream copied trades + their resolutions as event rows, ts-ordered.
+
+    Two CTEs: `selected` = each copyset wallet's BUYs inside its frozen
+    rebalance period; `sel_res` = resolutions for those selected markets.
+    """
     tpred = "AND t.platform = ?" if has_platform else ""
     rpred = "AND r.platform = ?" if has_platform else ""
     tparams = [platform] if has_platform else []

--- a/scripts/copy_selection.py
+++ b/scripts/copy_selection.py
@@ -64,7 +64,7 @@ def _build_rb(con: duckdb.DuckDBPyConnection, *, platform: str, has_platform: bo
     """Materialize the causal resolved-buy fact table `rb`."""
     tpred = "AND t.platform = ?" if has_platform else ""
     rpred = "AND r.platform = ?" if has_platform else ""
-    params = ([platform, platform] if has_platform else [])
+    params = [platform, platform] if has_platform else []
     con.execute(
         f"""
         CREATE TEMP TABLE rb AS
@@ -83,7 +83,11 @@ def _build_rb(con: duckdb.DuckDBPyConnection, *, platform: str, has_platform: bo
 
 
 def ranked_qualifiers(
-    db_path: Path, *, platform: str, min_resolved: int, edge_window_days: int,
+    db_path: Path,
+    *,
+    platform: str,
+    min_resolved: int,
+    edge_window_days: int,
     boundaries: Sequence[int],
 ) -> list[tuple[int, str, float, int, int, int]]:
     """Return (boundary_ts, wallet, edge, n_resolved, rank, n_qualified) rows.
@@ -101,8 +105,7 @@ def ranked_qualifiers(
         con.execute("CREATE TEMP TABLE bnd(boundary_ts BIGINT)")
         con.executemany("INSERT INTO bnd VALUES (?)", [(int(b),) for b in boundaries])
         window_pred = (
-            "" if edge_window_days == 0
-            else "AND rb.resolved_at >= b.boundary_ts - ? * 86400"
+            "" if edge_window_days == 0 else "AND rb.resolved_at >= b.boundary_ts - ? * 86400"
         )
         params = [] if edge_window_days == 0 else [edge_window_days]
         rows = con.execute(
@@ -126,14 +129,17 @@ def ranked_qualifiers(
         ).fetchall()
     finally:
         con.close()
-    return [(int(b), str(w), float(e), int(n), int(rk), int(nq))
-            for (b, w, e, n, rk, nq) in rows]
+    return [(int(b), str(w), float(e), int(n), int(rk), int(nq)) for (b, w, e, n, rk, nq) in rows]
 
 
-def _make_boundaries(con: duckdb.DuckDBPyConnection, *, period: int,
-                     start_ts: int | None, end_ts: int | None) -> list[int]:
+def _make_boundaries(
+    con: duckdb.DuckDBPyConnection, *, period: int, start_ts: int | None, end_ts: int | None
+) -> list[int]:
     """Boundary grid spanning the trade ts range (or the provided window), step=period."""
-    lo, hi = con.execute("SELECT MIN(ts), MAX(ts) FROM rb").fetchone()
+    row = con.execute("SELECT MIN(ts), MAX(ts) FROM rb").fetchone()
+    if row is None:
+        return []
+    lo, hi = row
     if lo is None:
         return []
     lo = start_ts if start_ts is not None else int(lo)
@@ -141,17 +147,51 @@ def _make_boundaries(con: duckdb.DuckDBPyConnection, *, period: int,
     return list(range(lo, hi + 1, period))
 
 
+def _resolve_period(rebalance_days: int | None, rebalance_seconds: int | None) -> int:
+    """Return the rebalance period in seconds, validating inputs."""
+    if rebalance_seconds is not None:
+        return rebalance_seconds
+    if rebalance_days is None:
+        raise ValueError("rebalance_days must be set when rebalance_seconds is None")
+    return rebalance_days * 86400
+
+
+def _build_copyset(
+    ranked: list[tuple[int, str, float, int, int, int]],
+    policy: KPolicy,
+    bankroll: float,
+) -> list[tuple[int, str]]:
+    """Apply per-boundary K cut to ranked qualifiers, returning (boundary_ts, wallet) pairs."""
+    n_qual_by_b: dict[int, int] = {b: nq for b, _w, _e, _n, _rk, nq in ranked}
+    copyset: list[tuple[int, str]] = []
+    for b, w, _e, _n, rk, _nq in ranked:
+        k = resolve_k(policy, bankroll=bankroll, qualified_count=n_qual_by_b[b])
+        if rk <= k:
+            copyset.append((b, w))
+    return copyset
+
+
 def iter_selected_rows(
-    db_path: Path, *, platform: str, min_resolved: int, edge_window_days: int,
-    rebalance_days: int | None, policy: KPolicy, bankroll: float,
-    start_ts: int | None, end_ts: int | None, rebalance_seconds: int | None = None,
+    db_path: Path,
+    *,
+    platform: str,
+    min_resolved: int,
+    edge_window_days: int,
+    rebalance_days: int | None,
+    policy: KPolicy,
+    bankroll: float,
+    start_ts: int | None,
+    end_ts: int | None,
+    rebalance_seconds: int | None = None,
 ) -> Iterator[tuple]:
-    """Yield (kind, ts, wallet, condition_id, outcome_side, price, notional_usd,
-    outcome_yes_won) rows for the causally-selected copy stream, ts-ordered.
+    """Yield event rows for the causally-selected copy stream, ts-ordered.
+
+    Row shape: (kind, ts, wallet, condition_id, outcome_side, price,
+    notional_usd, outcome_yes_won).
 
     rebalance_seconds overrides rebalance_days (tests use small windows).
     """
-    period = rebalance_seconds if rebalance_seconds is not None else rebalance_days * 86400
+    period = _resolve_period(rebalance_days, rebalance_seconds)
     has_plat = has_platform_column(db_path)
     con = _attach(db_path)
     try:
@@ -162,22 +202,20 @@ def iter_selected_rows(
         con.close()  # ranked_qualifiers reopens its own connection
         con = None
         ranked = ranked_qualifiers(
-            db_path, platform=platform, min_resolved=min_resolved,
-            edge_window_days=edge_window_days, boundaries=boundaries,
+            db_path,
+            platform=platform,
+            min_resolved=min_resolved,
+            edge_window_days=edge_window_days,
+            boundaries=boundaries,
         )
-        # apply per-boundary K cut
-        n_qual_by_b: dict[int, int] = {}
-        for b, _w, _e, _n, _rk, nq in ranked:
-            n_qual_by_b[b] = nq
-        copyset: list[tuple[int, str]] = []
-        for b, w, _e, _n, rk, _nq in ranked:
-            k = resolve_k(policy, bankroll=bankroll, qualified_count=n_qual_by_b[b])
-            if rk <= k:
-                copyset.append((b, w))
+        copyset = _build_copyset(ranked, policy, bankroll)
         if not copyset:
             return
         yield from _stream_selected(
-            db_path, platform=platform, has_platform=has_plat, period=period,
+            db_path,
+            platform=platform,
+            has_platform=has_plat,
+            period=period,
             copyset=copyset,
         )
     finally:
@@ -186,7 +224,11 @@ def iter_selected_rows(
 
 
 def _stream_selected(
-    db_path: Path, *, platform: str, has_platform: bool, period: int,
+    db_path: Path,
+    *,
+    platform: str,
+    has_platform: bool,
+    period: int,
     copyset: list[tuple[int, str]],
 ) -> Iterator[tuple]:
     tpred = "AND t.platform = ?" if has_platform else ""

--- a/scripts/copy_selection.py
+++ b/scripts/copy_selection.py
@@ -51,3 +51,80 @@ def has_platform_column(db_path: Path) -> bool:
     cols = [r[1] for r in conn.execute("PRAGMA table_info(corpus_trades)")]
     conn.close()
     return "platform" in cols
+
+
+def _attach(db_path: Path) -> duckdb.DuckDBPyConnection:
+    con = duckdb.connect(":memory:")
+    con.execute("PRAGMA memory_limit='3GB'")
+    con.execute(f"ATTACH '{db_path}' AS s (TYPE sqlite, READONLY)")
+    return con
+
+
+def _build_rb(con: duckdb.DuckDBPyConnection, *, platform: str, has_platform: bool) -> None:
+    """Materialize the causal resolved-buy fact table `rb`."""
+    tpred = "AND t.platform = ?" if has_platform else ""
+    rpred = "AND r.platform = ?" if has_platform else ""
+    params = ([platform, platform] if has_platform else [])
+    con.execute(
+        f"""
+        CREATE TEMP TABLE rb AS
+        SELECT t.wallet_address AS wallet, t.condition_id AS condition_id,
+               t.price AS price, t.ts AS ts, t.outcome_side AS outcome_side,
+               r.resolved_at AS resolved_at,
+               CASE WHEN (r.outcome_yes_won = 1 AND t.outcome_side = 'YES')
+                      OR (r.outcome_yes_won = 0 AND t.outcome_side = 'NO')
+                    THEN 1 ELSE 0 END AS won
+        FROM s.corpus_trades t
+        JOIN s.market_resolutions r ON r.condition_id = t.condition_id {rpred}
+        WHERE t.bs = 'BUY' AND t.ts <= r.resolved_at {tpred}
+        """,  # noqa: S608 -- predicates are fixed literals; values via ? params
+        params,
+    )
+
+
+def ranked_qualifiers(
+    db_path: Path, *, platform: str, min_resolved: int, edge_window_days: int,
+    boundaries: Sequence[int],
+) -> list[tuple[int, str, float, int, int, int]]:
+    """Return (boundary_ts, wallet, edge, n_resolved, rank, n_qualified) rows.
+
+    Only qualified (>= min_resolved within window) AND positive-edge wallets,
+    ranked per boundary by (edge DESC, wallet ASC). No lookahead: each
+    boundary's edge uses only resolutions with resolved_at < boundary_ts.
+    """
+    if not boundaries:
+        return []
+    has_plat = has_platform_column(db_path)
+    con = _attach(db_path)
+    try:
+        _build_rb(con, platform=platform, has_platform=has_plat)
+        con.execute("CREATE TEMP TABLE bnd(boundary_ts BIGINT)")
+        con.executemany("INSERT INTO bnd VALUES (?)", [(int(b),) for b in boundaries])
+        window_pred = (
+            "" if edge_window_days == 0
+            else "AND rb.resolved_at >= b.boundary_ts - ? * 86400"
+        )
+        params = [] if edge_window_days == 0 else [edge_window_days]
+        rows = con.execute(
+            f"""
+            WITH agg AS (
+              SELECT b.boundary_ts AS boundary_ts, rb.wallet AS wallet,
+                     COUNT(*) AS n_resolved, AVG(rb.won - rb.price) AS edge
+              FROM bnd b
+              JOIN rb ON rb.resolved_at < b.boundary_ts {window_pred}
+              GROUP BY b.boundary_ts, rb.wallet
+              HAVING COUNT(*) >= ? AND AVG(rb.won - rb.price) > 0
+            )
+            SELECT boundary_ts, wallet, edge, n_resolved,
+                   ROW_NUMBER() OVER (PARTITION BY boundary_ts
+                                      ORDER BY edge DESC, wallet ASC) AS rank,
+                   COUNT(*) OVER (PARTITION BY boundary_ts) AS n_qualified
+            FROM agg
+            ORDER BY boundary_ts, rank
+            """,  # noqa: S608 -- window_pred is a fixed literal; values via ? params
+            [*params, min_resolved],
+        ).fetchall()
+    finally:
+        con.close()
+    return [(int(b), str(w), float(e), int(n), int(rk), int(nq))
+            for (b, w, e, n, rk, nq) in rows]

--- a/scripts/copy_selection.py
+++ b/scripts/copy_selection.py
@@ -1,0 +1,45 @@
+"""Causal copy-trading wallet selection precompute (DuckDB-backed).
+
+Qualifies wallets at >= min_resolved resolved trades, ranks by causal
+(no-lookahead) edge, freezes a global top-K copy set per rebalance
+boundary, and emits the selected trades + their resolutions as event
+rows for scripts.backtest_copy_sizing's Simulator.
+
+Spec: docs/superpowers/specs/2026-05-30-causal-copy-selection-design.md
+"""
+
+from __future__ import annotations
+
+import math
+import sqlite3
+from collections.abc import Iterator, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+import duckdb
+
+
+@dataclass(frozen=True)
+class KPolicy:
+    """Top-K policy for the copy set. Exactly one field is set."""
+
+    top_k: int | None = None
+    capital_per_wallet: float | None = None
+    top_frac: float | None = None
+
+
+def resolve_k(policy: KPolicy, *, bankroll: float, qualified_count: int) -> int:
+    """Return the top-K cut for one rebalance boundary.
+
+    Args:
+        policy: which sizing rule to apply.
+        bankroll: constant starting bankroll (USD).
+        qualified_count: number of qualified wallets at this boundary.
+    """
+    if policy.top_k is not None:
+        return policy.top_k
+    if policy.capital_per_wallet is not None:
+        return max(0, int(bankroll // policy.capital_per_wallet))
+    if policy.top_frac is not None:
+        return math.ceil(policy.top_frac * qualified_count)
+    raise ValueError("KPolicy has no mode set")

--- a/tests/scripts/conftest.py
+++ b/tests/scripts/conftest.py
@@ -1,0 +1,67 @@
+"""Shared fixtures for scripts tests."""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+# trade tuple: (wallet, condition_id, outcome_side, bs, price, notional_usd, ts)
+# resolution tuple: (condition_id, outcome_yes_won, resolved_at)
+Trade = tuple[str, str, str, str, float, float, int]
+Resolution = tuple[str, int, int]
+
+
+def _build(path: Path, trades: list[Trade], resolutions: list[Resolution],
+           *, with_platform: bool) -> None:
+    plat_col = "platform TEXT NOT NULL DEFAULT 'polymarket'," if with_platform else ""
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        f"""
+        CREATE TABLE corpus_trades (
+          {plat_col}
+          tx_hash TEXT NOT NULL, asset_id TEXT NOT NULL,
+          wallet_address TEXT NOT NULL, condition_id TEXT NOT NULL,
+          outcome_side TEXT NOT NULL, bs TEXT NOT NULL,
+          price REAL NOT NULL, size REAL NOT NULL,
+          notional_usd REAL NOT NULL, ts INTEGER NOT NULL
+        );
+        CREATE TABLE market_resolutions (
+          {plat_col}
+          condition_id TEXT NOT NULL, winning_outcome_index INTEGER NOT NULL,
+          outcome_yes_won INTEGER NOT NULL, resolved_at INTEGER NOT NULL,
+          source TEXT NOT NULL, recorded_at INTEGER NOT NULL
+        );
+        """
+    )
+    prefix = "'polymarket'," if with_platform else ""
+    for i, (w, cid, side, bs, price, notional, ts) in enumerate(trades):
+        conn.execute(
+            f"INSERT INTO corpus_trades VALUES ({prefix}?,?,?,?,?,?,?,?,?,?)",
+            (f"0xtx{i}", f"asset{i}", w, cid, side, bs, price,
+             notional / price, notional, ts),
+        )
+    for cid, yes_won, resolved_at in resolutions:
+        conn.execute(
+            f"INSERT INTO market_resolutions VALUES ({prefix}?,?,?,?,'test',?)",
+            (cid, 0 if yes_won else 1, yes_won, resolved_at, resolved_at),
+        )
+    conn.commit()
+    conn.close()
+
+
+@pytest.fixture
+def corpus_factory(tmp_path: Path) -> Callable[..., Path]:
+    """Return a builder: corpus_factory(trades, resolutions, with_platform=True) -> db path."""
+    counter = {"n": 0}
+
+    def make(trades: list[Trade], resolutions: list[Resolution],
+             *, with_platform: bool = True) -> Path:
+        counter["n"] += 1
+        db = tmp_path / f"corpus{counter['n']}.sqlite3"
+        _build(db, trades, resolutions, with_platform=with_platform)
+        return db
+
+    return make

--- a/tests/scripts/conftest.py
+++ b/tests/scripts/conftest.py
@@ -14,8 +14,9 @@ Trade = tuple[str, str, str, str, float, float, int]
 Resolution = tuple[str, int, int]
 
 
-def _build(path: Path, trades: list[Trade], resolutions: list[Resolution],
-           *, with_platform: bool) -> None:
+def _build(
+    path: Path, trades: list[Trade], resolutions: list[Resolution], *, with_platform: bool
+) -> None:
     plat_col = "platform TEXT NOT NULL DEFAULT 'polymarket'," if with_platform else ""
     conn = sqlite3.connect(path)
     conn.executescript(
@@ -39,13 +40,12 @@ def _build(path: Path, trades: list[Trade], resolutions: list[Resolution],
     prefix = "'polymarket'," if with_platform else ""
     for i, (w, cid, side, bs, price, notional, ts) in enumerate(trades):
         conn.execute(
-            f"INSERT INTO corpus_trades VALUES ({prefix}?,?,?,?,?,?,?,?,?,?)",
-            (f"0xtx{i}", f"asset{i}", w, cid, side, bs, price,
-             notional / price, notional, ts),
+            f"INSERT INTO corpus_trades VALUES ({prefix}?,?,?,?,?,?,?,?,?,?)",  # noqa: S608
+            (f"0xtx{i}", f"asset{i}", w, cid, side, bs, price, notional / price, notional, ts),
         )
     for cid, yes_won, resolved_at in resolutions:
         conn.execute(
-            f"INSERT INTO market_resolutions VALUES ({prefix}?,?,?,?,'test',?)",
+            f"INSERT INTO market_resolutions VALUES ({prefix}?,?,?,?,'test',?)",  # noqa: S608
             (cid, 0 if yes_won else 1, yes_won, resolved_at, resolved_at),
         )
     conn.commit()
@@ -57,8 +57,9 @@ def corpus_factory(tmp_path: Path) -> Callable[..., Path]:
     """Return a builder: corpus_factory(trades, resolutions, with_platform=True) -> db path."""
     counter = {"n": 0}
 
-    def make(trades: list[Trade], resolutions: list[Resolution],
-             *, with_platform: bool = True) -> Path:
+    def make(
+        trades: list[Trade], resolutions: list[Resolution], *, with_platform: bool = True
+    ) -> Path:
         counter["n"] += 1
         db = tmp_path / f"corpus{counter['n']}.sqlite3"
         _build(db, trades, resolutions, with_platform=with_platform)

--- a/tests/scripts/test_backtest_simulator.py
+++ b/tests/scripts/test_backtest_simulator.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import csv
 import sqlite3
+import subprocess
+import sys as _sys
 from pathlib import Path
 
 import pytest
@@ -630,3 +632,16 @@ def test_main_causal_select_end_to_end(corpus_factory, capsys, tmp_path) -> None
     assert equal_weight_rows[0]["wallet"] == "A"
     assert equal_weight_rows[0]["condition_id"] == "n1"
     assert {r["wallet"] for r in rows} == {"A"}
+
+
+def test_script_runs_via_direct_execution() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    result = subprocess.run(
+        [_sys.executable, "scripts/backtest_copy_sizing.py", "--help"],
+        capture_output=True,
+        text=True,
+        cwd=repo_root,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "--causal-select" in result.stdout

--- a/tests/scripts/test_backtest_simulator.py
+++ b/tests/scripts/test_backtest_simulator.py
@@ -586,14 +586,27 @@ def test_main_causal_select_end_to_end(corpus_factory, capsys) -> None:  # type:
         ("B", "n2", "YES", "BUY", 0.50, 100.0, 160),
     ]
     resolutions = [
-        ("h1", 1, 50), ("h2", 1, 60), ("h3", 0, 50), ("h4", 0, 60),
-        ("n1", 1, 300), ("n2", 1, 300),
+        ("h1", 1, 50),
+        ("h2", 1, 60),
+        ("h3", 0, 50),
+        ("h4", 0, 60),
+        ("n1", 1, 300),
+        ("n2", 1, 300),
     ]
     db = corpus_factory(trades, resolutions)
-    rc = main([
-        "--db", str(db), "--causal-select", "--min-resolved", "2",
-        "--rebalance-days", "1", "--copy-top-k", "5",
-    ])
+    rc = main(
+        [
+            "--db",
+            str(db),
+            "--causal-select",
+            "--min-resolved",
+            "2",
+            "--rebalance-days",
+            "1",
+            "--copy-top-k",
+            "5",
+        ]
+    )
     out = capsys.readouterr().out
     assert rc == 0
     assert "Causal selection" in out

--- a/tests/scripts/test_backtest_simulator.py
+++ b/tests/scripts/test_backtest_simulator.py
@@ -634,6 +634,38 @@ def test_main_causal_select_end_to_end(corpus_factory, capsys, tmp_path) -> None
     assert {r["wallet"] for r in rows} == {"A"}
 
 
+def test_main_causal_select_top_frac_policy(corpus_factory, capsys, tmp_path) -> None:  # type: ignore[no-untyped-def]
+    # Exercise the --copy-top-frac policy through main() (the top_k path is
+    # covered above). Same corpus: A is positive-edge, B never positive, so the
+    # positive-edge floor leaves only A regardless of the fraction; frac=1.0
+    # copies all qualified (= A). Proves _resolve_policy + wl_size wiring for frac.
+    day = 86_400
+    trades = [
+        ("A", "h1", "YES", "BUY", 0.30, 100.0, 1),
+        ("A", "h2", "YES", "BUY", 0.30, 100.0, 2),
+        ("B", "h3", "YES", "BUY", 0.90, 100.0, 1),
+        ("B", "h4", "YES", "BUY", 0.90, 100.0, 2),
+        ("A", "n1", "YES", "BUY", 0.50, 100.0, day + 100),
+        ("B", "n2", "YES", "BUY", 0.50, 100.0, day + 110),
+    ]
+    resolutions = [
+        ("h1", 1, 50), ("h2", 1, 60), ("h3", 0, 50), ("h4", 0, 60),
+        ("n1", 1, day + 300), ("n2", 1, day + 300),
+    ]
+    db = corpus_factory(trades, resolutions)
+    csv_path = tmp_path / "frac.csv"
+    rc = main([
+        "--db", str(db), "--causal-select", "--min-resolved", "2",
+        "--rebalance-days", "1", "--copy-top-frac", "1.0", "--csv", str(csv_path),
+    ])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "top_frac=1.0" in out  # policy threaded through to the header
+    with csv_path.open() as fh:
+        rows = list(csv.DictReader(fh))
+    assert {r["wallet"] for r in rows} == {"A"}
+
+
 def test_script_runs_via_direct_execution() -> None:
     repo_root = Path(__file__).resolve().parents[2]
     result = subprocess.run(

--- a/tests/scripts/test_backtest_simulator.py
+++ b/tests/scripts/test_backtest_simulator.py
@@ -17,6 +17,7 @@ from scripts.backtest_copy_sizing import (
     build_parser,
     load_event_stream,
     load_watchlist,
+    main,
     render_report,
 )
 
@@ -551,3 +552,49 @@ def test_render_report_includes_skipped_column_and_capacity_note() -> None:
     )
     assert "Skipped" in report
     assert "Capacity enforcement" in report
+
+
+def test_build_parser_causal_select_defaults() -> None:
+    args = build_parser().parse_args(["--causal-select"])
+    assert args.causal_select is True
+    assert args.min_resolved == 20
+    assert args.edge_window == 0
+    assert args.rebalance_days == 14
+    assert args.copy_top_k is None
+    assert args.copy_capital_per_wallet is None
+    assert args.copy_top_frac is None
+
+
+def test_build_parser_causal_off_by_default() -> None:
+    args = build_parser().parse_args([])
+    assert args.causal_select is False
+
+
+def test_build_parser_rejects_two_copy_policies() -> None:
+    with pytest.raises(SystemExit):
+        build_parser().parse_args(["--copy-top-k", "10", "--copy-top-frac", "0.1"])
+
+
+def test_main_causal_select_end_to_end(corpus_factory, capsys) -> None:  # type: ignore[no-untyped-def]
+    # A qualifies positive and is copied; B never positive -> never copied.
+    trades = [
+        ("A", "h1", "YES", "BUY", 0.30, 100.0, 1),
+        ("A", "h2", "YES", "BUY", 0.30, 100.0, 2),
+        ("B", "h3", "YES", "BUY", 0.90, 100.0, 1),
+        ("B", "h4", "YES", "BUY", 0.90, 100.0, 2),
+        ("A", "n1", "YES", "BUY", 0.50, 100.0, 150),
+        ("B", "n2", "YES", "BUY", 0.50, 100.0, 160),
+    ]
+    resolutions = [
+        ("h1", 1, 50), ("h2", 1, 60), ("h3", 0, 50), ("h4", 0, 60),
+        ("n1", 1, 300), ("n2", 1, 300),
+    ]
+    db = corpus_factory(trades, resolutions)
+    rc = main([
+        "--db", str(db), "--causal-select", "--min-resolved", "2",
+        "--rebalance-days", "1", "--copy-top-k", "5",
+    ])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Causal selection" in out
+    assert "equal_weight" in out

--- a/tests/scripts/test_backtest_simulator.py
+++ b/tests/scripts/test_backtest_simulator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import csv
 import sqlite3
 from pathlib import Path
 
@@ -575,25 +576,31 @@ def test_build_parser_rejects_two_copy_policies() -> None:
         build_parser().parse_args(["--copy-top-k", "10", "--copy-top-frac", "0.1"])
 
 
-def test_main_causal_select_end_to_end(corpus_factory, capsys) -> None:  # type: ignore[no-untyped-def]
+def test_main_causal_select_end_to_end(corpus_factory, capsys, tmp_path) -> None:  # type: ignore[no-untyped-def]
     # A qualifies positive and is copied; B never positive -> never copied.
+    # Historical trades (h*) resolve before the second rebalance boundary
+    # (at ts=86401 for --rebalance-days 1); the new-period trades (n1 for A,
+    # n2 for B) fall inside that boundary's copy window. Selection must filter
+    # B out so only A's n1 is booked.
+    day = 86_400
     trades = [
         ("A", "h1", "YES", "BUY", 0.30, 100.0, 1),
         ("A", "h2", "YES", "BUY", 0.30, 100.0, 2),
         ("B", "h3", "YES", "BUY", 0.90, 100.0, 1),
         ("B", "h4", "YES", "BUY", 0.90, 100.0, 2),
-        ("A", "n1", "YES", "BUY", 0.50, 100.0, 150),
-        ("B", "n2", "YES", "BUY", 0.50, 100.0, 160),
+        ("A", "n1", "YES", "BUY", 0.50, 100.0, day + 100),
+        ("B", "n2", "YES", "BUY", 0.50, 100.0, day + 110),
     ]
     resolutions = [
         ("h1", 1, 50),
         ("h2", 1, 60),
         ("h3", 0, 50),
         ("h4", 0, 60),
-        ("n1", 1, 300),
-        ("n2", 1, 300),
+        ("n1", 1, day + 300),
+        ("n2", 1, day + 300),
     ]
     db = corpus_factory(trades, resolutions)
+    csv_path = tmp_path / "out.csv"
     rc = main(
         [
             "--db",
@@ -605,9 +612,21 @@ def test_main_causal_select_end_to_end(corpus_factory, capsys) -> None:  # type:
             "1",
             "--copy-top-k",
             "5",
+            "--csv",
+            str(csv_path),
         ]
     )
     out = capsys.readouterr().out
     assert rc == 0
     assert "Causal selection" in out
     assert "equal_weight" in out
+    # equal_weight booked exactly 1 resolved trade (only A's n1; B's n2 filtered).
+    assert "| equal_weight | 1 |" in out
+    # Every booked row across all schemes belongs to wallet A — B was excluded.
+    with csv_path.open() as fh:
+        rows = list(csv.DictReader(fh))
+    equal_weight_rows = [r for r in rows if r["scheme"] == "equal_weight"]
+    assert len(equal_weight_rows) == 1
+    assert equal_weight_rows[0]["wallet"] == "A"
+    assert equal_weight_rows[0]["condition_id"] == "n1"
+    assert {r["wallet"] for r in rows} == {"A"}

--- a/tests/scripts/test_copy_selection.py
+++ b/tests/scripts/test_copy_selection.py
@@ -100,3 +100,35 @@ def test_ranked_qualifiers_excludes_below_min_resolved(corpus_factory) -> None:
         platform="polymarket", min_resolved=2, edge_window_days=0, boundaries=[200],
     )
     assert rows == []
+
+
+def test_ranked_qualifiers_no_lookahead(corpus_factory) -> None:
+    # A's trades resolve at 250/260, AFTER boundary 200 -> A not qualified at 200.
+    trades = [
+        ("A", "m1", "YES", "BUY", 0.40, 100.0, 10),
+        ("A", "m2", "YES", "BUY", 0.30, 100.0, 20),
+    ]
+    resolutions = [("m1", 1, 250), ("m2", 1, 260)]
+    rows = ranked_qualifiers(
+        corpus_factory(trades, resolutions),
+        platform="polymarket", min_resolved=2, edge_window_days=0, boundaries=[200],
+    )
+    assert rows == []  # no resolutions before the boundary
+
+
+def test_ranked_qualifiers_rolling_window_drops_old_trades(corpus_factory) -> None:
+    # window=1 day: at boundary 200 (ts), only trades resolved within [200-86400, 200).
+    # Put 2 old resolutions far in the past and 1 recent -> under min_resolved=2 in window.
+    day = 86400
+    trades = [
+        ("A", "m1", "YES", "BUY", 0.40, 100.0, 1),
+        ("A", "m2", "YES", "BUY", 0.40, 100.0, 2),
+        ("A", "m3", "YES", "BUY", 0.40, 100.0, 3),
+    ]
+    boundary = 10 * day
+    resolutions = [("m1", 1, 1 * day), ("m2", 1, 2 * day), ("m3", 1, boundary - 100)]
+    rows = ranked_qualifiers(
+        corpus_factory(trades, resolutions),
+        platform="polymarket", min_resolved=2, edge_window_days=1, boundaries=[boundary],
+    )
+    assert rows == []  # only 1 trade inside the 1-day window -> below min_resolved

--- a/tests/scripts/test_copy_selection.py
+++ b/tests/scripts/test_copy_selection.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from scripts.copy_selection import KPolicy, has_platform_column, resolve_k
+from scripts.copy_selection import KPolicy, has_platform_column, ranked_qualifiers, resolve_k
 
 
 def test_resolve_k_fixed_count() -> None:
@@ -41,3 +41,62 @@ def test_has_platform_column_true(corpus_factory) -> None:
 def test_has_platform_column_false(corpus_factory) -> None:
     db: Path = corpus_factory([], [], with_platform=False)
     assert has_platform_column(db) is False
+
+
+def _brute_edge(trades, resolutions, boundary_ts, *, min_resolved, window_days):
+    """Reference: causal mean(won - price) per wallet at one boundary."""
+    res = {cid: (yw, rt) for cid, yw, rt in resolutions}
+    per_wallet: dict[str, list[tuple[int, float]]] = {}
+    for w, cid, side, bs, price, _notional, ts in trades:
+        if bs != "BUY" or cid not in res:
+            continue
+        yw, rt = res[cid]
+        if not (ts <= rt and rt < boundary_ts):
+            continue
+        if window_days and rt < boundary_ts - window_days * 86400:
+            continue
+        won = 1.0 if ((yw == 1 and side == "YES") or (yw == 0 and side == "NO")) else 0.0
+        per_wallet.setdefault(w, []).append((rt, won - price))
+    out = {}
+    for w, recs in per_wallet.items():
+        if len(recs) < min_resolved:
+            continue
+        edge = sum(d for _, d in recs) / len(recs)
+        if edge > 0:
+            out[w] = edge
+    return out
+
+
+def test_ranked_qualifiers_matches_bruteforce_lifetime(corpus_factory) -> None:
+    # Two wallets: A strongly positive, B negative. min_resolved=2 for a tiny case.
+    trades = [
+        ("A", "m1", "YES", "BUY", 0.40, 100.0, 10),
+        ("A", "m2", "YES", "BUY", 0.30, 100.0, 20),
+        ("B", "m3", "YES", "BUY", 0.80, 100.0, 15),
+        ("B", "m4", "YES", "BUY", 0.70, 100.0, 25),
+    ]
+    resolutions = [("m1", 1, 100), ("m2", 1, 110), ("m3", 0, 120), ("m4", 0, 130)]
+    boundary = 200
+    rows = ranked_qualifiers(
+        corpus_factory(trades, resolutions),
+        platform="polymarket", min_resolved=2, edge_window_days=0,
+        boundaries=[boundary],
+    )
+    got = {w: edge for (b, w, edge, n, rk, nq) in rows if b == boundary}
+    expected = _brute_edge(trades, resolutions, boundary, min_resolved=2, window_days=0)
+    assert set(got) == set(expected)  # only A qualifies (positive edge); B excluded
+    for w in expected:
+        assert got[w] == pytest.approx(expected[w])
+    # rank is deterministic and 1-based
+    a_row = next(r for r in rows if r[1] == "A")
+    assert a_row[4] == 1
+
+
+def test_ranked_qualifiers_excludes_below_min_resolved(corpus_factory) -> None:
+    trades = [("A", "m1", "YES", "BUY", 0.40, 100.0, 10)]  # only 1 resolved
+    resolutions = [("m1", 1, 100)]
+    rows = ranked_qualifiers(
+        corpus_factory(trades, resolutions),
+        platform="polymarket", min_resolved=2, edge_window_days=0, boundaries=[200],
+    )
+    assert rows == []

--- a/tests/scripts/test_copy_selection.py
+++ b/tests/scripts/test_copy_selection.py
@@ -34,9 +34,14 @@ def test_resolve_k_top_frac_zero_qualified_is_zero() -> None:
     assert resolve_k(KPolicy(top_frac=0.1), bankroll=10_000.0, qualified_count=0) == 0
 
 
-def test_resolve_k_no_mode_raises() -> None:
-    with pytest.raises(ValueError, match="no mode"):
-        resolve_k(KPolicy(), bankroll=10_000.0, qualified_count=10)
+def test_kpolicy_no_mode_raises_at_construction() -> None:
+    with pytest.raises(ValueError, match="exactly one"):
+        KPolicy()
+
+
+def test_kpolicy_multiple_modes_raises_at_construction() -> None:
+    with pytest.raises(ValueError, match="exactly one"):
+        KPolicy(top_k=5, top_frac=0.1)
 
 
 def test_has_platform_column_true(corpus_factory) -> None:
@@ -235,6 +240,85 @@ def test_iter_selected_rows_k_larger_than_qualified(corpus_factory) -> None:
     )
     copied = {r[2] for r in rows if r[0] == "trade" and r[3] == "n1"}
     assert copied == {"A"}  # only 1 qualifies; K=50 just takes all qualified
+
+
+def test_iter_selected_rows_multi_boundary_rebalance(corpus_factory) -> None:
+    # Per-boundary freeze: A qualifies positive before t=100; B only before t=200
+    # (and outranks A once it qualifies). With rebalance_seconds=100, top_k=1:
+    #   boundary 100 -> A copied -> A's trades in [100,200) are copied (an1).
+    #   boundary 200 -> B copied -> B's trades in [200,300) are copied (bn2).
+    # B's [100,200) trade (bn1) and A's [200,300) trade (an2) must NOT be copied.
+    trades = [
+        # A qualifying history: resolves before boundary 100, positive edge (~0.60)
+        ("A", "ah1", "YES", "BUY", 0.40, 100.0, 10),
+        ("A", "ah2", "YES", "BUY", 0.40, 100.0, 20),
+        # B qualifying history: resolves in [100,200), higher edge (~0.80)
+        ("B", "bh1", "YES", "BUY", 0.20, 100.0, 30),
+        ("B", "bh2", "YES", "BUY", 0.20, 100.0, 40),
+        # new trades in [100,200): only A is the frozen pick at boundary 100
+        ("A", "an1", "YES", "BUY", 0.50, 100.0, 150),
+        ("B", "bn1", "YES", "BUY", 0.50, 100.0, 160),
+        # new trades in [200,300): only B is the frozen pick at boundary 200
+        ("B", "bn2", "YES", "BUY", 0.50, 100.0, 250),
+        ("A", "an2", "YES", "BUY", 0.50, 100.0, 260),
+    ]
+    resolutions = [
+        ("ah1", 1, 40),
+        ("ah2", 1, 50),
+        ("bh1", 1, 120),
+        ("bh2", 1, 130),
+        ("an1", 1, 400),
+        ("bn1", 1, 400),
+        ("bn2", 1, 400),
+        ("an2", 1, 400),
+    ]
+    rows = list(
+        iter_selected_rows(
+            corpus_factory(trades, resolutions),
+            platform="polymarket",
+            min_resolved=2,
+            edge_window_days=0,
+            rebalance_days=None,
+            rebalance_seconds=100,
+            policy=KPolicy(top_k=1),
+            bankroll=10_000.0,
+            start_ts=0,
+            end_ts=250,
+        )
+    )
+    copied = {(r[3], r[2]) for r in rows if r[0] == "trade" and r[3].startswith(("an", "bn"))}
+    # [100,200): only A's an1; [200,300): only B's bn2
+    assert copied == {("an1", "A"), ("bn2", "B")}
+
+
+def test_iter_selected_rows_rebalance_days_path(corpus_factory) -> None:
+    # Exercise the real rebalance_days=1 path (* _SECONDS_PER_DAY). All ts fall
+    # inside a single 1-day period anchored at the min trade ts.
+    day = 86_400
+    trades = [
+        # qualifying history resolves before the boundary at t=day
+        ("A", "h1", "YES", "BUY", 0.30, 100.0, 10),
+        ("A", "h2", "YES", "BUY", 0.30, 100.0, 20),
+        # new trade inside the single period [day, 2*day)
+        ("A", "n1", "YES", "BUY", 0.50, 100.0, day + 5_000),
+    ]
+    resolutions = [("h1", 1, 50), ("h2", 1, 60), ("n1", 1, 3 * day)]
+    rows = list(
+        iter_selected_rows(
+            corpus_factory(trades, resolutions),
+            platform="polymarket",
+            min_resolved=2,
+            edge_window_days=0,
+            rebalance_days=1,
+            rebalance_seconds=None,
+            policy=KPolicy(top_k=5),
+            bankroll=10_000.0,
+            start_ts=day,
+            end_ts=2 * day - 1,
+        )
+    )
+    copied = {r[2] for r in rows if r[0] == "trade" and r[3] == "n1"}
+    assert copied == {"A"}
 
 
 def test_iter_selected_rows_no_platform_corpus(corpus_factory) -> None:

--- a/tests/scripts/test_copy_selection.py
+++ b/tests/scripts/test_copy_selection.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-
 from scripts.copy_selection import (
     KPolicy,
     has_platform_column,
@@ -21,8 +20,9 @@ def test_resolve_k_fixed_count() -> None:
 
 def test_resolve_k_capital_per_wallet_floors() -> None:
     # 10_000 / 750 = 13.33 -> 13
-    assert resolve_k(KPolicy(capital_per_wallet=750.0), bankroll=10_000.0,
-                     qualified_count=500) == 13
+    assert (
+        resolve_k(KPolicy(capital_per_wallet=750.0), bankroll=10_000.0, qualified_count=500) == 13
+    )
 
 
 def test_resolve_k_top_frac_ceils_against_qualified() -> None:
@@ -57,7 +57,7 @@ def _brute_edge(trades, resolutions, boundary_ts, *, min_resolved, window_days):
         if bs != "BUY" or cid not in res:
             continue
         yw, rt = res[cid]
-        if not (ts <= rt and rt < boundary_ts):
+        if not (ts <= rt < boundary_ts):
             continue
         if window_days and rt < boundary_ts - window_days * 86400:
             continue
@@ -85,7 +85,9 @@ def test_ranked_qualifiers_matches_bruteforce_lifetime(corpus_factory) -> None:
     boundary = 200
     rows = ranked_qualifiers(
         corpus_factory(trades, resolutions),
-        platform="polymarket", min_resolved=2, edge_window_days=0,
+        platform="polymarket",
+        min_resolved=2,
+        edge_window_days=0,
         boundaries=[boundary],
     )
     got = {w: edge for (b, w, edge, n, rk, nq) in rows if b == boundary}
@@ -103,7 +105,10 @@ def test_ranked_qualifiers_excludes_below_min_resolved(corpus_factory) -> None:
     resolutions = [("m1", 1, 100)]
     rows = ranked_qualifiers(
         corpus_factory(trades, resolutions),
-        platform="polymarket", min_resolved=2, edge_window_days=0, boundaries=[200],
+        platform="polymarket",
+        min_resolved=2,
+        edge_window_days=0,
+        boundaries=[200],
     )
     assert rows == []
 
@@ -117,7 +122,10 @@ def test_ranked_qualifiers_no_lookahead(corpus_factory) -> None:
     resolutions = [("m1", 1, 250), ("m2", 1, 260)]
     rows = ranked_qualifiers(
         corpus_factory(trades, resolutions),
-        platform="polymarket", min_resolved=2, edge_window_days=0, boundaries=[200],
+        platform="polymarket",
+        min_resolved=2,
+        edge_window_days=0,
+        boundaries=[200],
     )
     assert rows == []  # no resolutions before the boundary
 
@@ -135,7 +143,10 @@ def test_ranked_qualifiers_rolling_window_drops_old_trades(corpus_factory) -> No
     resolutions = [("m1", 1, 1 * day), ("m2", 1, 2 * day), ("m3", 1, boundary - 100)]
     rows = ranked_qualifiers(
         corpus_factory(trades, resolutions),
-        platform="polymarket", min_resolved=2, edge_window_days=1, boundaries=[boundary],
+        platform="polymarket",
+        min_resolved=2,
+        edge_window_days=1,
+        boundaries=[boundary],
     )
     assert rows == []  # only 1 trade inside the 1-day window -> below min_resolved
 
@@ -154,15 +165,27 @@ def test_iter_selected_rows_only_copies_top_k_in_frozen_period(corpus_factory) -
         ("B", "n2", "YES", "BUY", 0.50, 100.0, 160),
     ]
     resolutions = [
-        ("h1", 1, 50), ("h2", 1, 60), ("h3", 1, 50), ("h4", 1, 60),
-        ("n1", 1, 300), ("n2", 1, 300),
+        ("h1", 1, 50),
+        ("h2", 1, 60),
+        ("h3", 1, 50),
+        ("h4", 1, 60),
+        ("n1", 1, 300),
+        ("n2", 1, 300),
     ]
-    rows = list(iter_selected_rows(
-        corpus_factory(trades, resolutions),
-        platform="polymarket", min_resolved=2, edge_window_days=0,
-        rebalance_days=None, rebalance_seconds=100, policy=KPolicy(top_k=1),
-        bankroll=10_000.0, start_ts=None, end_ts=None,
-    ))
+    rows = list(
+        iter_selected_rows(
+            corpus_factory(trades, resolutions),
+            platform="polymarket",
+            min_resolved=2,
+            edge_window_days=0,
+            rebalance_days=None,
+            rebalance_seconds=100,
+            policy=KPolicy(top_k=1),
+            bankroll=10_000.0,
+            start_ts=None,
+            end_ts=None,
+        )
+    )
     trade_rows = [r for r in rows if r[0] == "trade"]
     copied_new = {r[2] for r in trade_rows if r[3] in ("n1", "n2")}
     assert copied_new == {"A"}  # only top-1 wallet A copied; B excluded
@@ -172,11 +195,20 @@ def test_iter_selected_rows_only_copies_top_k_in_frozen_period(corpus_factory) -
 
 
 def test_iter_selected_rows_empty_universe(corpus_factory) -> None:
-    rows = list(iter_selected_rows(
-        corpus_factory([], []), platform="polymarket", min_resolved=20,
-        edge_window_days=0, rebalance_days=None, rebalance_seconds=100,
-        policy=KPolicy(top_k=5), bankroll=10_000.0, start_ts=None, end_ts=None,
-    ))
+    rows = list(
+        iter_selected_rows(
+            corpus_factory([], []),
+            platform="polymarket",
+            min_resolved=20,
+            edge_window_days=0,
+            rebalance_days=None,
+            rebalance_seconds=100,
+            policy=KPolicy(top_k=5),
+            bankroll=10_000.0,
+            start_ts=None,
+            end_ts=None,
+        )
+    )
     assert rows == []
 
 
@@ -187,11 +219,20 @@ def test_iter_selected_rows_k_larger_than_qualified(corpus_factory) -> None:
         ("A", "n1", "YES", "BUY", 0.50, 100.0, 150),
     ]
     resolutions = [("h1", 1, 50), ("h2", 1, 60), ("n1", 1, 300)]
-    rows = list(iter_selected_rows(
-        corpus_factory(trades, resolutions), platform="polymarket", min_resolved=2,
-        edge_window_days=0, rebalance_days=None, rebalance_seconds=100,
-        policy=KPolicy(top_k=50), bankroll=10_000.0, start_ts=None, end_ts=None,
-    ))
+    rows = list(
+        iter_selected_rows(
+            corpus_factory(trades, resolutions),
+            platform="polymarket",
+            min_resolved=2,
+            edge_window_days=0,
+            rebalance_days=None,
+            rebalance_seconds=100,
+            policy=KPolicy(top_k=50),
+            bankroll=10_000.0,
+            start_ts=None,
+            end_ts=None,
+        )
+    )
     copied = {r[2] for r in rows if r[0] == "trade" and r[3] == "n1"}
     assert copied == {"A"}  # only 1 qualifies; K=50 just takes all qualified
 
@@ -203,10 +244,18 @@ def test_iter_selected_rows_no_platform_corpus(corpus_factory) -> None:
         ("A", "n1", "YES", "BUY", 0.50, 100.0, 150),
     ]
     resolutions = [("h1", 1, 50), ("h2", 1, 60), ("n1", 1, 300)]
-    rows = list(iter_selected_rows(
-        corpus_factory(trades, resolutions, with_platform=False),
-        platform="polymarket", min_resolved=2, edge_window_days=0,
-        rebalance_days=None, rebalance_seconds=100, policy=KPolicy(top_k=5),
-        bankroll=10_000.0, start_ts=None, end_ts=None,
-    ))
+    rows = list(
+        iter_selected_rows(
+            corpus_factory(trades, resolutions, with_platform=False),
+            platform="polymarket",
+            min_resolved=2,
+            edge_window_days=0,
+            rebalance_days=None,
+            rebalance_seconds=100,
+            policy=KPolicy(top_k=5),
+            bankroll=10_000.0,
+            start_ts=None,
+            end_ts=None,
+        )
+    )
     assert any(r[0] == "trade" and r[3] == "n1" for r in rows)

--- a/tests/scripts/test_copy_selection.py
+++ b/tests/scripts/test_copy_selection.py
@@ -1,0 +1,31 @@
+"""Tests for the causal copy-selection precompute."""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.copy_selection import KPolicy, resolve_k
+
+
+def test_resolve_k_fixed_count() -> None:
+    assert resolve_k(KPolicy(top_k=25), bankroll=10_000.0, qualified_count=500) == 25
+
+
+def test_resolve_k_capital_per_wallet_floors() -> None:
+    # 10_000 / 750 = 13.33 -> 13
+    assert resolve_k(KPolicy(capital_per_wallet=750.0), bankroll=10_000.0,
+                     qualified_count=500) == 13
+
+
+def test_resolve_k_top_frac_ceils_against_qualified() -> None:
+    # ceil(0.1 * 95) = 10
+    assert resolve_k(KPolicy(top_frac=0.1), bankroll=10_000.0, qualified_count=95) == 10
+
+
+def test_resolve_k_top_frac_zero_qualified_is_zero() -> None:
+    assert resolve_k(KPolicy(top_frac=0.1), bankroll=10_000.0, qualified_count=0) == 0
+
+
+def test_resolve_k_no_mode_raises() -> None:
+    with pytest.raises(ValueError, match="no mode"):
+        resolve_k(KPolicy(), bankroll=10_000.0, qualified_count=10)

--- a/tests/scripts/test_copy_selection.py
+++ b/tests/scripts/test_copy_selection.py
@@ -169,3 +169,44 @@ def test_iter_selected_rows_only_copies_top_k_in_frozen_period(corpus_factory) -
     # resolutions for copied markets are present and stream is ts-ordered
     assert any(r[0] == "resolution" and r[3] == "n1" for r in rows)
     assert [r[1] for r in rows] == sorted(r[1] for r in rows)
+
+
+def test_iter_selected_rows_empty_universe(corpus_factory) -> None:
+    rows = list(iter_selected_rows(
+        corpus_factory([], []), platform="polymarket", min_resolved=20,
+        edge_window_days=0, rebalance_days=None, rebalance_seconds=100,
+        policy=KPolicy(top_k=5), bankroll=10_000.0, start_ts=None, end_ts=None,
+    ))
+    assert rows == []
+
+
+def test_iter_selected_rows_k_larger_than_qualified(corpus_factory) -> None:
+    trades = [
+        ("A", "h1", "YES", "BUY", 0.30, 100.0, 1),
+        ("A", "h2", "YES", "BUY", 0.30, 100.0, 2),
+        ("A", "n1", "YES", "BUY", 0.50, 100.0, 150),
+    ]
+    resolutions = [("h1", 1, 50), ("h2", 1, 60), ("n1", 1, 300)]
+    rows = list(iter_selected_rows(
+        corpus_factory(trades, resolutions), platform="polymarket", min_resolved=2,
+        edge_window_days=0, rebalance_days=None, rebalance_seconds=100,
+        policy=KPolicy(top_k=50), bankroll=10_000.0, start_ts=None, end_ts=None,
+    ))
+    copied = {r[2] for r in rows if r[0] == "trade" and r[3] == "n1"}
+    assert copied == {"A"}  # only 1 qualifies; K=50 just takes all qualified
+
+
+def test_iter_selected_rows_no_platform_corpus(corpus_factory) -> None:
+    trades = [
+        ("A", "h1", "YES", "BUY", 0.30, 100.0, 1),
+        ("A", "h2", "YES", "BUY", 0.30, 100.0, 2),
+        ("A", "n1", "YES", "BUY", 0.50, 100.0, 150),
+    ]
+    resolutions = [("h1", 1, 50), ("h2", 1, 60), ("n1", 1, 300)]
+    rows = list(iter_selected_rows(
+        corpus_factory(trades, resolutions, with_platform=False),
+        platform="polymarket", min_resolved=2, edge_window_days=0,
+        rebalance_days=None, rebalance_seconds=100, policy=KPolicy(top_k=5),
+        bankroll=10_000.0, start_ts=None, end_ts=None,
+    ))
+    assert any(r[0] == "trade" and r[3] == "n1" for r in rows)

--- a/tests/scripts/test_copy_selection.py
+++ b/tests/scripts/test_copy_selection.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
-from scripts.copy_selection import KPolicy, resolve_k
+from scripts.copy_selection import KPolicy, has_platform_column, resolve_k
 
 
 def test_resolve_k_fixed_count() -> None:
@@ -29,3 +31,13 @@ def test_resolve_k_top_frac_zero_qualified_is_zero() -> None:
 def test_resolve_k_no_mode_raises() -> None:
     with pytest.raises(ValueError, match="no mode"):
         resolve_k(KPolicy(), bankroll=10_000.0, qualified_count=10)
+
+
+def test_has_platform_column_true(corpus_factory) -> None:
+    db: Path = corpus_factory([], [], with_platform=True)
+    assert has_platform_column(db) is True
+
+
+def test_has_platform_column_false(corpus_factory) -> None:
+    db: Path = corpus_factory([], [], with_platform=False)
+    assert has_platform_column(db) is False

--- a/tests/scripts/test_copy_selection.py
+++ b/tests/scripts/test_copy_selection.py
@@ -6,7 +6,13 @@ from pathlib import Path
 
 import pytest
 
-from scripts.copy_selection import KPolicy, has_platform_column, ranked_qualifiers, resolve_k
+from scripts.copy_selection import (
+    KPolicy,
+    has_platform_column,
+    iter_selected_rows,
+    ranked_qualifiers,
+    resolve_k,
+)
 
 
 def test_resolve_k_fixed_count() -> None:
@@ -132,3 +138,34 @@ def test_ranked_qualifiers_rolling_window_drops_old_trades(corpus_factory) -> No
         platform="polymarket", min_resolved=2, edge_window_days=1, boundaries=[boundary],
     )
     assert rows == []  # only 1 trade inside the 1-day window -> below min_resolved
+
+
+def test_iter_selected_rows_only_copies_top_k_in_frozen_period(corpus_factory) -> None:
+    # Boundaries every 100s from ts=0. A & B both qualify positive by boundary 100;
+    # A has higher edge. top_k=1 -> only A copied. Each makes a NEW trade in [100,200).
+    trades = [
+        # qualifying history (resolves before boundary 100)
+        ("A", "h1", "YES", "BUY", 0.30, 100.0, 1),
+        ("A", "h2", "YES", "BUY", 0.30, 100.0, 2),
+        ("B", "h3", "YES", "BUY", 0.45, 100.0, 1),
+        ("B", "h4", "YES", "BUY", 0.45, 100.0, 2),
+        # new trades inside period [100,200)
+        ("A", "n1", "YES", "BUY", 0.50, 100.0, 150),
+        ("B", "n2", "YES", "BUY", 0.50, 100.0, 160),
+    ]
+    resolutions = [
+        ("h1", 1, 50), ("h2", 1, 60), ("h3", 1, 50), ("h4", 1, 60),
+        ("n1", 1, 300), ("n2", 1, 300),
+    ]
+    rows = list(iter_selected_rows(
+        corpus_factory(trades, resolutions),
+        platform="polymarket", min_resolved=2, edge_window_days=0,
+        rebalance_days=None, rebalance_seconds=100, policy=KPolicy(top_k=1),
+        bankroll=10_000.0, start_ts=None, end_ts=None,
+    ))
+    trade_rows = [r for r in rows if r[0] == "trade"]
+    copied_new = {r[2] for r in trade_rows if r[3] in ("n1", "n2")}
+    assert copied_new == {"A"}  # only top-1 wallet A copied; B excluded
+    # resolutions for copied markets are present and stream is ts-ordered
+    assert any(r[0] == "resolution" and r[3] == "n1" for r in rows)
+    assert [r[1] for r in rows] == sorted(r[1] for r in rows)


### PR DESCRIPTION
Adds a `--causal-select` mode to `scripts/backtest_copy_sizing.py` so the backtest resembles live performance instead of measuring in-sample edge. Spec: `docs/superpowers/specs/2026-05-30-causal-copy-selection-design.md`; plan: `docs/superpowers/plans/2026-05-30-causal-copy-selection.md`.

## What it does

Instead of copying a fixed, hand-picked watchlist from each wallet's first trade, the new mode:
- Pre-filters the corpus to wallets with ≥`--min-resolved` resolved BUY trades.
- Computes each wallet's **causal** edge — `mean(won − price)` over only the resolutions that happened *before* the decision point (two no-lookahead guards in SQL).
- Every `--rebalance-days`, ranks qualified wallets globally and freezes a **top-K copy set**, with a **positive-edge hard floor** (negative-edge wallets are never copied).
- Copies only that evolving set through the existing four sizing schemes + the #204 capacity gates, which are unchanged.

Three tunable copy-set policies (mutually exclusive): `--copy-top-k`, `--copy-capital-per-wallet`, `--copy-top-frac`. Plus `--edge-window` (rolling D-day edge; `0` = lifetime). The existing watchlist mode is untouched and still the default.

## Architecture

The selector runs as a DuckDB precompute (`scripts/copy_selection.py`): resolved-buy fact table → per-boundary edge → ranked qualifiers → frozen copy set → selected-trade stream. The Python event-walk, sizing schemes, and capacity gates are unchanged; the per-boundary top-K cut is applied in Python (`resolve_k`) for testability. Platform-column presence is detected so it works on corpora with and without the multi-platform schema.

## Validation

Smoke-run on the production 69 GB corpus (`--copy-top-k 25 --rebalance-days 14 --enforce-capacity --max-open-exposure-frac 1`) completes in a few minutes. Results are sober and lookahead-free: win rates ~47–58% (not 100%), per-scheme PnL ranging −13% to +1.7% — far more conservative than the in-sample 1,790-wallet run (+30–49%), which is the point.

## Test Plan
- [x] 63 tests pass (`uv run pytest tests/scripts/ -q`); ruff/format/ty clean.
- [x] Cross-validation test: DuckDB per-boundary edge vs an independent Python brute-force.
- [x] No-lookahead, rolling-window, multi-boundary freeze, positive-edge floor, three K-policies, no-platform corpus, empty universe.
- [x] End-to-end through `main()` for top-k and top-frac policies (proves selection filters; only the positive-edge wallet is booked).
- [x] Subprocess regression test for direct `python scripts/...` execution (caught a real `sys.path` import bug the in-process tests missed).
- [x] Smoke on the real 69 GB corpus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)